### PR TITLE
Enable blank GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: 🤔 Long question or idea
     url: https://github.com/solidjs/solid/discussions


### PR DESCRIPTION
Oren mentioned on Discord that he couldn't report a general issue/concern, only fill out the bug report template. This change should allow starting from a blank template as an option, while still making the bug report template prominent at the top.