### PR TITLE
refactor(store): Refactor store types again

### DIFF
--- a/packages/solid/store/src/index.ts
+++ b/packages/solid/store/src/index.ts
@@ -8,9 +8,8 @@ export type {
   StorePathRange,
   ArrayFilterFn,
   Part,
-  Next,
-  WrappableNext,
-  DeepReadonly
+  DeepReadonly,
+  DeepMutable
 } from "./store";
 export * from "./mutable";
 export * from "./modifiers";

--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -17,7 +17,7 @@ const proxyTraps: ProxyHandler<StoreNode> = {
   get(target, property, receiver) {
     if (property === $RAW) return target;
     if (property === $PROXY) return receiver;
-    const value = target[property as string | number];
+    const value = target[property];
     if (property === $NODE || property === "__proto__") return value;
 
     const wrappable = isWrappable(value);
@@ -32,17 +32,17 @@ const proxyTraps: ProxyHandler<StoreNode> = {
       node();
     }
     return wrappable
-      ? wrap(value, "_SOLID_DEV_" && target[$NAME] && `${target[$NAME]}:${property as string}`)
+      ? wrap(value, "_SOLID_DEV_" && target[$NAME] && `${target[$NAME]}:${property.toString()}`)
       : value;
   },
 
   set(target, property, value) {
-    setProperty(target, property as string, unwrap(value));
+    setProperty(target, property, unwrap(value));
     return true;
   },
 
   deleteProperty(target, property) {
-    setProperty(target, property as string, undefined);
+    setProperty(target, property, undefined);
     return true;
   },
 


### PR DESCRIPTION
Overall:
- Changed all instances of property keys typed with `keyof any` or some subset of `string | number | symbol` to the built-in `PropertyKey` type to improve readability.
- Changed all instances of `Store<T>` with `DeepReadonly<T>` except those that explicitly accept a store e.g. `create(Store|Mutable)`.
- Marked parameters `readonly` or `DeepReadonly` where possible to enforce const-correctness (is this the correct term in TS?).
- Fixed interactions with `any` (ugh).
- Removed more instances of unneeded casting.
- Added a `DeepMutable` type. This is probably the easiest way of solving mutability issues, including `produce`. Users can now cast stores as `DeepMutable<typeof store>` if desired (not recommended).

SetStoreFunction:
- Fixed the type of `traversed` in `setStore`.  It now correctly types the traversed path.
- Removed the "intermediate" types in SetStoreFunction as they were causing issues with inference for `produce` and `reconcile` in the absence of a proper `NoInfer` (`T & { [K in keyof T]: T[K] }` only delays inference, but doesn't completely disable it, causing issues when providing a generic function directly to a generic parameter). This drastically slows down inference.
- To combat the slowdown described above, further optimized SetStoreFunction by not using `Part` as the generics to avoid needing to transform the types back from `Part` to access a property's type. This is strictly an improvement afaict, also improving readability when calling `setStore`.
- As a result, `WrappableNext` and `Next` are removed. There is a `W` (for `Wrappable`) type, but it is a simple shortcut for (`Exclude<T, NotWrappable>`). I don't believe these types were necessary to export, but if desired they can be readded (albeit they are unnecessary now). Added a `KeyOf<T>` as `keyof T` is inadequate.

produce:
- Now correctly strips arrays of their readonly type in the mutation function. Uses the new `DeepMutable` type, as this is the least complicated way to correctly type a produce function called on a nested store.

reconcile:
- Now disallows passing a value with missing non-optional properties which resulted in the store being wrongly typed after being reconciled with a value with missing properties.

runtime changes:
- The server `reconcile` function was changed to more closely match the client's version of the function in both functionality and typing. Previously it returned `(state: T) => void`, but this was incompatible with the client version which always returned `(state: T) => T` (or now (state: U) => T).
- Added `toString` to a `string | symbol` used in a template literal in `mutable.ts` to avoid a dev mode error. A similar fix was in https://github.com/solidjs/solid/pull/763 for stores which also had the same issue.