### PR TITLE
feat(signal): abortable resource

### DIFF
--- a/packages/solid/test/resource.spec.ts
+++ b/packages/solid/test/resource.spec.ts
@@ -174,7 +174,7 @@ describe("abortable resource fetching", () => {
     error: string,
     aborted = false;
   const AbortedError = new DOMException("Aborted", "AbortError");
-  function fetcher(_id: string, _getPrev: Accessor<string>, abort: AbortController) {
+  function fetcher(_id: string, _getPrev: Accessor<string>, { abort }: { abort : AbortController }) {
     return new Promise<string>((r, f) => {
       resolve = r;
       reject = f;
@@ -189,7 +189,7 @@ describe("abortable resource fetching", () => {
       const [id, setId] = createSignal("1");
       trigger = setId;
       onError(e => (error = e));
-      [value, { refetch }] = createResource(id, fetcher, { initialValue: "Loading" });
+      [value, { refetch }] = createResource(id, fetcher, { initialValue: "Loading", abort: true });
       createRenderEffect(value);
     });
     expect(value()).toBe("Loading");


### PR DESCRIPTION
As mentioned earlier on Discord, it would be helpful to be able to abort resource fetching (for fetch or anything else you intend to make abortable). A simple way to do so is to introduce an optional third argument to the fetcher that if used creates an AbortController automatically and calls it whenever the resource is fetched anew. This saves developers the hassle of managing the creation of new AbortControllers themselves, as those are not reusable once called.