### PR TITLE
Fix function type merging for `mergeProps` args

### DIFF
--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -78,7 +78,8 @@ const propTraps: ProxyHandler<{
   }
 };
 
-type BoxedTupleTypes<T extends any[]> = { [P in keyof T]: [T[P]] }[Exclude<keyof T, keyof any[]>];
+type UnboxLazy<T> = T extends () => infer U ? U : T;
+type BoxedTupleTypes<T extends any[]> = { [P in keyof T]: [UnboxLazy<T[P]>] }[Exclude<keyof T, keyof any[]>];
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void
   ? I
   : never;


### PR DESCRIPTION
`mergeProps` already allows reactive prop source since `1.2`(?) however `mergeProps` type merging still assumes that all parameters passed to it are objects and not functions. This patch adds a way to unbox this prop source to correctly infer and merge the type.