### PR TITLE
fix: add source entry and includes src files

### DIFF
--- a/packages/solid/h/package.json
+++ b/packages/solid/h/package.json
@@ -2,6 +2,7 @@
   "name": "solid-js/h",
   "main": "./dist/h.cjs",
   "module": "./dist/h.js",
+  "source": "./src/index.ts",
   "types": "./types/index.d.ts",
   "type": "module",
   "sideEffects": false

--- a/packages/solid/html/package.json
+++ b/packages/solid/html/package.json
@@ -2,6 +2,7 @@
   "name": "solid-js/html",
   "main": "./dist/html.cjs",
   "module": "./dist/html.js",
+  "source": "./src/index.ts",
   "types": "./types/index.d.ts",
   "type": "module",
   "sideEffects": false

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -21,12 +21,20 @@
   "type": "module",
   "files": [
     "dist",
+    "src",
+    "web/package.json",
     "web/dist",
     "web/types",
+    "web/src",
+    "web/server",
+    "h/package.json",
     "h/dist",
     "h/types",
+    "h/src",
+    "html/package.json",
     "html/dist",
     "html/types",
+    "html/src",
     "types",
     "jsx-runtime.d.ts"
   ],
@@ -76,6 +84,7 @@
     },
     "./html/dist/*": "./html/dist/*"
   },
+  "source": "./src/index.ts",
   "scripts": {
     "prebuild": "npm run clean",
     "clean": "rimraf dist/ types/ coverage/ web/dist/ web/types/ h/dist/ h/types/ html/dist/ html/types/",

--- a/packages/solid/web/package.json
+++ b/packages/solid/web/package.json
@@ -7,6 +7,7 @@
     "./dist/server.js": "./dist/web.js"
   },
   "unpkg": "./dist/web.cjs",
+  "source": "./src/index.ts",
   "types": "./types/index.d.ts",
   "type": "module",
   "sideEffects": false


### PR DESCRIPTION
See https://github.com/solidjs/solid-app-router/pull/17#issuecomment-865675780

This mostly works, but there is a `dom-expressions` dependency that is not declared anywhere in package.json of `solid-js`, and makes issues for the direct source build. I don't know how you publish the packages, so this might be an issue with the way I use `npm pack`.

```js
× Build failed.
@parcel/core: Failed to resolve 'dom-expressions/src/client' from './node_modules/.pnpm/local+C+solid+solid+packages+solid+solid-js-1.0.0-rc.7.tgz/node_modules/solid-js/web/src/client.js'
C:\test\node_modules\.pnpm\local+C+solid+solid+packages+solid+solid-js-1.0.0-rc.7.tgz\node_modules\solid-js\web\src\client.js:1:15
> 1 | export * from "dom-expressions/src/client";
>   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR  Command failed with exit code 1.
```