### PR TITLE
Fix missing character in JSDoc

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -319,7 +319,7 @@ export type ResourceOptions<T> = T extends undefined
 /**
  * Creates a resource that wraps a repeated promise in a reactive pattern:
  * ```typescript
- * const [resource, { mutate, refetch }] = crateResource(source, fetcher, options);
+ * const [resource, { mutate, refetch }] = createResource(source, fetcher, options);
  * ```
  * @param source - reactive data function to toggle the request, optional
  * @param fetcher - function that receives the source (or true) and an accessor for the last or initial value and returns a value or a Promise with the value:


### PR DESCRIPTION
Hello! By learning solidjs I found that a character is missing for `createResource` documentation.