### PR TITLE
feat: add `enableExternalSource` for reactivity interoperability

### DIFF
--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -15,6 +15,7 @@ export {
   batch,
   on,
   enableScheduling,
+  enableExternalSource,
   startTransition,
   useTransition,
   createContext,

--- a/packages/solid/test/external-source.spec.ts
+++ b/packages/solid/test/external-source.spec.ts
@@ -1,0 +1,62 @@
+import { createRoot, createMemo, onCleanup, enableExternalSource } from "../src";
+
+import "./MessageChannel";
+
+class ExternalSource<T = any> {
+  listeners: Set<() => void> = new Set();
+
+  constructor(private value: T) {}
+
+  update(x: T) {
+    this.value = x;
+    this.listeners.forEach(x => x());
+  }
+
+  get() {
+    this.listeners.add(listener);
+    sources.get(listener).add(this);
+    return this.value;
+  }
+
+  removeListener(listener: () => void) {
+    this.listeners.delete(listener);
+  }
+}
+
+let listener: (() => void) | null = null;
+
+let sources: Map<() => void, Set<ExternalSource>> = new Map();
+
+enableExternalSource((fn, trigger) => {
+  sources.set(trigger, new Set());
+  onCleanup(() => {
+    sources.get(trigger).forEach(x => x.removeListener(trigger));
+    sources.delete(trigger);
+  });
+  return x => {
+    const tmp = listener;
+    // trigger could play the role of listener，as it has stable reference
+    listener = trigger;
+    try {
+      return fn(x);
+    } finally {
+      listener = tmp;
+    }
+  };
+});
+
+enableExternalSource(fn => fn); // do nothing, make sure multiple factories be piped.
+
+describe("external source", () => {
+  it("should trigger solid primitive update", () => {
+    createRoot(() => {
+      const e = new ExternalSource(0);
+      const memo = createMemo(() => {
+        return e.get();
+      });
+      expect(memo()).toBe(0);
+      e.update(1);
+      expect(memo()).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
This pull request brings a new API `enableExternalSource` which provides more flexible reactivity interoperability (i.e. it's possible to use external reactive source __directly__ in solid primitives (createMemo, createEffect, etc.))

For a concrete example please check out `packages/solid/test/external-source.spec.ts`.

Potential issue: 
* `enableExternalSource` could be piped, but this feature seems not to be reflected well from the naming?