### PR TITLE
Fix incompatibility with RxJS

### DIFF
--- a/packages/solid/src/reactive/observable.ts
+++ b/packages/solid/src/reactive/observable.ts
@@ -1,4 +1,4 @@
-import { createComputed, untrack, Accessor, createSignal, Setter, onCleanup } from "./signal";
+import { Accessor, createComputed, createSignal, onCleanup, Setter, untrack } from "./signal";
 
 function getSymbol() {
   const SymbolCopy = Symbol as any;
@@ -29,7 +29,7 @@ export function observable<T>(input: Accessor<T>) {
       if (!(observer instanceof Object) || observer == null) {
         throw new TypeError("Expected the observer to be an object.");
       }
-      const handler = "next" in observer ? observer.next : observer;
+      const handler = "next" in observer ? observer.next.bind(observer) : observer;
       let complete = false;
       createComputed(() => {
         if (complete) return;

--- a/packages/solid/test/observable.spec.ts
+++ b/packages/solid/test/observable.spec.ts
@@ -1,4 +1,4 @@
-import { createSignal, createRoot, observable, from } from "../src";
+import { createRoot, createSignal, from, observable } from "../src";
 
 describe("Observable operator", () => {
   test("to observable", () => {
@@ -15,6 +15,20 @@ describe("Observable operator", () => {
     set!("John");
     expect(out!).toBe("John");
   });
+
+  test("preserve the observer's this", () => {
+    const observer = {
+      next: jest.fn().mockReturnThis(),
+    };
+
+    createRoot(() => {
+      const [s] = createSignal("Hi"),
+        obsv$ = observable(s);
+
+      obsv$.subscribe(observer);
+    });
+    expect(observer.next).toHaveReturnedWith(observer);
+  })
 });
 
 describe("from transform", () => {

--- a/packages/solid/test/observable.spec.ts
+++ b/packages/solid/test/observable.spec.ts
@@ -16,7 +16,7 @@ describe("Observable operator", () => {
     expect(out!).toBe("John");
   });
 
-  test("preserve the observer's this", () => {
+  test("preserve the observer's next binding", () => {
     const observer = {
       next: jest.fn().mockReturnThis(),
     };


### PR DESCRIPTION
## :memo: Summary

This fixes an incompatibility of `observable()` with RxJS's `from()`.

fixes #554 

## :female_detective: Review notes

The cause for the incompatibility seems to be the following combination of circumstances:

- The `subscribe()` function created inside of Solid's `observable()` stores a reference to the observer's `next` function and calls it without explicitly supplying `this`.
- The `next` function of RxJS's `Subscriber` is not statically bound to the subscriber instance.

These two combine to the effect that a call to `next` originating from Solid's `observable` sees an incorrect value for `this`. This fix explicitly `.bind()`s the `next` handler to the observer to avoid that.