### PR TITLE
add type test cases for createSignal/Setter

### DIFF
--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -626,8 +626,8 @@ describe("runWithOwner", () => {
     });
 
     runWithOwner(owner, () => {
-      createEffect(() => effectRun = true);
-      onCleanup(() => cleanupRun = true);
+      createEffect(() => (effectRun = true));
+      onCleanup(() => (cleanupRun = true));
       expect(effectRun).toBe(false);
       expect(cleanupRun).toBe(false);
     });
@@ -639,13 +639,13 @@ describe("runWithOwner", () => {
 });
 
 describe("createReaction", () => {
-  test("Create and trigger a Reaction", (done) => {
+  test("Create and trigger a Reaction", done => {
     createRoot(() => {
       let count = 0;
       const [sign, setSign] = createSignal("thoughts");
       const track = createReaction(() => count++);
       expect(count).toBe(0);
-      track(sign)
+      track(sign);
       expect(count).toBe(0);
       setTimeout(() => {
         expect(count).toBe(0);
@@ -653,11 +653,11 @@ describe("createReaction", () => {
         expect(count).toBe(1);
         setSign("body");
         expect(count).toBe(1);
-        track(sign)
+        track(sign);
         setSign("everything");
         expect(count).toBe(2);
         done();
       });
     });
   });
-})
+});


### PR DESCRIPTION
~~I think this makes the `Setter` type easier to read and understand. I am thinking that in this form, the cases are explicitly laid out, easier to read.~~

~~What are your opinions?~~

~~If we end up preferring the previous form, we can merge just the added test cases.~~

I removed the type changes, so this now only adds new type test cases to cover signal function values well.