### PR TITLE
Export noShadowDOM from component-register in solid-element

### DIFF
--- a/packages/solid-element/src/index.ts
+++ b/packages/solid-element/src/index.ts
@@ -6,7 +6,7 @@ import {
   ComponentOptions,
   PropsDefinitionInput
 } from "component-register";
-export { hot, getCurrentElement } from "component-register";
+export { hot, getCurrentElement, noShadowDOM } from "component-register";
 export type ComponentType<T> = mComponentType<T>;
 import { createRoot, createSignal } from "solid-js";
 import { insert } from "solid-js/web";


### PR DESCRIPTION
* Export the `noShadowDOM` method from `component-register` in `solid-element`.

The `noShadowDOM` method is available in `component-register`, but not directly available from `solid-element`.
You can work-around this by importing it from `component-register`. 

Since we already have `hot` and `getCurrentElement` exported, it would be great to also have `noShadowDOM`.