### PR TITLE
fix(store): fix inferrence of array types

### DIFF
--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -1,4 +1,4 @@
-import { setProperty, unwrap, isWrappable, Store, StoreNode, $RAW } from "./store";
+import { setProperty, unwrap, isWrappable, Store, StoreNode, $RAW, StoreSetter } from "./store";
 
 export type ReconcileOptions = {
   key?: string | null;
@@ -135,7 +135,7 @@ const setterTraps: ProxyHandler<StoreNode> = {
 };
 
 // Immer style mutation style
-export function produce<T>(fn: (state: T) => void): (state: Store<T>) => Store<T> {
+export function produce<T>(fn: (state: T) => void): StoreSetter<T> {
   return state => {
     if (isWrappable(state)) fn(new Proxy(state as object, setterTraps) as unknown as T);
     return state;

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -223,11 +223,11 @@ export type DeepReadonly<T> = {
 export type StoreSetter<T> =
   | T
   | Partial<T>
-  | ((prevState: T, traversed?: (keyof any)[]) => Partial<T> | void);
+  | ((prevState: DeepReadonly<T>, traversed?: (keyof any)[]) => Partial<DeepReadonly<T>> | void);
 
 export type StorePathRange = { from?: number; to?: number; by?: number };
 
-export type ArrayFilterFn<T> = (item: T, index: number) => boolean;
+export type ArrayFilterFn<T> = (item: DeepReadonly<T>, index: number) => boolean;
 
 export type Part<T> = [T] extends [never]
   ? never
@@ -257,8 +257,7 @@ export type Rest<T> = 0 extends 1 & T
   ? [...(keyof any)[], any]
   : [StoreSetter<T>] | (T extends NotWrappable ? never : DistributeRest<T, Part<T>>);
 
-export type SetStoreFunction<T> = _SetStoreFunction<Store<T>>;
-interface _SetStoreFunction<T> {
+export interface SetStoreFunction<T> {
   <
     K1 extends Part<T>,
     K2 extends Part<T1>,


### PR DESCRIPTION
Previously produce would wrongly infer all arrays from a store as readonly.
This fix makes the return type of produce StoreSetter instead, fixing the issue.
This change has a few caveats; namely, produce is less strictly typed: it should return a function that takes and returns `DeepReadonly<T>`, but now it returns all types contained in `StoreSetter<T>`. This has no consequence for normal usage other than better type inference.
Additionally to facilitate this change, DeepReadonly is no longer applied to the entire SetStoreFunction, but only where it is consumed (the setter and filter functions).

#790 would also fix this issue.