### PR TITLE
fix(store): fix traversed returning duplicate values

### DIFF
--- a/packages/solid/store/src/server.ts
+++ b/packages/solid/store/src/server.ts
@@ -40,21 +40,20 @@ export function updatePath(current: any, path: any[], traversed: (number | strin
     if (Array.isArray(part)) {
       // Ex. update('data', [2, 23], 'label', l => l + ' !!!');
       for (let i = 0; i < part.length; i++) {
-        updatePath(current, [part[i]].concat(path), [part[i]].concat(traversed));
+        updatePath(current, [part[i]].concat(path), traversed);
       }
       return;
     } else if (isArray && partType === "function") {
       // Ex. update('data', i => i.id === 42, 'label', l => l + ' !!!');
       for (let i = 0; i < current.length; i++) {
-        if (part(current[i], i))
-          updatePath(current, [i].concat(path), ([i] as (number | string)[]).concat(traversed));
+        if (part(current[i], i)) updatePath(current, [i].concat(path), traversed);
       }
       return;
     } else if (isArray && partType === "object") {
       // Ex. update('data', { from: 3, to: 12, by: 2 }, 'label', l => l + ' !!!');
       const { from = 0, to = current.length - 1, by = 1 } = part;
       for (let i = from; i <= to; i += by) {
-        updatePath(current, [i].concat(path), ([i] as (number | string)[]).concat(traversed));
+        updatePath(current, [i].concat(path), traversed);
       }
       return;
     } else if (path.length > 1) {

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -180,21 +180,20 @@ export function updatePath(current: StoreNode, path: any[], traversed: (keyof an
     if (Array.isArray(part)) {
       // Ex. update('data', [2, 23], 'label', l => l + ' !!!');
       for (let i = 0; i < part.length; i++) {
-        updatePath(current, [part[i]].concat(path), [part[i]].concat(traversed));
+        updatePath(current, [part[i]].concat(path), traversed);
       }
       return;
     } else if (isArray && partType === "function") {
       // Ex. update('data', i => i.id === 42, 'label', l => l + ' !!!');
       for (let i = 0; i < current.length; i++) {
-        if (part(current[i], i))
-          updatePath(current, [i].concat(path), [i as keyof any].concat(traversed));
+        if (part(current[i], i)) updatePath(current, [i].concat(path), traversed);
       }
       return;
     } else if (isArray && partType === "object") {
       // Ex. update('data', { from: 3, to: 12, by: 2 }, 'label', l => l + ' !!!');
       const { from = 0, to = current.length - 1, by = 1 } = part;
       for (let i = from; i <= to; i += by) {
-        updatePath(current, [i].concat(path), [i as keyof any].concat(traversed));
+        updatePath(current, [i].concat(path), traversed);
       }
       return;
     } else if (path.length > 1) {

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -85,7 +85,10 @@ describe("Simple setState modes", () => {
 
   test("Top level state function merge", () => {
     const [state, setState] = createStore({ starting: 1, ending: 1 });
-    setState(s => ({ ending: s.starting + 1 }));
+    setState((s, t) => {
+      expect(t).toStrictEqual([]);
+      return { ending: s.starting + 1 };
+    });
     expect(state.starting).toBe(1);
     expect(state.ending).toBe(2);
   });
@@ -99,7 +102,10 @@ describe("Simple setState modes", () => {
 
   test("Nested state function merge", () => {
     const [state, setState] = createStore({ data: { starting: 1, ending: 1 } });
-    setState("data", d => ({ ending: d.starting + 1 }));
+    setState("data", (d, t) => {
+      expect(t).toStrictEqual(["data"]);
+      return { ending: d.starting + 1 };
+    });
     expect(state.data.starting).toBe(1);
     expect(state.data.ending).toBe(2);
   });
@@ -122,7 +128,13 @@ describe("Simple setState modes", () => {
 describe("Array setState modes", () => {
   test("Update Specific", () => {
     const [state, setState] = createStore({ rows: [1, 2, 3, 4, 5] });
-    setState("rows", [1, 3], r => r * 2);
+    setState("rows", [1, 3], (r, t) => {
+      // @ts-ignore traversed types are wrong and incomplete
+      expect(typeof t[0]).toBe("number");
+      // @ts-ignore
+      expect(t[1]).toBe("rows");
+      return r * 2;
+    });
     expect(state.rows[0]).toBe(1);
     expect(state.rows[1]).toBe(4);
     expect(state.rows[2]).toBe(3);
@@ -135,7 +147,13 @@ describe("Array setState modes", () => {
     setState(
       "rows",
       (r, i) => Boolean(i % 2),
-      r => r * 2
+      (r, t) => {
+        // @ts-ignore
+        expect(typeof t[0]).toBe("number");
+        // @ts-ignore
+        expect(t[1]).toBe("rows");
+        return r * 2;
+      }
     );
     expect(state.rows[0]).toBe(1);
     expect(state.rows[1]).toBe(4);
@@ -145,7 +163,13 @@ describe("Array setState modes", () => {
   });
   test("Update traversal range", () => {
     const [state, setState] = createStore({ rows: [1, 2, 3, 4, 5] });
-    setState("rows", { from: 1, to: 4, by: 2 }, r => r * 2);
+    setState("rows", { from: 1, to: 4, by: 2 }, (r, t) => {
+      // @ts-ignore
+      expect(typeof t[0]).toBe("number");
+      // @ts-ignore
+      expect(t[1]).toBe("rows");
+      return r * 2;
+    });
     expect(state.rows[0]).toBe(1);
     expect(state.rows[1]).toBe(4);
     expect(state.rows[2]).toBe(3);
@@ -154,7 +178,13 @@ describe("Array setState modes", () => {
   });
   test("Update traversal range defaults", () => {
     const [state, setState] = createStore({ rows: [1, 2, 3, 4, 5] });
-    setState("rows", {}, r => r * 2);
+    setState("rows", {}, (r, t) => {
+      // @ts-ignore
+      expect(typeof t[0]).toBe("number");
+      // @ts-ignore
+      expect(t[1]).toBe("rows");
+      return r * 2;
+    });
     expect(state.rows[0]).toBe(2);
     expect(state.rows[1]).toBe(4);
     expect(state.rows[2]).toBe(6);


### PR DESCRIPTION
Fixes #840

~~Also made the type of `traversed` reflect the keys traversed e.g.~~ Will make a PR after the other store type PRs are done
```ts
setStore("list", [0, 1], (v, traversed) => {
  traversed[0]; // <-- number
  traversed[1]; // <-- "list"
})
```