### PR TITLE
feat: allow adding types to stores' `NotWrappable`

### DIFF
--- a/packages/solid/store/src/index.ts
+++ b/packages/solid/store/src/index.ts
@@ -3,6 +3,7 @@ export type {
   Store,
   SetStoreFunction,
   NotWrappable,
+  SolidStore,
   StoreNode,
   StoreSetter,
   StorePathRange,

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -4,6 +4,9 @@ export const $RAW = Symbol("store-raw"),
   $NAME = Symbol("store-name");
 
 export type StoreNode = Record<PropertyKey, any>;
+export namespace SolidStore {
+  export interface Unwrappable {}
+}
 export type NotWrappable =
   | string
   | number
@@ -12,7 +15,8 @@ export type NotWrappable =
   | boolean
   | Function
   | null
-  | undefined;
+  | undefined
+  | SolidStore.Unwrappable[keyof SolidStore.Unwrappable];
 export type Store<T> = DeepReadonly<T>;
 
 function wrap<T extends StoreNode>(value: T, name?: string): DeepReadonly<T> {


### PR DESCRIPTION
Classes are not distinguishable from types in typescript which can be troublesome for stores, which don't wrap classes.

This adds an interface `Unwrappable` which can be used to add unwrappable types via declaration merging, like how custom directives are currently handled. 

For example, to exclude `Element`:
```ts
declare module "solid-js/store" {
  namespace SolidStore {
    interface Unwrappable {
      anyUniqueKey: Element
    }
  }
}
```