### PR TITLE
Export `Signal<T>` type

### DIFF
--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -33,6 +33,7 @@ export {
 export type {
   Accessor,
   Setter,
+  Signal,
   Resource,
   ResourceReturn,
   ResourceFetcher,


### PR DESCRIPTION
Im assuming this was intended. It's pretty handy