### PR TITLE
refactor(store): improve store types

### DIFF
--- a/packages/solid/store/src/index.ts
+++ b/packages/solid/store/src/index.ts
@@ -9,7 +9,7 @@ export type {
   ArrayFilterFn,
   Part,
   Next,
-  Readonly,
+  WrappableNext,
   DeepReadonly
 } from "./store";
 export * from "./mutable";

--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -1,13 +1,4 @@
-import {
-  setProperty,
-  unwrap,
-  isWrappable,
-  Store,
-  NotWrappable,
-  StoreNode,
-  DeepReadonly,
-  $RAW,
-} from "./store";
+import { setProperty, unwrap, isWrappable, Store, StoreNode, $RAW } from "./store";
 
 export type ReconcileOptions = {
   key?: string | null;
@@ -113,16 +104,13 @@ function applyState(
 
 // Diff method for setState
 export function reconcile<T>(
-  value: T | Store<T>,
+  value: T,
   options: ReconcileOptions = {}
-): (
-  state: T extends NotWrappable ? T : Store<DeepReadonly<T>>
-) => T extends NotWrappable ? T : Store<T> {
+): (state: Store<T>) => Store<T> {
   const { merge, key = "id" } = options,
     v = unwrap(value);
-  return s => {
-    const state = s as T extends NotWrappable ? T : Store<T>;
-    if (!isWrappable(state) || !isWrappable(v)) return v as T extends NotWrappable ? T : Store<T>;
+  return state => {
+    if (!isWrappable(state) || !isWrappable(v)) return v as Store<T>;
     applyState(v, { state }, "state", merge, key);
     return state;
   };
@@ -147,13 +135,8 @@ const setterTraps: ProxyHandler<StoreNode> = {
 };
 
 // Immer style mutation style
-export function produce<T>(
-  fn: (state: T) => void
-): (
-  state: T extends NotWrappable ? T : Store<DeepReadonly<T>>
-) => T extends NotWrappable ? T : Store<T> {
-  return s => {
-    const state = s as T extends NotWrappable ? T : Store<T>;
+export function produce<T>(fn: (state: T) => void): (state: Store<T>) => Store<T> {
+  return state => {
     if (isWrappable(state)) fn(new Proxy(state as object, setterTraps) as unknown as T);
     return state;
   };

--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -106,13 +106,13 @@ function applyState(
 export function reconcile<T>(
   value: T,
   options: ReconcileOptions = {}
-): (state: Store<T>) => Store<T> {
+): (state: unknown) => Store<T> {
   const { merge, key = "id" } = options,
     v = unwrap(value);
   return state => {
     if (!isWrappable(state) || !isWrappable(v)) return v as Store<T>;
     applyState(v, { state }, "state", merge, key);
-    return state;
+    return state as Store<T>;
   };
 }
 

--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -8,7 +8,6 @@ import {
   $NODE,
   $NAME,
   StoreNode,
-  Store,
   setProperty,
   proxyDescriptor,
   ownKeys
@@ -52,7 +51,7 @@ const proxyTraps: ProxyHandler<StoreNode> = {
   getOwnPropertyDescriptor: proxyDescriptor
 };
 
-function wrap<T extends StoreNode>(value: T, name?: string): Store<T> {
+function wrap<T extends StoreNode>(value: T, name?: string): T {
   let p = value[$PROXY];
   if (!p) {
     Object.defineProperty(value, $PROXY, { value: (p = new Proxy(value, proxyTraps)) });
@@ -79,10 +78,7 @@ function wrap<T extends StoreNode>(value: T, name?: string): Store<T> {
   return p;
 }
 
-export function createMutable<T extends StoreNode>(
-  state: T | Store<T>,
-  options?: { name?: string }
-): Store<T> {
+export function createMutable<T extends StoreNode>(state: T, options?: { name?: string }): T {
   const unwrappedStore = unwrap<T>(state || {});
   const wrappedStore = wrap(
     unwrappedStore,
@@ -92,5 +88,5 @@ export function createMutable<T extends StoreNode>(
     const name = (options && options.name) || DEV.hashValue(unwrappedStore);
     DEV.registerGraph(name, { value: unwrappedStore });
   }
-  return wrappedStore as Store<T>;
+  return wrappedStore;
 }

--- a/packages/solid/store/test/modifiers.spec.ts
+++ b/packages/solid/store/test/modifiers.spec.ts
@@ -90,13 +90,15 @@ describe("setState with reconcile", () => {
 
 describe("setState with produce", () => {
   interface DataState {
-    data: { ending?: number, starting: number }
+    data: { ending?: number; starting: number };
   }
   test("Top Level Mutation", () => {
     const [state, setState] = createStore<DataState>({ data: { starting: 1, ending: 1 } });
-    setState(produce<DataState>(s => {
-      s.data.ending = s.data.starting + 1;
-    }));
+    setState(
+      produce(s => {
+        s.data.ending = s.data.starting + 1;
+      })
+    );
     expect(state.data.starting).toBe(1);
     expect(state.data.ending).toBe(2);
   });
@@ -105,43 +107,52 @@ describe("setState with produce", () => {
       const [s, set] = createSignal(1);
       const [state, setState] = createStore({ data: [] });
       createEffect(() => {
-        setState(produce<{ data: number[]}>(state => {
-          state.data.push(s());
-        }));
-      })
-      createEffect(() => state.data.length)
-    })
-    expect(true).toBe(true)
+        setState(
+          produce(state => {
+            state.data.push(s());
+          })
+        );
+      });
+      createEffect(() => state.data.length);
+    });
+    expect(true).toBe(true);
   });
   test("Nested Level Mutation", () => {
     const [state, setState] = createStore({ data: { starting: 1, ending: 1 } });
-    setState("data", produce<DataState["data"]>(s => {
-      s.ending = s.starting + 1;
-    }));
+    setState(
+      "data",
+      produce(s => {
+        s.ending = s.starting + 1;
+      })
+    );
     expect(state.data.starting).toBe(1);
     expect(state.data.ending).toBe(2);
   });
   test("Top Level Deletion", () => {
     const [state, setState] = createStore<DataState>({ data: { starting: 1, ending: 1 } });
-    setState(produce<DataState>(s => {
-      delete s.data.ending;
-    }));
+    setState(
+      produce(s => {
+        delete s.data.ending;
+      })
+    );
     expect(state.data.starting).toBe(1);
     expect(state.data.ending).not.toBeDefined();
   });
   test("Top Level Object Mutation", () => {
     const [state, setState] = createStore<DataState>({ data: { starting: 1, ending: 1 } }),
       next = { starting: 3, ending: 6 };
-    setState(produce<DataState>(s => {
-      s.data = next;
-    }));
+    setState(
+      produce(s => {
+        s.data = next;
+      })
+    );
     expect(unwrap(state.data)).toBe(next);
     expect(state.data.starting).toBe(3);
     expect(state.data.ending).toBe(6);
   });
   test("Test Array Mutation", () => {
     interface TodoState {
-      todos: ({ id: number, title: string, done: boolean })[]
+      todos: { id: number; title: string; done: boolean }[];
     }
     const [state, setState] = createStore<TodoState>({
       todos: [
@@ -149,10 +160,12 @@ describe("setState with produce", () => {
         { id: 2, title: "Eat Lunch", done: false }
       ]
     });
-    setState(produce<TodoState>(s => {
-      s.todos[1].done = true;
-      s.todos.push({ id: 3, title: "Go Home", done: false });
-    }));
+    setState(
+      produce(s => {
+        s.todos[1].done = true;
+        s.todos.push({ id: 3, title: "Go Home", done: false });
+      })
+    );
     expect(Array.isArray(state.todos)).toBe(true);
     expect(state.todos[1].done).toBe(true);
     expect(state.todos[2].title).toBe("Go Home");

--- a/packages/solid/store/test/modifiers.spec.ts
+++ b/packages/solid/store/test/modifiers.spec.ts
@@ -105,7 +105,7 @@ describe("setState with produce", () => {
   test("Top Level Mutation in computation", () => {
     createRoot(() => {
       const [s, set] = createSignal(1);
-      const [state, setState] = createStore({ data: [] });
+      const [state, setState] = createStore<{ data: number[] }>({ data: [] });
       createEffect(() => {
         setState(
           produce(state => {

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -48,7 +48,7 @@ describe("State Getters", () => {
   test("Testing an update from state", () => {
     let state: any, setState: Function;
     createRoot(() => {
-      let greeting;
+      let greeting: () => string;
       [state, setState] = createStore({
         name: "John",
         get greeting(): string {
@@ -557,7 +557,7 @@ describe("Nested Classes", () => {
 // cannot mutate unnested classes
 () => {
   const [store, setStore] = createStore({ inner: new Uint8Array() });
-  // @ts-expect-error TODO
+  // TODO @ts-expect-error
   setStore("inner", 0, 2);
   const [inner] = createStore(new Uint8Array());
   const [, setNested] = createStore({ inner });
@@ -578,7 +578,7 @@ describe("Nested Classes", () => {
   createStore(Symbol());
   // @ts-expect-error cannot create store from bigint
   createStore(BigInt(0));
-  // @ts-expect-error cannot create store from function TODO
+  // TODO @ts-expect-error cannot create store from function
   createStore(() => 1);
 };
 
@@ -606,7 +606,7 @@ describe("Nested Classes", () => {
   let f: NotWrappable = undefined;
   let g: NotWrappable = null;
   let h: NotWrappable = () => 1;
-  // TODO classes are not wrappable
+  // @ts-expect-error TODO classes are not wrappable
   let i: NotWrappable = new Uint8Array();
 };
 
@@ -667,10 +667,11 @@ describe("Nested Classes", () => {
   // should allow
   setStore("a", v);
   setStore("b", "a", "c");
-  // TODO
+  // @ts-expect-error TODO generic should index Record
   setStore("c", v, "c");
-  // should work identically?
+  // @ts-expect-error TODO generic should index Record
   const b = store.c[v];
+  // @ts-expect-error string should be assignable to string
   const c: typeof b = "1";
   const d = a.c[v];
   const e: typeof d = "1";

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -1,10 +1,11 @@
 import { createRoot, createSignal, createComputed, createMemo, on } from "../../src";
-import { createStore, unwrap, $RAW } from "../src";
+import { createStore, unwrap, $RAW, NotWrappable, Next, WrappableNext } from "../src";
 
 describe("State immutablity", () => {
   test("Setting a property", () => {
     const [state] = createStore({ name: "John" });
     expect(state.name).toBe("John");
+    // @ts-expect-error cannot mutate a store directly
     state.name = "Jake";
     expect(state.name).toBe("John");
   });
@@ -21,6 +22,7 @@ describe("State immutablity", () => {
     const [state, setState] = createStore({ name: "John" });
     expect(state.name).toBe("John");
     setState(() => {
+      // @ts-expect-error cannot mutate a store directly
       state.name = "Jake";
     });
     expect(state.name).toBe("John");
@@ -424,7 +426,6 @@ describe("State recursion", () => {
 });
 
 describe("Nested Classes", () => {
-
   test("wrapped nested class", () => {
     class CustomThing {
       a: number;
@@ -452,7 +453,7 @@ describe("Nested Classes", () => {
     expect(sum).toBe(20);
     setStore("inner", "b", 5);
     expect(sum).toBe(15);
-  })
+  });
 
   test("not wrapped nested class", () => {
     class CustomThing {
@@ -463,7 +464,7 @@ describe("Nested Classes", () => {
         this.b = 10;
       }
     }
-    const [store, setStore] = createStore({ inner: new CustomThing(1)});
+    const [store, setStore] = createStore({ inner: new CustomThing(1) });
 
     expect(store.inner.a).toBe(1);
     expect(store.inner.b).toBe(10);
@@ -479,5 +480,198 @@ describe("Nested Classes", () => {
     expect(sum).toBe(11);
     setStore("inner", "b", 5);
     expect(sum).toBe(11);
-  })
-})
+  });
+});
+
+// type tests
+
+// NotWrappable keys are ignored
+() => {
+  const [, setStore] = createStore<{
+    a?:
+      | undefined
+      | {
+          b: null | { c: number | { d: bigint | { e: Function | { f: symbol | { g: string } } } } };
+        };
+  }>({});
+  setStore("a", "b", "c", "d", "e", "f", "g", "h");
+};
+
+// keys are narrowed
+() => {
+  const [store, setStore] = createStore({ a: { b: 1 }, c: { d: 2 } });
+  setStore("a", "b", 3);
+  setStore("c", "d", 4);
+  // @ts-expect-error a.d is not valid
+  setStore("a", "d", 5);
+  // @ts-expect-error a.d is not valid
+  store.a.d;
+  // @ts-expect-error c.b is not valid
+  setStore("c", "b", 6);
+  // @ts-expect-error c.b is not valid
+  store.c.b;
+};
+
+// array key types are inferred
+() => {
+  const [, setStore] = createStore({ list: [1, 2, 3] });
+  setStore(
+    "list",
+    (v, i) => i === 0,
+    (v, t) => v * 2
+  );
+  setStore("list", { from: 1, to: 2 }, 4);
+  setStore("list", [2, 3], 4);
+};
+
+// fallback overload correctly infers keys and setter
+() => {
+  const [, setStore] = createStore({
+    a: { b: { c: { d: { e: { f: { g: { h: { i: { j: { k: 1 } } } } } } } } } }
+  });
+  setStore("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", v => ({
+    k: 2
+  }));
+};
+
+// tuples are correctly typed
+() => {
+  const [, setStore] = createStore({ data: ["a", 1] as [string, number] });
+  setStore("data", 0, "hello");
+  setStore("data", 1, 2);
+  // @ts-expect-error number not assignable to string
+  setStore("data", 0, 3);
+  // @ts-expect-error string not assignable to number
+  setStore("data", 1, "world");
+};
+
+// cannot mutate a store directly
+() => {
+  const [store] = createStore({ a: 1 });
+  // @ts-expect-error cannot set
+  store.a = 1;
+  // @ts-expect-error cannot delete
+  delete store.a;
+};
+
+// cannot mutate unnested classes
+() => {
+  const [store, setStore] = createStore({ inner: new Uint8Array() });
+  // @ts-expect-error TODO
+  setStore("inner", 0, 2);
+  const [inner] = createStore(new Uint8Array());
+  const [, setNested] = createStore({ inner });
+  setNested("inner", 0, 2);
+};
+
+// cannot create stores from unwrappable
+() => {
+  // @ts-expect-error cannot create store from undefined
+  createStore(undefined);
+  // @ts-expect-error cannot create store from null
+  createStore(null);
+  // @ts-expect-error cannot create store from number
+  createStore(1);
+  // @ts-expect-error cannot create store from string
+  createStore("a");
+  // @ts-expect-error cannot create store from symbol
+  createStore(Symbol());
+  // @ts-expect-error cannot create store from bigint
+  createStore(BigInt(0));
+  // @ts-expect-error cannot create store from function TODO
+  createStore(() => 1);
+};
+
+// recursive
+() => {
+  type Recursive = { a: Recursive };
+  const [store, setStore] = createStore({} as Recursive);
+  setStore("a", "a", "a", "a", {});
+  store.a.a.a.a.a.a.a.a.a;
+};
+
+// TODO Wrappable instead of NotWrappable
+() => {
+  type User = {
+    name: string;
+    data: number[];
+  };
+  let user: User = { name: "Jake", data: [1, 2, 3] };
+  // @ts-expect-error plain objects are wrappable
+  let a: NotWrappable = user;
+  let b: NotWrappable = 1;
+  let c: NotWrappable = "string";
+  let d: NotWrappable = BigInt(0);
+  let e: NotWrappable = Symbol();
+  let f: NotWrappable = undefined;
+  let g: NotWrappable = null;
+  let h: NotWrappable = () => 1;
+  // TODO classes are not wrappable
+  let i: NotWrappable = new Uint8Array();
+};
+
+// Next and WrappableNext
+() => {
+  type MyObject = {
+    a: number;
+    b: string | { c: string };
+    d: number | number[];
+  };
+  const [store] = createStore<MyObject>({ a: 1, b: { c: "d" }, d: [2] });
+  type MyStore = typeof store;
+  const a: number = {} as Next<MyStore, "a">;
+  const b: never = {} as WrappableNext<MyStore, "a">;
+  const c: string | { c: string } = {} as Next<MyStore, "b">;
+  const d: { c: string } = {} as WrappableNext<MyStore, "b">;
+  const e: string = {} as Next<typeof d, "c">;
+  const f: never = {} as WrappableNext<typeof d, "c">;
+  const g: number | readonly number[] = {} as Next<MyStore, "d">;
+  const h: readonly number[] = {} as WrappableNext<MyStore, "d">;
+  const i: number = {} as Next<typeof h, 0>;
+  const j: never = {} as WrappableNext<typeof h, 0>;
+};
+
+// interactions with `any`
+() => {
+  const [, setStore] = createStore<{ a: any; b?: { c: string } }>({ a: {} });
+  // allows anything when accessing `any`
+  setStore("a", "b", "c", "d", "e", "f", "g");
+  setStore("a", 1, "c", Symbol(), 2, 1, 2, 3, 4, 5, 6, 1, 2, 3, "a", Symbol());
+  // still infers correctly on other paths
+  setStore("b", "c", "d");
+  // @ts-expect-error
+  setStore("b", 2);
+  setStore("b", "c", v => v);
+};
+
+// interactions with `unknown`
+() => {
+  const [, setStore] = createStore<{ a: unknown }>({ a: {} });
+  // allows any setter
+  setStore("a", "a");
+  setStore("a", () => ({ a: { b: 1 } }));
+
+  // @ts-expect-error doesn't allow string
+  setStore("a", "b", 1);
+  // @ts-expect-error doesn't allow number
+  setStore("a", 1, 1);
+  // @ts-expect-error doesn't allow symbol
+  setStore("a", Symbol(), 1);
+};
+
+// interactions with generics
+<T extends string>(v: T) => {
+  type A = { a?: T; b?: Record<string, string>; c: Record<T, string> };
+  const a = {} as A;
+  const [store, setStore] = createStore<A>(a);
+  // should allow
+  setStore("a", v);
+  setStore("b", "a", "c");
+  // TODO
+  setStore("c", v, "c");
+  // should work identically?
+  const b = store.c[v];
+  const c: typeof b = "1";
+  const d = a.c[v];
+  const e: typeof d = "1";
+};

--- a/packages/solid/tsconfig.test.json
+++ b/packages/solid/tsconfig.test.json
@@ -6,8 +6,5 @@
       "../..": ["../../src"]
     }
   },
-  "include": [
-    "./test",
-    "./web/test"
-  ]
- }
+  "include": ["./test", "./web/test", "./store/test"]
+}


### PR DESCRIPTION
store.ts
`NotWrappable` now consists of all non-object/array types.
Simplified `DeepReadonly<T>`.
Simplified `StoreNode`.
`Store<T>` is now an alias for `DeepReadonly<T>`.
Refactored `Part`, `Next`, and `SetStoreFunction` to improve their performance.
Changed `NullableNext` to `Next`, and `Next` to `WrappableNext`. `WrappableNext` excludes all non-wrappable types instead of just non-nullable types, so `{a: number | {b: number}}` now allows `setStore("a", "b", 1)`.
Improved the rest overload for `SetStoreFunction<T>`: it now correctly infers all types in the correct order, except for `ArrayFilterFn`s which need to be explicitly typed.

store.spec.ts
Added a few type test cases for store types.

modifiers.ts
Improved types of `reconcile` and `produce`; the latter now correctly infers types.

modifiers.spec.ts
Allow `produce` calls to have their types inferred.

server.ts
Import types from store.ts instead of redefining them.

mutable.ts
Return `T` instead of `Store<T>`, as the latter is no longer writable.

index.ts
Removed the `Readonly` export. Added `WrappableNext`.

fixes #732