### PR TITLE
Fix/improve types for `Resource` and `For`/`Index`/`mapArray`/`indexArray`

### DIFF
--- a/packages/solid/src/reactive/array.ts
+++ b/packages/solid/src/reactive/array.ts
@@ -7,7 +7,7 @@ function dispose(d: (() => void)[]) {
 
 // Modified version of mapSample from S-array[https://github.com/adamhaile/S-array] by Adam Haile
 export function mapArray<T, U>(
-  list: Accessor<readonly T[]>,
+  list: Accessor<readonly T[] | undefined | null | false>,
   mapFn: (v: T, i: Accessor<number>) => U,
   options: { fallback?: Accessor<any> } = {}
 ): () => U[] {
@@ -136,7 +136,7 @@ export function mapArray<T, U>(
 }
 
 export function indexArray<T, U>(
-  list: Accessor<readonly T[]>,
+  list: Accessor<readonly T[] | undefined | null | false>,
   mapFn: (v: Accessor<T>, i: number) => U,
   options: { fallback?: Accessor<any> } = {}
 ): () => U[] {

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -194,7 +194,7 @@ export function createMemo<T>(
   return readSignal.bind(c as Memo<T>);
 }
 
-export interface Resource<T> extends Accessor<T | undefined> {
+export interface Resource<T> extends Accessor<T> {
   loading: boolean;
   error: any;
 }

--- a/packages/solid/src/render/flow.ts
+++ b/packages/solid/src/render/flow.ts
@@ -3,7 +3,7 @@ import { mapArray, indexArray } from "../reactive/array";
 import type { JSX } from "../jsx";
 
 export function For<T, U extends JSX.Element>(props: {
-  each: readonly T[];
+  each: readonly T[] | undefined | null | false;
   fallback?: JSX.Element;
   children: (item: T, index: Accessor<number>) => U;
 }) {
@@ -15,7 +15,7 @@ export function For<T, U extends JSX.Element>(props: {
 
 // non-keyed
 export function Index<T, U extends JSX.Element>(props: {
-  each: readonly T[];
+  each: readonly T[] | undefined | null | false;
   fallback?: JSX.Element;
   children: (item: Accessor<T>, index: number) => U;
 }) {


### PR DESCRIPTION
Some minor changes to types. 

1. `Resource<T>` still extended `Accessor<T | undefined>` despite other changes to `createResource`. This PR completes the fix intended in https://github.com/solidjs/solid/commit/85fe17b18a681d828582c8a0d9b16990d25e6a58 removing the `undefined`.
2. Added falsy types to the each accessor in `For`, `Index`, `mapArray` and `indexArray` so that patterns such as `<For each={resource()}>` and `<For each={store.nullable?.list}>` work. I'm not sure if `false` is necessary here, but added it anyway for consistency with `Show`. 