### PR TITLE
Allow generic to be left out in PropsWithChildren type

### DIFF
--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -9,7 +9,7 @@ import {
 import { sharedConfig, nextHydrateContext, setHydrateContext } from "./hydration";
 import type { JSX } from "../jsx";
 
-export type PropsWithChildren<P> = P & { children?: JSX.Element };
+export type PropsWithChildren<P = {}> = P & { children?: JSX.Element };
 export type Component<P = {}> = (props: PropsWithChildren<P>) => JSX.Element;
 /**
  * Takes the props of the passed component and returns its type


### PR DESCRIPTION
Many components take only `children` as a prop, and nothing else. Defaulting the generic helper type `PropsWithChildren` to `{}` allows the consumer to use it as simply `props: PropsWithChildren` instead of the awkward-looking `props: PropsWithChildren<{}>`.