### PR TITLE
Refactor store to remove readonly

### DIFF
--- a/packages/solid/store/src/index.ts
+++ b/packages/solid/store/src/index.ts
@@ -9,8 +9,7 @@ export type {
   ArrayFilterFn,
   Part,
   Next,
-  WrappableNext,
-  DeepReadonly
+  WrappableNext
 } from "./store";
 export * from "./mutable";
 export * from "./modifiers";

--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -1,4 +1,4 @@
-import { setProperty, unwrap, isWrappable, Store, StoreNode, $RAW } from "./store";
+import { setProperty, unwrap, isWrappable, Store, StoreNode, $RAW, DeepReadonly } from "./store";
 
 export type ReconcileOptions = {
   key?: string | null;
@@ -103,10 +103,7 @@ function applyState(
 }
 
 // Diff method for setState
-export function reconcile<T>(
-  value: T,
-  options: ReconcileOptions = {}
-): (state: unknown) => Store<T> {
+export function reconcile<T>(value: T, options: ReconcileOptions = {}): (state: unknown) => T {
   const { merge, key = "id" } = options,
     v = unwrap(value);
   return state => {
@@ -135,9 +132,11 @@ const setterTraps: ProxyHandler<StoreNode> = {
 };
 
 // Immer style mutation style
-export function produce<T>(fn: (state: T) => void): (state: Store<T>) => Store<T> {
+export function produce<T extends StoreNode>(
+  fn: (state: T) => void
+): (state: DeepReadonly<T>) => T {
   return state => {
-    if (isWrappable(state)) fn(new Proxy(state as object, setterTraps) as unknown as T);
+    if (isWrappable(state)) fn(new Proxy(state as unknown as object, setterTraps) as unknown as T);
     return state;
   };
 }

--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -1,4 +1,4 @@
-import { setProperty, unwrap, isWrappable, Store, StoreNode, $RAW, DeepReadonly } from "./store";
+import { setProperty, unwrap, isWrappable, Store, StoreNode, $RAW } from "./store";
 
 export type ReconcileOptions = {
   key?: string | null;
@@ -132,9 +132,7 @@ const setterTraps: ProxyHandler<StoreNode> = {
 };
 
 // Immer style mutation style
-export function produce<T extends StoreNode>(
-  fn: (state: T) => void
-): (state: DeepReadonly<T>) => T {
+export function produce<T extends StoreNode>(fn: (state: T) => void): (state: T) => T {
   return state => {
     if (isWrappable(state)) fn(new Proxy(state as unknown as object, setterTraps) as unknown as T);
     return state;

--- a/packages/solid/store/src/server.ts
+++ b/packages/solid/store/src/server.ts
@@ -92,10 +92,7 @@ type ReconcileOptions = {
 };
 
 // Diff method for setStore
-export function reconcile<T>(
-  value: T | Store<T>,
-  options: ReconcileOptions = {}
-): (state: Store<T>) => void {
+export function reconcile<T>(value: T, options: ReconcileOptions = {}): (state: unknown) => void {
   return state => {
     if (!isWrappable(state)) return value;
     const targetKeys = Object.keys(value) as (keyof T)[];
@@ -112,9 +109,7 @@ export function reconcile<T>(
 }
 
 // Immer style mutation style
-export function produce<T extends StoreNode>(
-  fn: (state: T) => void
-): (state: Store<T>) => Store<T> {
+export function produce<T extends StoreNode>(fn: (state: T) => void): (state: T) => T {
   return state => {
     if (isWrappable(state)) fn(state as T);
     return state;

--- a/packages/solid/store/src/server.ts
+++ b/packages/solid/store/src/server.ts
@@ -1,4 +1,4 @@
-import { SetStoreFunction, Store } from "store";
+import { SetStoreFunction, Store, StoreNode } from "store";
 
 export const $RAW = Symbol("state-raw");
 
@@ -103,7 +103,7 @@ export function reconcile<T>(
       const key = targetKeys[i];
       setProperty(state, key as string, value[key]);
     }
-    const previousKeys = Object.keys(state as object) as (keyof T)[];
+    const previousKeys = Object.keys(state as unknown as object) as (keyof T)[];
     for (let i = 0, len = previousKeys.length; i < len; i++) {
       if (value[previousKeys[i]] === undefined)
         setProperty(state, previousKeys[i] as string, undefined);
@@ -112,7 +112,9 @@ export function reconcile<T>(
 }
 
 // Immer style mutation style
-export function produce<T>(fn: (state: T) => void): (state: Store<T>) => Store<T> {
+export function produce<T extends StoreNode>(
+  fn: (state: T) => void
+): (state: Store<T>) => Store<T> {
   return state => {
     if (isWrappable(state)) fn(state as T);
     return state;

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -215,23 +215,14 @@ export function updatePath(current: StoreNode, path: any[], traversed: (keyof an
   } else setProperty(current, part, value);
 }
 
-type NoInfer<T> = T & { [K in keyof T]: T[K] };
-export type DeepReadonly<T> = NoInfer<
-  T extends NotWrappable
-    ? T
-    : {
-        readonly [K in keyof T]: DeepReadonly<T[K]>;
-      }
->;
-
 export type StoreSetter<T> =
   | T
   | Partial<T>
-  | ((prevState: DeepReadonly<T>, traversed?: (keyof any)[]) => Partial<T> | void);
+  | ((prevState: T, traversed?: (keyof any)[]) => Partial<T> | void);
 
 export type StorePathRange = { from?: number; to?: number; by?: number };
 
-export type ArrayFilterFn<T> = (item: DeepReadonly<T>, index: number) => boolean;
+export type ArrayFilterFn<T> = (item: T, index: number) => boolean;
 
 export type Part<T> = [T] extends [never]
   ? never

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -5,7 +5,6 @@ describe("State immutablity", () => {
   test("Setting a property", () => {
     const [state] = createStore({ name: "John" });
     expect(state.name).toBe("John");
-    // @ts-expect-error cannot mutate a store directly
     state.name = "Jake";
     expect(state.name).toBe("John");
   });
@@ -22,7 +21,6 @@ describe("State immutablity", () => {
     const [state, setState] = createStore({ name: "John" });
     expect(state.name).toBe("John");
     setState(() => {
-      // @ts-expect-error cannot mutate a store directly
       state.name = "Jake";
     });
     expect(state.name).toBe("John");
@@ -545,14 +543,14 @@ describe("Nested Classes", () => {
   setStore("data", 1, "world");
 };
 
-// cannot mutate a store directly
-() => {
-  const [store] = createStore({ a: 1 });
-  // @ts-expect-error cannot set
-  store.a = 1;
-  // @ts-expect-error cannot delete
-  delete store.a;
-};
+// // cannot mutate a store directly
+// () => {
+//   const [store] = createStore({ a: 1 });
+//   // @ts-expect-error cannot set
+//   store.a = 1;
+//   // @ts-expect-error cannot delete
+//   delete store.a;
+// };
 
 // cannot mutate unnested classes
 () => {
@@ -661,7 +659,7 @@ describe("Nested Classes", () => {
 
 // interactions with generics
 <T extends string>(v: T) => {
-  type A = { a?: T; b?: Record<string, string>; c: Record<T, string> };
+  type A = { a: T; b: Record<string, string>; c: Record<T, string> };
   const a = {} as A;
   const [store, setStore] = createStore<A>(a);
   // should allow
@@ -669,10 +667,6 @@ describe("Nested Classes", () => {
   setStore("b", "a", "c");
   // @ts-expect-error TODO generic should index Record
   setStore("c", v, "c");
-  // @ts-expect-error TODO generic should index Record
   const b = store.c[v];
-  // @ts-expect-error string should be assignable to string
   const c: typeof b = "1";
-  const d = a.c[v];
-  const e: typeof d = "1";
 };


### PR DESCRIPTION
After changing `Store` to be readonly, @high1 pointed out that non-readonly types might be more desirable e.g. in this scenario:

```ts
function getFirst(list: string[]): string {
  return list[0];
}

const [store, setStore] = createStore({ list: ["hello"] });

getFirst(store.list) // <-- readonly string[] not assignable to string[]
setStore("list", (list) => [getFirst(list)]) // <-- readonly string[] not assignable to string[]
```

It's fairly common to encounter immutable functions that do not type their parameters as `readonly` outside of native functions/classes like `Object.fromEntries` or `Map`. This PR makes it so none of these are readonly. However, I'm not sure if `setStore` should be kept as readonly. 

I imagine that the same reasoning can be applied to both `store` and `setStore` here, but it is much less likely for users to pass the `list` in `setStore` to a function typed with `string[]`, and much more likely for users to try to directly modify `list`. 