### PR TITLE
Fix `mergeProps` type to support arbitrary amount of objects

### DIFF
--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -71,15 +71,14 @@ const propTraps: ProxyHandler<{
   }
 };
 
-export function mergeProps<T>(source: T): T;
-export function mergeProps<T, U>(source: T, source1: U): T & U;
-export function mergeProps<T, U, V>(source: T, source1: U, source2: V): T & U & V;
-export function mergeProps<T, U, V, W>(
-  source: T,
-  source1: U,
-  source2: V,
-  source3: W
-): T & U & V & W;
+type BoxedTupleTypes<T extends any[]> =
+  { [P in keyof T]: [T[P]] }[Exclude<keyof T, keyof any[]>]
+type UnionToIntersection<U> =
+  (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never;
+type UnboxIntersection<T> = T extends { 0: infer U } ? U : never;
+type MergeProps<T extends any[]> = UnboxIntersection<UnionToIntersection<BoxedTupleTypes<T>>>;
+
+export function mergeProps<T extends any[]>(...sources: T): MergeProps<T>;
 export function mergeProps(...sources: any): any {
   return new Proxy(
     {


### PR DESCRIPTION
- This fixes the type for `mergeProps` to support arbitrary amount of objects and still correctly intersect their types.

POC: https://www.typescriptlang.org/play?ssl=10&ssc=97&pln=10&pc=52#code/C4TwDgpgBAQg9gDwgEwCoFcwBsKvBAZwB5UoIFgIA7ZAqAQypAG0BdAPigF4AoKKAN5RmABSgBLKlADWEEHABmUVKwBcw1KNasoAX2YBRBAGMs6ZBCKz5S1ABoZcxQyZt2rHqEhQAqlXFwVKhwAJJUlABOBBDGwAFURD6cvPwAFD5kFNS0LiBQAPxQqdLqPgCU3JwAbnDiyFDqVBBVEBEV5JQ0dKnF6pIKrVAhFVzVtcgVhSENUE0tEQDcnvi+VABGiGGR0bHxJMnKmZ05QgAMfVQDEb56BTeNza1LXtAAsq0A5hAiEXBgxKQOtk6IwWBxuKsNggtq0dnFAol-IFgjCojF4Ql4Eg0JgcHhIAD2ESljwLKZ6BFoAp0FRdoEoABbT6WQFZLq5NypAB0PIpHwI6lQZXU7wiXx+f0JJOMgQIwCgCAhTLFEFSQno6gAjHoHEI1uoAEw6wRQYxa41CZCGi1kc26XVQBTW+0mj52h0AC2dZQWQA