### PR TITLE
Improve the typing of parameters of unwrap

### DIFF
--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -110,7 +110,7 @@ export function reconcile<T extends U, U>(
   const { merge, key = "id" } = options,
     v = unwrap(value);
   return state => {
-    if (!isWrappable(state) || !isWrappable(v)) return v;
+    if (!isWrappable(state) || !isWrappable(v)) return v as T;
     applyState(v, { state }, "state", merge, key);
     return state as T;
   };

--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -79,7 +79,7 @@ function wrap<T extends StoreNode>(value: T, name?: string): T {
 }
 
 export function createMutable<T extends StoreNode>(state: T, options?: { name?: string }): T {
-  const unwrappedStore = unwrap<T>(state || {});
+  const unwrappedStore = unwrap(state || {});
   if ("_SOLID_DEV_" && typeof unwrappedStore !== "object" && typeof unwrappedStore !== "function")
     throw new Error(
       `Unexpected type ${typeof unwrappedStore} received when initializing 'createMutable'. Expected an object.`

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -47,13 +47,13 @@ export function isWrappable(obj: any) {
   );
 }
 
-export function unwrap<T extends StoreNode>(item: any, set = new Set()): T {
+export function unwrap<T extends StoreNode>(item: T, set = new Set()): T {
   let result, unwrapped, v, prop;
   if ((result = item != null && item[$RAW])) return result;
   if (!isWrappable(item) || set.has(item)) return item;
 
   if (Array.isArray(item)) {
-    if (Object.isFrozen(item)) item = item.slice(0);
+    if (Object.isFrozen(item)) item = item.slice(0) as unknown as T;
     else set.add(item);
     for (let i = 0, l = item.length; i < l; i++) {
       v = item[i];
@@ -68,7 +68,7 @@ export function unwrap<T extends StoreNode>(item: any, set = new Set()): T {
       prop = keys[i];
       if ((desc as any)[prop].get) continue;
       v = item[prop];
-      if ((unwrapped = unwrap(v, set)) !== v) item[prop] = unwrapped;
+      if ((unwrapped = unwrap(v, set)) !== v) item[prop as keyof T] = unwrapped;
     }
   }
   return item;


### PR DESCRIPTION
The type of the 1st parameter was any, but we can assume that the
user won't pass as the template type a type that is "wrapped"
(contains properties that unwrapping will remove), this way the
user doesn't needs to pass a type to unwrap to it works well.