### PR TITLE
fix: fix the signal setter type when used with generics

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -124,7 +124,7 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: Owner): T {
 
 export type Accessor<T> = () => T;
 
-export type Setter<T> = (undefined extends T ? (value?: undefined) => undefined : {}) &
+export type Setter<T> = (undefined extends T ? () => undefined : {}) &
   (<U extends T>(value: Exclude<U, Function> | ((prev: T) => U)) => U);
 
 export type Signal<T> = [get: Accessor<T>, set: Setter<T>];
@@ -172,7 +172,7 @@ export function createSignal<T>(value?: T, options?: SignalOptions<T>): Signal<T
   if ("_SOLID_DEV_" && !options.internal)
     s.name = registerGraph(options.name || hashValue(value), s as { value: unknown });
 
-  const setter: Setter<T | undefined> = (value: unknown) => {
+  const setter: Setter<T | undefined> = (value?: unknown) => {
     if (typeof value === "function") {
       if (Transition && Transition.running && Transition.sources.has(s))
         value = value(s.pending !== NOTPENDING ? s.pending : s.tValue);

--- a/packages/solid/test/signals.type-tests.ts
+++ b/packages/solid/test/signals.type-tests.ts
@@ -5,7 +5,9 @@ import {
   createMemo,
   Accessor,
   on,
-  createSignal
+  createSignal,
+  Signal,
+  Setter
   // } from "../types/index";
 } from "../src";
 
@@ -716,9 +718,9 @@ const n6: number = func2()();
 const [stringOrFunc1, setStringOrFunc1] = createSignal<(() => number) | string>("");
 // @ts-expect-error number should not be assignable to string
 setStringOrFunc1(() => 1);
-const sf1: () => number = setStringOrFunc1(() => () => 1);
-const sf2: string = setStringOrFunc1("oh yeah");
-const sf3: string = setStringOrFunc1(() => "oh yeah");
+const sf1: () => 1 = setStringOrFunc1(() => () => 1);
+const sf2: "oh yeah" = setStringOrFunc1("oh yeah");
+const sf3: "oh yeah" = setStringOrFunc1(() => "oh yeah");
 // @ts-expect-error cannot set signal to undefined
 setStringOrFunc1();
 // @ts-expect-error cannot set signal to undefined
@@ -731,14 +733,26 @@ const sf8: (() => number) | string = stringOrFunc1();
 const [stringOrFunc2, setStringOrFunc2] = createSignal<(() => number) | string>();
 // @ts-expect-error number should not be assignable to string
 setStringOrFunc2(() => 1);
-const sf9: () => number = setStringOrFunc2(() => () => 1);
-const sf10: string = setStringOrFunc2("oh yeah");
-const sf11: string = setStringOrFunc2(() => "oh yeah");
+const sf9: () => 1 = setStringOrFunc2(() => () => 1);
+const sf10: "oh yeah" = setStringOrFunc2("oh yeah");
+const sf11: "oh yeah" = setStringOrFunc2(() => "oh yeah");
 const sf12: undefined = setStringOrFunc2();
 const sf13: undefined = setStringOrFunc2(undefined);
 const sf14: (() => number) | string | undefined = stringOrFunc2();
 // @ts-expect-error return value might be undefined
 const sf15: (() => number) | string = stringOrFunc2();
+
+function createGenericSignal<T>(): Signal<T | undefined> {
+  const [generic, setGeneric] = createSignal<T>();
+  const customSet: Setter<T | undefined> = (v?) => setGeneric(v);
+  return [generic, (v?) => setGeneric(v)];
+}
+
+function createInitializedSignal<T>(init: T): Signal<T> {
+  const [generic, setGeneric] = createSignal<T>(init);
+  const customSet: Setter<T> = (v?) => setGeneric(v);
+  return [generic, (v?) => setGeneric(v)];
+}
 
 //////////////////////////////////////////////////////////////////////////
 // test explicit generic args ////////////////////////////////////////////


### PR DESCRIPTION
This makes it easier to create generic wrappers around `createSignal` e.g.
```ts
function createGenericSignal<T>(): Signal<T | undefined> {
  const [generic, setGeneric] = createSignal<T>();
  const customSet: Setter<T | undefined> = (v?) => setGeneric(v);
  return [generic, (v?) => setGeneric(v)];
}

function createInitializedSignal<T>(init: T): Signal<T> {
  const [generic, setGeneric] = createSignal<T>(init);
  const customSet: Setter<T> = (v?) => setGeneric(v);
  return [generic, (v?) => setGeneric(v)];
}
```
where previously such an implementation would not be assignable to `Setter`, and would need to be cast.

In the `createSignal` implmentation, this still doesn't allow `value` to be callable after the `typeof value` type guard, as `Exclude<U, Function> & Function` doesn't get reduced to `never` due to how generics work. As such (and also because the result of the call is assigned back to `value`, which might not be able to hold it), I've left it as is instead of using inference.