### PR TITLE
Add 'undefined' to ResourceSource<S> union type

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -414,7 +414,7 @@ export type ResourceActions<T> = { mutate: Setter<T>; refetch: (info?: unknown) 
 
 export type ResourceReturn<T> = [Resource<T>, ResourceActions<T>];
 
-export type ResourceSource<S> = S | false | null | (() => S | false | null);
+export type ResourceSource<S> = S | false | null | undefined | (() => S | false | null | undefined);
 
 export type ResourceFetcher<S, T> = (k: S, info: ResourceFetcherInfo<T>) => T | Promise<T>;
 


### PR DESCRIPTION
Adding `undefined` as one of the possible values allows for the pattern
where the source of the resource is a signal with implicit undefined value,
as in the following example:
```
const [source, set] = createSignal<string>();
const resource = createResource(source, fetchFunction);
```
Else one has to explicitly add `null` both as a type and value:
```
const [source, set] = createSignal<string | null>(null);
const resource = createResource(source, fetchFunction);
```