### PR TITLE
log when ErrorBoundary doesn't handle errors

### DIFF
--- a/packages/solid/src/render/flow.ts
+++ b/packages/solid/src/render/flow.ts
@@ -176,7 +176,7 @@ export function ErrorBoundary(props: {
   return createMemo(() => {
     if ((e = errored()) != null) {
       const f = props.fallback;
-      if ("_SOLID_DEV_" && typeof f === "function" && f.length == 0) console.error(e);
+      if ("_SOLID_DEV_" && (typeof f !== "function" || f.length == 0)) console.error(e);
       return typeof f === "function" && f.length ? untrack(() => f(e, () => setErrored(null))) : f;
     }
     onError(setErrored);

--- a/packages/solid/src/render/flow.ts
+++ b/packages/solid/src/render/flow.ts
@@ -176,6 +176,7 @@ export function ErrorBoundary(props: {
   return createMemo(() => {
     if ((e = errored()) != null) {
       const f = props.fallback;
+      if ("_SOLID_DEV_" && typeof f === "function" && f.length == 0) console.error(e);
       return typeof f === "function" && f.length ? untrack(() => f(e, () => setErrored(null))) : f;
     }
     onError(setErrored);


### PR DESCRIPTION
A common pattern is to use an error boundary to warn users about errors without telling them exactly what the error is, but in development it would be useful to surface the error