### PR TITLE
fix: Change ordering for module exports field

### DIFF
--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -44,13 +44,17 @@
         "import": "./dist/solid.js",
         "require": "./dist/solid.cjs"
       },
+      "node": {
+        "development": {
+          "import": "./dist/dev.js",
+          "require": "./dist/dev.cjs"
+        },
+        "import": "./dist/server.js",
+        "require": "./dist/server.cjs"
+      },
       "development": {
         "import": "./dist/dev.js",
         "require": "./dist/dev.cjs"
-      },
-      "node": {
-        "import": "./dist/server.js",
-        "require": "./dist/server.cjs"
       },
       "import": "./dist/solid.js",
       "require": "./dist/solid.cjs"

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -44,13 +44,13 @@
         "import": "./dist/solid.js",
         "require": "./dist/solid.cjs"
       },
-      "node": {
-        "import": "./dist/server.js",
-        "require": "./dist/server.cjs"
-      },
       "development": {
         "import": "./dist/dev.js",
         "require": "./dist/dev.cjs"
+      },
+      "node": {
+        "import": "./dist/server.js",
+        "require": "./dist/server.cjs"
       },
       "import": "./dist/solid.js",
       "require": "./dist/solid.cjs"

--- a/packages/solid/store/package.json
+++ b/packages/solid/store/package.json
@@ -20,13 +20,17 @@
         "import": "./dist/store.js",
         "require": "./dist/store.cjs"
       },
+      "node": {
+        "development": {
+          "import": "./dist/dev.js",
+          "require": "./dist/dev.cjs"
+        },
+        "import": "./dist/server.js",
+        "require": "./dist/server.cjs"
+      },
       "development": {
         "import": "./dist/dev.js",
         "require": "./dist/dev.cjs"
-      },
-      "node": {
-        "import": "./dist/server.js",
-        "require": "./dist/server.cjs"
       },
       "import": "./dist/store.js",
       "require": "./dist/store.cjs"

--- a/packages/solid/store/package.json
+++ b/packages/solid/store/package.json
@@ -9,5 +9,27 @@
   "unpkg": "./dist/store.cjs",
   "types": "./types/index.d.ts",
   "type": "module",
-  "sideEffects": false
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "browser": {
+        "development": {
+          "import": "./dist/dev.js",
+          "require": "./dist/dev.cjs"
+        },
+        "import": "./dist/store.js",
+        "require": "./dist/store.cjs"
+      },
+      "development": {
+        "import": "./dist/dev.js",
+        "require": "./dist/dev.cjs"
+      },
+      "node": {
+        "import": "./dist/server.js",
+        "require": "./dist/server.cjs"
+      },
+      "import": "./dist/store.js",
+      "require": "./dist/store.cjs"
+    }
+  }
 }

--- a/packages/solid/universal/package.json
+++ b/packages/solid/universal/package.json
@@ -4,5 +4,15 @@
   "module": "./dist/universal.js",
   "types": "./types/index.d.ts",
   "type": "module",
-  "sideEffects": false
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "development": {
+        "import": "./dist/dev.js",
+        "require": "./dist/dev.cjs"
+      },
+      "import": "./dist/universal.js",
+      "require": "./dist/universal.cjs"
+    }
+  }
 }

--- a/packages/solid/web/package.json
+++ b/packages/solid/web/package.json
@@ -9,5 +9,27 @@
   "unpkg": "./dist/web.cjs",
   "types": "./types/index.d.ts",
   "type": "module",
-  "sideEffects": false
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "browser": {
+        "development": {
+          "import": "./dist/dev.js",
+          "require": "./dist/dev.cjs"
+        },
+        "import": "./dist/web.js",
+        "require": "./dist/web.cjs"
+      },
+      "development": {
+        "import": "./dist/dev.js",
+        "require": "./dist/dev.cjs"
+      },
+      "node": {
+        "import": "./dist/server.js",
+        "require": "./dist/server.cjs"
+      },
+      "import": "./dist/web.js",
+      "require": "./dist/web.cjs"
+    }
+  }
 }

--- a/packages/solid/web/package.json
+++ b/packages/solid/web/package.json
@@ -20,13 +20,17 @@
         "import": "./dist/web.js",
         "require": "./dist/web.cjs"
       },
+      "node": {
+        "development": {
+          "import": "./dist/dev.js",
+          "require": "./dist/dev.cjs"
+        },
+        "import": "./dist/server.js",
+        "require": "./dist/server.cjs"
+      },
       "development": {
         "import": "./dist/dev.js",
         "require": "./dist/dev.cjs"
-      },
-      "node": {
-        "import": "./dist/server.js",
-        "require": "./dist/server.cjs"
       },
       "import": "./dist/web.js",
       "require": "./dist/web.cjs"


### PR DESCRIPTION
This PR fixes the ordering of exports field to comply with the node spec and how https://github.com/lukeed/resolve.exports 
works.

Also adds exports field for subpackages.

```
Within the "exports" object, key order is significant. 
During condition matching, earlier entries have higher priority and take precedence over later entries. 
The general rule is that conditions should be from most specific to least specific in object order.
```

