### PR TITLE
fix: Prevent hashValue from throwing when stringifying bigints

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -596,6 +596,9 @@ export function hashValue(v: any): string {
               if (s.has(v)) return;
               s.add(v);
             }
+            if (typeof v === "bigint") {
+              return `${v.toString()}n`;
+            }
             return v;
           }) || ""
         )


### PR DESCRIPTION
hashValue uses `JSON.stringify` which throws when it encounters a bigint. This commit fixes that by checking for bigints and converting them to strings and appending `n` when stringifying.