### PR TITLE
re-export all things from signal.ts?

### DIFF
--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -1,47 +1,4 @@
-export {
-  createRoot,
-  createSignal,
-  createEffect,
-  createRenderEffect,
-  createComputed,
-  createReaction,
-  createDeferred,
-  createSelector,
-  createMemo,
-  createResource,
-  onMount,
-  onCleanup,
-  onError,
-  untrack,
-  batch,
-  on,
-  enableScheduling,
-  enableExternalSource,
-  startTransition,
-  useTransition,
-  refetchResources,
-  createContext,
-  useContext,
-  children,
-  getListener,
-  getOwner,
-  runWithOwner,
-  equalFn,
-  $DEVCOMP,
-  $PROXY
-} from "./reactive/signal";
-export type {
-  Accessor,
-  Setter,
-  Signal,
-  Resource,
-  ResourceReturn,
-  ResourceFetcher,
-  ResourceFetcherInfo,
-  Context,
-  ReturnTypes
-} from "./reactive/signal";
-
+export * from "./reactive/signal";
 export * from "./reactive/observable";
 export * from "./reactive/scheduler";
 export * from "./reactive/array";


### PR DESCRIPTION
they are available indirectly via the path to the file anyway

### Use case:

I am extending types from signal.ts in new primitives outside of Solid, and I have to import types directly, f.e.:

```js
import type {SignalOptions, etc} from 'solid-js/types/reactive/signal'
```

So I figured, why not just re-export to simplify the code. Then end user can more easily do the following, although it's not critical:

```js
import type {SignalOptions, etc} from 'solid-js'
```

Does this have any significant cons?