### PR TITLE
docs: Fix a typo in examples.md

### DIFF
--- a/documentation/resources/examples.md
+++ b/documentation/resources/examples.md
@@ -14,7 +14,7 @@
 - [Async Resource](https://codesandbox.io/s/2o4wmxj9zy) Ajax requests to SWAPI with Promise cancellation
 - [Async Resource GraphQL](https://codesandbox.io/s/async-resource-graphql-r4rcx?file=/index.js) Simple resource for handling graphql request.
 - [Suspense](https://codesandbox.io/s/5v67oym224) Various Async loading with Solid's Suspend control flow
-- [Suspense Tabs](https://codesandbox.io/s/solid-suspense-tabs-vkgpj) Defered loading spinners for smooth UX.
+- [Suspense Tabs](https://codesandbox.io/s/solid-suspense-tabs-vkgpj) Deferred loading spinners for smooth UX.
 - [SuspenseList](https://codesandbox.io/s/solid-suspenselist-eorvk) Orchestrating multiple Suspense Components.
 - [Redux Undoable Todos](https://codesandbox.io/s/pkjw38r8mj) Example from Redux site done with Solid.
 - [Simple Todos Template Literals](https://codesandbox.io/s/jpm68z1q33) Simple Todos using Lit DOM Expressions


### PR DESCRIPTION
Fix a typo