### PR TITLE
feat: throw error when using ssr render functions in browser

### DIFF
--- a/packages/solid/web/src/server-mock.ts
+++ b/packages/solid/web/src/server-mock.ts
@@ -1,11 +1,19 @@
 //@ts-nocheck
+function throwInBrowser(func: Function) {
+  const err = new Error(`${func.name} is not supported in the browser, returning undefined`);
+
+  console.error(err);
+}
+
 export function renderToString<T>(
   fn: () => T,
   options?: {
     nonce?: string;
     renderId?: string;
   }
-): string {}
+): string {
+  throwInBrowser(renderToString);
+}
 export function renderToStringAsync<T>(
   fn: () => T,
   options?: {
@@ -13,7 +21,9 @@ export function renderToStringAsync<T>(
     nonce?: string;
     renderId?: string;
   }
-): Promise<string> {}
+): Promise<string> {
+  throwInBrowser(renderToStringAsync);
+}
 export function renderToStream<T>(
   fn: () => T,
   options?: {
@@ -25,7 +35,9 @@ export function renderToStream<T>(
 ): {
   pipe: (writable: { write: (v: string) => void }) => void;
   pipeTo: (writable: WritableStream) => void;
-} {}
+} {
+  throwInBrowser(renderToStream);
+}
 export function ssr(template: string[] | string, ...nodes: any[]): { t: string } {}
 export function resolveSSRNode(node: any): string {}
 export function ssrClassList(value: { [k: string]: boolean }): string {}

--- a/packages/solid/web/test/server-mock.spec.tsx
+++ b/packages/solid/web/test/server-mock.spec.tsx
@@ -1,0 +1,46 @@
+import { renderToString, renderToStringAsync, renderToStream } from "../src/server-mock";
+
+const origConsoleError = console.error;
+const mockConsoleError = jest.fn();
+
+beforeEach(() => {
+  console.error = mockConsoleError;
+  mockConsoleError.mockReset();
+});
+
+afterAll(() => {
+  console.error = origConsoleError;
+});
+
+test("renderToString", () => {
+  const result = renderToString(() => {});
+
+  const err: Error = mockConsoleError.mock.calls[0][0];
+
+  expect(err.message).toContain(
+    "renderToString is not supported in the browser, returning undefined"
+  );
+  expect(result).toBeUndefined();
+});
+
+test("renderToStringAsync", () => {
+  const result = renderToStringAsync(() => {});
+
+  const err: Error = mockConsoleError.mock.calls[0][0];
+
+  expect(err.message).toContain(
+    "renderToStringAsync is not supported in the browser, returning undefined"
+  );
+  expect(result).toBeUndefined();
+});
+
+test("renderToStream", () => {
+  const result = renderToStream(() => {});
+
+  const err: Error = mockConsoleError.mock.calls[0][0];
+
+  expect(err.message).toContain(
+    "renderToStream is not supported in the browser, returning undefined"
+  );
+  expect(result).toBeUndefined();
+});


### PR DESCRIPTION
Resolves #878 

This PR tries using throwInBrowser, so we can log an error that tells the user that using such functions is not possible in the browser, though it does not break the user's code (logging instead of throwing)!