### PR TITLE
refactor(store): improve store types

### DIFF
--- a/packages/solid/store/src/index.ts
+++ b/packages/solid/store/src/index.ts
@@ -8,9 +8,10 @@ export type {
   StorePathRange,
   ArrayFilterFn,
   Part,
-  Next,
-  Readonly,
-  DeepReadonly
+  DeepReadonly,
+  StoreKeys,
+  StoreBranch,
+  SetStoreFallback
 } from "./store";
 export * from "./mutable";
 export * from "./modifiers";

--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -1,13 +1,4 @@
-import {
-  setProperty,
-  unwrap,
-  isWrappable,
-  Store,
-  NotWrappable,
-  StoreNode,
-  DeepReadonly,
-  $RAW,
-} from "./store";
+import { setProperty, unwrap, isWrappable, Store, StoreNode, $RAW, NotWrappable } from "./store";
 
 export type ReconcileOptions = {
   key?: string | null;
@@ -113,16 +104,13 @@ function applyState(
 
 // Diff method for setState
 export function reconcile<T>(
-  value: T | Store<T>,
+  value: T,
   options: ReconcileOptions = {}
-): (
-  state: T extends NotWrappable ? T : Store<DeepReadonly<T>>
-) => T extends NotWrappable ? T : Store<T> {
+): (state: Store<T>) => Store<T> {
   const { merge, key = "id" } = options,
     v = unwrap(value);
-  return s => {
-    const state = s as T extends NotWrappable ? T : Store<T>;
-    if (!isWrappable(state) || !isWrappable(v)) return v as T extends NotWrappable ? T : Store<T>;
+  return state => {
+    if (!isWrappable(state) || !isWrappable(v)) return v as Store<T>;
     applyState(v, { state }, "state", merge, key);
     return state;
   };
@@ -146,15 +134,19 @@ const setterTraps: ProxyHandler<StoreNode> = {
   }
 };
 
+type DeepMutable<T> = T extends NotWrappable
+  ? T
+  : {
+      -readonly [K in keyof T]: DeepMutable<T[K]>;
+    };
+
 // Immer style mutation style
 export function produce<T>(
-  fn: (state: T) => void
-): (
-  state: T extends NotWrappable ? T : Store<DeepReadonly<T>>
-) => T extends NotWrappable ? T : Store<T> {
-  return s => {
-    const state = s as T extends NotWrappable ? T : Store<T>;
-    if (isWrappable(state)) fn(new Proxy(state as object, setterTraps) as unknown as T);
+  fn: (state: DeepMutable<T>) => void
+): (state: Store<T>) => Partial<Store<T>> {
+  return state => {
+    if (isWrappable(state))
+      fn(new Proxy(state as object, setterTraps) as unknown as DeepMutable<T>);
     return state;
   };
 }

--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -134,19 +134,12 @@ const setterTraps: ProxyHandler<StoreNode> = {
   }
 };
 
-type DeepMutable<T> = T extends NotWrappable
-  ? T
-  : {
-      -readonly [K in keyof T]: DeepMutable<T[K]>;
-    };
-
 // Immer style mutation style
-export function produce<T>(
-  fn: (state: DeepMutable<T>) => void
+export function produce<T extends StoreNode>(
+  fn: (state: T) => void
 ): (state: Store<T>) => Partial<Store<T>> {
   return state => {
-    if (isWrappable(state))
-      fn(new Proxy(state as object, setterTraps) as unknown as DeepMutable<T>);
+    if (isWrappable(state)) fn(new Proxy(state as object, setterTraps) as unknown as T);
     return state;
   };
 }

--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -8,7 +8,6 @@ import {
   $NODE,
   $NAME,
   StoreNode,
-  Store,
   setProperty,
   proxyDescriptor,
   ownKeys
@@ -52,7 +51,7 @@ const proxyTraps: ProxyHandler<StoreNode> = {
   getOwnPropertyDescriptor: proxyDescriptor
 };
 
-function wrap<T extends StoreNode>(value: T, name?: string): Store<T> {
+function wrap<T extends StoreNode>(value: T, name?: string): T {
   let p = value[$PROXY];
   if (!p) {
     Object.defineProperty(value, $PROXY, { value: (p = new Proxy(value, proxyTraps)) });
@@ -79,10 +78,7 @@ function wrap<T extends StoreNode>(value: T, name?: string): Store<T> {
   return p;
 }
 
-export function createMutable<T extends StoreNode>(
-  state: T | Store<T>,
-  options?: { name?: string }
-): Store<T> {
+export function createMutable<T extends StoreNode>(state: T, options?: { name?: string }): T {
   const unwrappedStore = unwrap<T>(state || {});
   const wrappedStore = wrap(
     unwrappedStore,
@@ -92,5 +88,5 @@ export function createMutable<T extends StoreNode>(
     const name = (options && options.name) || DEV.hashValue(unwrappedStore);
     DEV.registerGraph(name, { value: unwrappedStore });
   }
-  return wrappedStore as Store<T>;
+  return wrappedStore;
 }

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -255,7 +255,8 @@ export type SetStoreFallback<T> =
   | [StoreSetter<T>]
   | (T extends NotWrappable ? never : InferAll<T, StoreKeys<T>>);
 
-export interface SetStoreFunction<T> {
+export type SetStoreFunction<T> = _SetStoreFunction<Store<T>>;
+interface _SetStoreFunction<T> {
   // uncommenting this drastically increases the time needed to infer types
   // <
   //   A extends StoreBranch<T>,
@@ -378,7 +379,7 @@ export interface SetStoreFunction<T> {
 export function createStore<T extends StoreNode>(
   store: T,
   options?: { name?: string }
-): [get: Store<T>, set: SetStoreFunction<Store<T>>] {
+): [get: Store<T>, set: SetStoreFunction<T>] {
   const unwrappedStore = unwrap<T>(store || {});
   const wrappedStore = wrap(
     unwrappedStore,

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -215,9 +215,9 @@ export function updatePath(current: StoreNode, path: any[], traversed: (number |
   } else setProperty(current, part, value);
 }
 
-export type DeepReadonly<T> = T extends NotWrappable
-  ? T
-  : { readonly [K in keyof T]: DeepReadonly<T[K]> };
+export type DeepReadonly<T> = {
+  readonly [K in keyof T]: T[K] extends NotWrappable ? T[K] : DeepReadonly<T[K]>;
+};
 
 export type StorePathRange = {
   from?: number;

--- a/packages/solid/store/test/modifiers.spec.ts
+++ b/packages/solid/store/test/modifiers.spec.ts
@@ -90,13 +90,15 @@ describe("setState with reconcile", () => {
 
 describe("setState with produce", () => {
   interface DataState {
-    data: { ending?: number, starting: number }
+    data: { ending?: number; starting: number };
   }
   test("Top Level Mutation", () => {
     const [state, setState] = createStore<DataState>({ data: { starting: 1, ending: 1 } });
-    setState(produce<DataState>(s => {
-      s.data.ending = s.data.starting + 1;
-    }));
+    setState(
+      produce<DataState>(s => {
+        s.data.ending = s.data.starting + 1;
+      })
+    );
     expect(state.data.starting).toBe(1);
     expect(state.data.ending).toBe(2);
   });
@@ -105,43 +107,52 @@ describe("setState with produce", () => {
       const [s, set] = createSignal(1);
       const [state, setState] = createStore({ data: [] });
       createEffect(() => {
-        setState(produce<{ data: number[]}>(state => {
-          state.data.push(s());
-        }));
-      })
-      createEffect(() => state.data.length)
-    })
-    expect(true).toBe(true)
+        setState(
+          produce(state => {
+            state.data.push(s());
+          })
+        );
+      });
+      createEffect(() => state.data.length);
+    });
+    expect(true).toBe(true);
   });
   test("Nested Level Mutation", () => {
     const [state, setState] = createStore({ data: { starting: 1, ending: 1 } });
-    setState("data", produce<DataState["data"]>(s => {
-      s.ending = s.starting + 1;
-    }));
+    setState(
+      "data",
+      produce<DataState["data"]>(s => {
+        s.ending = s.starting + 1;
+      })
+    );
     expect(state.data.starting).toBe(1);
     expect(state.data.ending).toBe(2);
   });
   test("Top Level Deletion", () => {
     const [state, setState] = createStore<DataState>({ data: { starting: 1, ending: 1 } });
-    setState(produce<DataState>(s => {
-      delete s.data.ending;
-    }));
+    setState(
+      produce<DataState>(s => {
+        delete s.data.ending;
+      })
+    );
     expect(state.data.starting).toBe(1);
     expect(state.data.ending).not.toBeDefined();
   });
   test("Top Level Object Mutation", () => {
     const [state, setState] = createStore<DataState>({ data: { starting: 1, ending: 1 } }),
       next = { starting: 3, ending: 6 };
-    setState(produce<DataState>(s => {
-      s.data = next;
-    }));
+    setState(
+      produce<DataState>(s => {
+        s.data = next;
+      })
+    );
     expect(unwrap(state.data)).toBe(next);
     expect(state.data.starting).toBe(3);
     expect(state.data.ending).toBe(6);
   });
   test("Test Array Mutation", () => {
     interface TodoState {
-      todos: ({ id: number, title: string, done: boolean })[]
+      todos: { id: number; title: string; done: boolean }[];
     }
     const [state, setState] = createStore<TodoState>({
       todos: [
@@ -149,10 +160,12 @@ describe("setState with produce", () => {
         { id: 2, title: "Eat Lunch", done: false }
       ]
     });
-    setState(produce<TodoState>(s => {
-      s.todos[1].done = true;
-      s.todos.push({ id: 3, title: "Go Home", done: false });
-    }));
+    setState(
+      produce<TodoState>(s => {
+        s.todos[1].done = true;
+        s.todos.push({ id: 3, title: "Go Home", done: false });
+      })
+    );
     expect(Array.isArray(state.todos)).toBe(true);
     expect(state.todos[1].done).toBe(true);
     expect(state.todos[2].title).toBe("Go Home");

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -5,6 +5,7 @@ describe("State immutablity", () => {
   test("Setting a property", () => {
     const [state] = createStore({ name: "John" });
     expect(state.name).toBe("John");
+    // @ts-expect-error Cannot mutate a store directly
     state.name = "Jake";
     expect(state.name).toBe("John");
   });
@@ -21,6 +22,7 @@ describe("State immutablity", () => {
     const [state, setState] = createStore({ name: "John" });
     expect(state.name).toBe("John");
     setState(() => {
+      // @ts-expect-error Cannot mutate a store directly
       state.name = "Jake";
     });
     expect(state.name).toBe("John");
@@ -424,7 +426,6 @@ describe("State recursion", () => {
 });
 
 describe("Nested Classes", () => {
-
   test("wrapped nested class", () => {
     class CustomThing {
       a: number;
@@ -452,7 +453,7 @@ describe("Nested Classes", () => {
     expect(sum).toBe(20);
     setStore("inner", "b", 5);
     expect(sum).toBe(15);
-  })
+  });
 
   test("not wrapped nested class", () => {
     class CustomThing {
@@ -463,7 +464,7 @@ describe("Nested Classes", () => {
         this.b = 10;
       }
     }
-    const [store, setStore] = createStore({ inner: new CustomThing(1)});
+    const [store, setStore] = createStore({ inner: new CustomThing(1) });
 
     expect(store.inner.a).toBe(1);
     expect(store.inner.b).toBe(10);
@@ -479,5 +480,5 @@ describe("Nested Classes", () => {
     expect(sum).toBe(11);
     setStore("inner", "b", 5);
     expect(sum).toBe(11);
-  })
-})
+  });
+});


### PR DESCRIPTION
This PR focuses more on the performance and inference issues the store types have.
It is not meant to be a complete typing overhaul.

Added `bigint` to `NotWrappable`.

`Store` was quite complicated and often confusing as it contained properties specific to the Store implementation.
However, most internal functions use `StoreNode`. As such `Store<T>` has been repurposed to simply be `DeepReadonly<T>`.

`DeepReadonly` has been simplified.

The Setter type is mostly unchanged externally, except:
- Only `number` is allowed to index Array types (before, for example Array methods and properties were allowed).
- The fallback overload is now much better and correctly constrains types but requires type annotations (they can't be inferred).
- All functions passed via the setter have parameters typed readonly as they should(?) be.

I tried to optimize the Setter as much as possible, and I think it's better at the same number of overloads but don't have any definitive proof of that.

`produce` is now able to infer types correctly from the `setStore` call.
~~It currently uses a `DeepMutable` type to circumvent `DeepReadonly` being part of the inferred input; the DeepReadonly part shouldn't be inferred.~~

fixes #732