### PR TITLE
Improve types for set state

### DIFF
--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -262,7 +262,11 @@ export type ArrayFilterFn<T> = (
   index: number
 ) => boolean;
 
-export type Part<T> = keyof T | Array<keyof T> | StorePathRange | ArrayFilterFn<T>; // changing this to "T extends any[] ? ArrayFilterFn<T> : never" results in depth limit errors
+export type Part<T> = T extends any[]
+  ? keyof T | Array<keyof T> | ArrayFilterFn<T> | StorePathRange
+  : T extends object
+  ? keyof T | Array<keyof T>
+  : never;
 
 export type NullableNext<T, K> = K extends keyof T
   ? T[K]


### PR DESCRIPTION
This resolves issue #656 by making the `Part` type conditional on whether the state it represents is an array or object.

There was a comment left on the `Part` type
> changing this to "T extends any[] ? ArrayFilterFn<T> : never" results in depth limit errors

I tested this with a depth of 8 arguments/path parts which is the maximum supported by the set state function and didn't run into any errors, but I didn't try a lot of different permutations.