### PR TITLE
Handle errors in batch()

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -238,12 +238,9 @@ export function createSelector<T, U>(
 export function batch<T>(fn: () => T): T {
   if (Pending) return fn();
   let result;
-  let error;
   const q: Signal<any>[] = Pending = [];
   try {
     result = fn();
-  } catch (e) {
-    error = e;
   } finally {
     Pending = null;
   }
@@ -259,11 +256,7 @@ export function batch<T>(fn: () => T): T {
     }
   }, false);
 
-  if (error)
-    throw error
-
-  // result might be undefined only if `fn()` threw, but we rethrow above
-  return result as T;
+  return result;
 }
 
 export function useTransition(): [() => boolean, (fn: () => void, cb?: () => void) => void] {

--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -7,6 +7,7 @@ import {
   createDeferred,
   createMemo,
   createSelector,
+  batch,
   untrack,
   on,
   onMount,
@@ -139,6 +140,63 @@ describe("Untrack signals", () => {
         expect(temp).toBe("unpure thoughts");
         setSign("mind");
         expect(temp).toBe("unpure thoughts");
+        done();
+      });
+    });
+  });
+});
+
+describe("Batch signals", () => {
+  test("Groups updates", done => {
+    createRoot(() => {
+      let count = 0;
+      const [a, setA] = createSignal(0);
+      const [b, setB] = createSignal(0);
+      createEffect(() => {
+        batch(() => {
+          setA(1);
+          setB(1);
+        });
+      });
+      createRenderEffect(() => {
+        count += 1;
+      });
+      createComputed(() => a() + b(), 0);
+      setTimeout(() => {
+        expect(count).toBe(1);
+        done();
+      });
+    });
+  });
+  test("Handles errors gracefully", done => {
+    createRoot(() => {
+      let error: Error;
+      let count = 0;
+      const [a, setA] = createSignal(0);
+      const [b, setB] = createSignal(0);
+      createEffect(() => {
+        try {
+          batch(() => {
+            setA(1);
+            throw new Error("test");
+            setB(1);
+          });
+        } catch(e) {
+          error = e
+        }
+      });
+      createRenderEffect(() => {
+        count += 1;
+      });
+      createComputed(() => a() + b(), 0);
+      setTimeout(() => {
+        expect(count).toBe(1);
+        expect(a()).toBe(1);
+        expect(b()).toBe(0);
+        setA(2);
+        expect(a()).toBe(2);
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toBe("test");
         done();
       });
     });


### PR DESCRIPTION
Fixes the error shown in https://stackblitz.com/edit/solid-batch-issue?file=index.ts

I've update the code mostly as was discussed on discord. I've also made sure to rethrow the error as to allow the users to deal with errors on their side.

I've added tests, however I wasn't able to make them fail like the code example shows :| So they're crap, I'm not sure why, maybe you see what I'm doing wrong.