### PR TITLE
fix: export refetchResources for server entry

### DIFF
--- a/packages/solid/src/server/index.ts
+++ b/packages/solid/src/server/index.ts
@@ -44,6 +44,7 @@ export {
   Suspense,
   SuspenseList,
   createResource,
+  refetchResources,
   enableScheduling,
   enableHydration,
   startTransition,


### PR DESCRIPTION
Exporting refetchResources from server entry (was missing after 1.3.4 changes I think)