### PR TITLE
fix: workaround for `StoreSetter` not working well with complex types

### DIFF
--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -1,13 +1,4 @@
-import {
-  setProperty,
-  unwrap,
-  isWrappable,
-  StoreNode,
-  $RAW,
-  DeepMutable,
-  DeepReadonly,
-  NotWrappable
-} from "./store";
+import { setProperty, unwrap, isWrappable, StoreNode, $RAW, DeepMutable } from "./store";
 
 export type ReconcileOptions = {
   key?: string | null;
@@ -144,12 +135,9 @@ const setterTraps: ProxyHandler<StoreNode> = {
 };
 
 // Immer style mutation style
-export function produce<T>(
-  fn: (state: DeepMutable<Exclude<T, NotWrappable>>) => void
-): (state: T) => T {
+export function produce<T>(fn: (state: DeepMutable<T>) => void): (state: T) => T {
   return state => {
-    if (isWrappable(state))
-      fn(new Proxy(state, setterTraps) as DeepMutable<Exclude<T, NotWrappable>>);
+    if (isWrappable(state)) fn(new Proxy(state, setterTraps) as DeepMutable<T>);
     return state;
   };
 }

--- a/packages/solid/store/src/server.ts
+++ b/packages/solid/store/src/server.ts
@@ -1,4 +1,4 @@
-import type { DeepMutable, DeepReadonly, SetStoreFunction, Store, StoreSetter } from "store";
+import type { DeepMutable, SetStoreFunction, Store } from "store";
 
 export const $RAW = Symbol("state-raw");
 
@@ -113,7 +113,7 @@ export function reconcile<T extends U, U>(
 // Immer style mutation style
 export function produce<T>(fn: (state: DeepMutable<T>) => void): (state: T) => T {
   return state => {
-    if (isWrappable(state)) fn(state as T);
+    if (isWrappable(state)) fn(state as DeepMutable<T>);
     return state;
   };
 }

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -217,13 +217,17 @@ export function updatePath(current: StoreNode, path: any[], traversed: PropertyK
 
 export type DeepReadonly<T> = 0 extends 1 & T
   ? T
+  : T extends NotWrappable
+  ? T
   : {
-      readonly [K in keyof T]: T[K] extends NotWrappable ? T[K] : DeepReadonly<T[K]>;
+      readonly [K in keyof T]: T[K];
     };
 export type DeepMutable<T> = 0 extends 1 & T
   ? T
+  : T extends NotWrappable
+  ? T
   : {
-      -readonly [K in keyof T]: T[K] extends NotWrappable ? T[K] : DeepMutable<T[K]>;
+      -readonly [K in keyof T]: T[K];
     };
 
 export type StorePathRange = { from?: number; to?: number; by?: number };

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -234,7 +234,9 @@ export type StoreSetter<T, U extends PropertyKey[] = []> =
   | ((
       prevState: DeepReadonly<T>,
       traversed: U
-    ) => DeepReadonly<T> | Partial<DeepReadonly<T>> | void)
+    ) => T | Partial<T> | DeepReadonly<T> | Partial<DeepReadonly<T>> | void)
+  | T
+  | Partial<T>
   | DeepReadonly<T>
   | Partial<DeepReadonly<T>>;
 

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -1,5 +1,5 @@
 import { createRoot, createSignal, createComputed, createMemo, on } from "../../src";
-import { createStore, unwrap, $RAW, NotWrappable, DeepReadonly } from "../src";
+import { createStore, unwrap, $RAW, NotWrappable } from "../src";
 
 describe("State immutablity", () => {
   test("Setting a property", () => {
@@ -680,9 +680,7 @@ describe("Nested Classes", () => {
   setStore("b", "a", "c");
   // @ts-expect-error TODO generic should index Record
   setStore("c", v, "c");
-  // @ts-expect-error TODO generic should index Record
   const b = store.c[v];
-  // @ts-expect-error string should be assignable to string
   const c: typeof b = "1";
   const d = a.c[v];
   const e: typeof d = "1";

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -1,5 +1,5 @@
 import { createRoot, createSignal, createComputed, createMemo, on } from "../../src";
-import { createStore, unwrap, $RAW, NotWrappable } from "../src";
+import { createStore, unwrap, $RAW, NotWrappable, DeepReadonly } from "../src";
 
 describe("State immutablity", () => {
   test("Setting a property", () => {
@@ -731,4 +731,10 @@ describe("Nested Classes", () => {
   setStore(() => true, 1);
   // @ts-expect-error from to by not allowed for objects
   setStore({ from: 0, to: 10, by: 3 }, 1);
+};
+
+// can set overly complex? types
+() => {
+  const [store, setStore] = createStore<{ el?: Element }>({});
+  setStore("el", {} as Element);
 };


### PR DESCRIPTION
This adds `T | Partial<T>` to the types accepted by `StoreSetter` as fallbacks in case `DeepReadonly<T> | Partial<DeepReadonly<T>>` fails to catch those types.