### PR TITLE
Fix solid-ssr on windows

### DIFF
--- a/packages/solid-ssr/static/writeToDisk.mjs
+++ b/packages/solid-ssr/static/writeToDisk.mjs
@@ -2,8 +2,8 @@ import { dirname } from "path";
 import { writeFile, mkdir } from "fs"
 
 async function write() {
-  const server = (await import(process.argv[2])).default;
-  const res = await server({ url: process.argv[4] });
+  const server = (await import(join("file://", process.argv[2]))).default;
+  const res = await server({ url: join("file://", process.argv[4]) });
   mkdir(dirname(process.argv[3]), {recursive: true},  () =>
     writeFile(process.argv[3], res, () => process.exit(0))
   );

--- a/packages/solid-ssr/static/writeToDisk.mjs
+++ b/packages/solid-ssr/static/writeToDisk.mjs
@@ -1,4 +1,4 @@
-import { dirname } from "path";
+import { dirname, join } from "path";
 import { writeFile, mkdir } from "fs"
 
 async function write() {


### PR DESCRIPTION
As discussed on discord, the static adapter for solid-start breaks because `writeToDisk.mjs` fails on windows (silently, because the asynchronous version of the function is called.

I really have no idea what I'm doing here, I just made changes that worked for me. Please review and determine the best solution!