### PR TITLE
type: Narrow down the return type of `children` primitive

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1093,6 +1093,9 @@ export function useContext<T>(context: Context<T>): T {
   return lookup(Owner, context.id) || context.defaultValue;
 }
 
+export type ResolvedJSXElement = Exclude<JSX.Element, JSX.ArrayElement | JSX.FunctionElement>;
+export type ResolvedChildren = ResolvedJSXElement | ResolvedJSXElement[];
+
 /**
  * Resolves child elements to help interact with children
  *
@@ -1101,7 +1104,7 @@ export function useContext<T>(context: Context<T>): T {
  *
  * @description https://www.solidjs.com/docs/latest/api#children
  */
-export function children(fn: Accessor<JSX.Element>): Accessor<JSX.Element> {
+export function children(fn: Accessor<JSX.Element>): Accessor<ResolvedChildren> {
   const children = createMemo(fn);
   return createMemo(() => resolveChildren(children()));
 }
@@ -1583,7 +1586,7 @@ function lookup(owner: Owner | null, key: symbol | string): any {
   );
 }
 
-function resolveChildren(children: JSX.Element): JSX.Element {
+function resolveChildren(children: JSX.Element): ResolvedChildren {
   if (typeof children === "function" && !children.length) return resolveChildren(children());
   if (Array.isArray(children)) {
     const results: any[] = [];
@@ -1593,7 +1596,7 @@ function resolveChildren(children: JSX.Element): JSX.Element {
     }
     return results;
   }
-  return children;
+  return children as ResolvedChildren;
 }
 
 function createProvider(id: symbol) {


### PR DESCRIPTION
This makes the return type of `children` primitive more accurate by narrowing `JSX.Element`. As mentioned here: #810 
It makes it a little bit easier to handle the resolved children as there are less types to worry about, or less type casting to do.
You'd still have to check if what's returned directly is an array or not, but it's still better than before.

For example looping over items get's easier:
```ts
import { children, createComputed, ResolvedJSXElement } from "solid-js"

const resolved = children(() => props.children)

createComputed(() => {
   const items = resolved() // T: ResolvedChildren
   if (Array.isArray(items)) items.forEach(handleItem)
   else handleItem(items)
})

const handleItem = (item: ResolvedJSXElement) => {
   ...
}
```

Not sure if there should be both `ResolvedJSXElement` & `ResolvedChildren` but it felt more ergonomic to have it this way.