### PR TITLE
fix: signal setter callback form incorrect prev parameter type

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -5,8 +5,8 @@ import type { JSX } from "../jsx";
 
 export type Accessor<T> = () => T;
 export type Setter<T> = undefined extends T
-  ? <U extends T>(v?: (U extends Function ? never : U) | ((prev?: U) => U)) => U
-  : <U extends T>(v: (U extends Function ? never : U) | ((prev: U) => U)) => U;
+  ? <U extends T>(v?: (U extends Function ? never : U) | ((prev?: T) => U)) => U
+  : <U extends T>(v: (U extends Function ? never : U) | ((prev: T) => U)) => U;
 export const equalFn = <T>(a: T, b: T) => a === b;
 export const $PROXY = Symbol("solid-proxy");
 const signalOptions = { equals: equalFn };
@@ -166,8 +166,8 @@ export function createSignal<T>(
     ((value: T extends Function ? never : T | ((p?: T) => T)) => {
       if (typeof value === "function") {
         if (Transition && Transition.running && Transition.sources.has(s))
-          value = value(s.pending !== NOTPENDING ? (s.pending as T) : s.tValue);
-        else value = value(s.pending !== NOTPENDING ? (s.pending as T) : s.value);
+          value = value(s.pending !== NOTPENDING ? s.pending : s.tValue);
+        else value = value(s.pending !== NOTPENDING ? s.pending : s.value);
       }
       return writeSignal(s, value);
     }) as Setter<T>


### PR DESCRIPTION
Previously the `prev` parameter would erroneously be the same as the return type of the callback, instead of any type the signal could hold; see [TS playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAchDuBlCxgQE4B4AqA+KAvFAK4B2AJhAGYCWpE5UEAHmhQM5TYCwAUFFAD8UTAFUmrCBy64AFADdBALiizxLNuU4AxMgGNgNAPakhUevIxQVogJRQAPqtlh0ERSuz2C+O9998AipiEpqceAoqaqFSWlC6pAbGpsIWVjb2TrIubvKe-lB+hL4A3Hx8oJBQAPIANuTIqBg4+ERklLT0jBqx4YFmIT3SER6q6pLSCUkmZmno1oWZzq7uyovFiwWi-cHjYTKRYzGT+oYzqe7p61k57hkbRT6FZbx8tShQ7EYAthAAagBCFQAIyMRneAENSC83h9wQ0UGh0Co6gimlhQeCIFDWqp5AUAN79AR6EzsYDmIzAbSmIiVCBGKhQeSEAhEADkVFOyXZZnksi+vz+9hU8heAgEAHpJZ8ULJSFSabZxRK3MBiOhTArqdC+ABfcq8d4U+hIREYFRwM3ozCYyGkXEKQnEqCk0jkyk6whQemM5msjlcxJnUi84T8wX-EXMlVSmXsOXapWxqBqjVaxW63h6oA).

