### PR TITLE
fix: fix `{ [x: string]: ... }` being treated as an array by setStore.

### DIFF
--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -240,18 +240,23 @@ export type StoreSetter<T, U extends PropertyKey[] = []> =
 
 export type Part<T, K extends KeyOf<T> = KeyOf<T>> = [K] extends [never]
   ? never // return never if key is never, else it'll return readonly never[] as well
-  : K | readonly K[] | (number extends K ? ArrayFilterFn<T[number]> | StorePathRange : never);
+  :
+      | K
+      | readonly K[]
+      | ([T] extends [readonly unknown[]] ? ArrayFilterFn<T[number]> | StorePathRange : never);
 
 // shortcut to avoid writing `Exclude<T, NotWrappable>` too many times
 type W<T> = Exclude<T, NotWrappable>;
 
 // specially handle keyof to avoid errors with arrays and any
-type KeyOf<T> = number extends keyof T
+type KeyOf<T> = number extends keyof T // have to check this otherwise ts won't allow KeyOf<T> to index T
   ? 0 extends 1 & T // if it's any just return keyof T
     ? keyof T
-    : [T] extends [never] // keyof never is PropertyKey which number extends; return never
-    ? never
-    : number // it's not any or never so it's an array or tuple; exclude the non-number properties
+    : [T] extends [readonly unknown[]]
+    ? number // it's an array or tuple; exclude the non-number properties
+    : [T] extends [never]
+    ? never // keyof never is PropertyKey which number extends; return never
+    : keyof T // it's something which contains an index signature for strings or numbers
   : keyof T;
 
 type Rest<T, U extends PropertyKey[]> =

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -723,3 +723,12 @@ describe("Nested Classes", () => {
     t = [0, "a"];
   });
 };
+
+// types with a string index signature are not wrongly assumed to be arrays in setStore
+() => {
+  const [store, setStore] = createStore<{ [x: string]: number }>({});
+  // @ts-expect-error filter function not allowed for objects
+  setStore(() => true, 1);
+  // @ts-expect-error from to by not allowed for objects
+  setStore({ from: 0, to: 10, by: 3 }, 1);
+};


### PR DESCRIPTION
`keyof { [x: string]: ... }` includes `number`, so `number extends keyof T` is insufficient for checking whether `T` is an array. This adds an additional check for `[T] extends [readonly unknown[]]` to rectify that, since `number extends keyof T` is still necessary to make typescript allow `number` to index `T` even after asserting that it is a `readonly unknown[]`.