### PR TITLE
Updated Repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/solidui/solid"
+    "url": "https://github.com/solidjs/solid"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
Simply updating the repository URL since the namespace for the project changed and NPM is still showing the old one.
