### PR TITLE
refactor: simplify/improve effect types

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -213,22 +213,18 @@ export type EffectFunction<Prev, Next extends Prev = Prev> = (v: Prev) => Next;
  *
  * @description https://www.solidjs.com/docs/latest/api#createcomputed
  */
+export function createComputed<Next>(fn: EffectFunction<undefined | NoInfer<Next>, Next>): void;
 export function createComputed<Next, Init = Next>(
   fn: EffectFunction<Init | Next, Next>,
   value: Init,
   options?: EffectOptions
 ): void;
-export function createComputed<Next, Init = undefined>(
-  ..._: undefined extends Init
-    ? [fn: EffectFunction<Init | Next, Next>, value?: Init, options?: EffectOptions]
-    : [fn: EffectFunction<Init | Next, Next>, value: Init, options?: EffectOptions]
-): void;
 export function createComputed<Next, Init>(
   fn: EffectFunction<Init | Next, Next>,
-  value: Init,
+  value?: Init,
   options?: EffectOptions
 ): void {
-  const c = createComputation(fn, value, true, STALE, "_SOLID_DEV_" ? options : undefined);
+  const c = createComputation(fn, value!, true, STALE, "_SOLID_DEV_" ? options : undefined);
   if (Scheduler && Transition && Transition.running) Updates!.push(c);
   else updateComputation(c);
 }
@@ -248,22 +244,18 @@ export function createComputed<Next, Init>(
  *
  * @description https://www.solidjs.com/docs/latest/api#createrendereffect
  */
+export function createRenderEffect<Next>(fn: EffectFunction<undefined | NoInfer<Next>, Next>): void;
 export function createRenderEffect<Next, Init = Next>(
   fn: EffectFunction<Init | Next, Next>,
   value: Init,
   options?: EffectOptions
 ): void;
-export function createRenderEffect<Next, Init = undefined>(
-  ..._: undefined extends Init
-    ? [fn: EffectFunction<Init | Next, Next>, value?: Init, options?: EffectOptions]
-    : [fn: EffectFunction<Init | Next, Next>, value: Init, options?: EffectOptions]
-): void;
 export function createRenderEffect<Next, Init>(
   fn: EffectFunction<Init | Next, Next>,
-  value: Init,
+  value?: Init,
   options?: EffectOptions
 ): void {
-  const c = createComputation(fn, value, false, STALE, "_SOLID_DEV_" ? options : undefined);
+  const c = createComputation(fn, value!, false, STALE, "_SOLID_DEV_" ? options : undefined);
   if (Scheduler && Transition && Transition.running) Updates!.push(c);
   else updateComputation(c);
 }
@@ -283,23 +275,19 @@ export function createRenderEffect<Next, Init>(
  *
  * @description https://www.solidjs.com/docs/latest/api#createeffect
  */
+export function createEffect<Next>(fn: EffectFunction<undefined | NoInfer<Next>, Next>): void;
 export function createEffect<Next, Init = Next>(
   fn: EffectFunction<Init | Next, Next>,
   value: Init,
   options?: EffectOptions
 ): void;
-export function createEffect<Next, Init = undefined>(
-  ..._: undefined extends Init
-    ? [fn: EffectFunction<Init | Next, Next>, value?: Init, options?: EffectOptions]
-    : [fn: EffectFunction<Init | Next, Next>, value: Init, options?: EffectOptions]
-): void;
-export function createEffect<Next, Init = Next>(
+export function createEffect<Next, Init>(
   fn: EffectFunction<Init | Next, Next>,
-  value: Init,
+  value?: Init,
   options?: EffectOptions
 ): void {
   runEffects = runUserEffects;
-  const c = createComputation(fn, value, false, STALE, "_SOLID_DEV_" ? options : undefined),
+  const c = createComputation(fn, value!, false, STALE, "_SOLID_DEV_" ? options : undefined),
     s = SuspenseContext && lookup(Owner, SuspenseContext.id);
   if (s) c.suspense = s;
   c.user = true;
@@ -363,29 +351,27 @@ export interface MemoOptions<T> extends EffectOptions {
  *
  * @description https://www.solidjs.com/docs/latest/api#creatememo
  */
-// The extra _Next generic parameter separates inference of the effect input
+// The extra Prev generic parameter separates inference of the effect input
 // parameter type from inference of the effect return type, so that the effect
 // return type is always used as the memo Accessor's return type.
-export function createMemo<Next extends _Next, Init = Next, _Next = Next>(
-  fn: EffectFunction<Init | _Next, Next>,
+export function createMemo<Next extends Prev, Prev = Next>(
+  fn: EffectFunction<undefined | NoInfer<Prev>, Next>
+): Accessor<Next>;
+export function createMemo<Next extends Prev, Init = Next, Prev = Next>(
+  fn: EffectFunction<Init | Prev, Next>,
   value: Init,
   options?: MemoOptions<Next>
 ): Accessor<Next>;
-export function createMemo<Next extends _Next, Init = undefined, _Next = Next>(
-  ..._: undefined extends Init
-    ? [fn: EffectFunction<Init | _Next, Next>, value?: Init, options?: MemoOptions<Next>]
-    : [fn: EffectFunction<Init | _Next, Next>, value: Init, options?: MemoOptions<Next>]
-): Accessor<Next>;
-export function createMemo<Next extends _Next, Init, _Next>(
-  fn: EffectFunction<Init | _Next, Next>,
-  value: Init,
+export function createMemo<Next extends Prev, Init, Prev>(
+  fn: EffectFunction<Init | Prev, Next>,
+  value?: Init,
   options?: MemoOptions<Next>
 ): Accessor<Next> {
   options = options ? Object.assign({}, signalOptions, options) : signalOptions;
 
   const c: Partial<Memo<Init, Next>> = createComputation(
     fn,
-    value,
+    value!,
     true,
     0,
     "_SOLID_DEV_" ? options : undefined

--- a/packages/solid/test/signals.type-tests.ts
+++ b/packages/solid/test/signals.type-tests.ts
@@ -580,6 +580,7 @@ const m2: Accessor<number | undefined> = createMemo(() => 123);
 const m3: //
 Accessor<undefined> = createMemo(() => {});
 const m4: Accessor<void> = createMemo(() => {});
+// @ts-expect-error void can't be assigned to anything!
 const m5: Accessor<number | undefined> = createMemo(
   // @ts-expect-error void can't be assigned to anything!
   (v?: number) => {}
@@ -625,7 +626,6 @@ const m18: Accessor<number> =
 const m19: Accessor<number> =
   // @ts-expect-error undefined initial value is not assignable to the number parameter
   createMemo((v: number | string): number => 123);
-// @ts-expect-error because the number return cannot be assigned to the boolean|string parameter
 const m20: Accessor<number> =
   // @ts-expect-error because the number return cannot be assigned to the boolean|string parameter
   createMemo((v: boolean | string): number => 123);
@@ -919,3 +919,13 @@ createRenderEffect<number | boolean>(
     // @ts-expect-error string return is not assignable to number|boolean
     "foo"
 );
+
+// FIXME cases failing due to partial generic inference not being implemented
+// @ts-expect-error second generic is not inferred and remains as number
+const a7: Accessor<number> = createMemo<number>((v: number | string) => 123, "asd");
+// @ts-expect-error second generic is not inferred and remains as number
+createEffect<number>((v: number | string) => 123, "asd");
+// @ts-expect-error second generic is not inferred and remains as number
+createComputed<number>((v: number | string) => 123, "asd");
+// @ts-expect-error second generic is not inferred and remains as number
+createRenderEffect<number>((v: number | string) => 123, "asd");


### PR DESCRIPTION
- Simplified `createEffect` etc. such that they no longer use rest params.
- Added test cases for effect functions failing partial generic inference (not supported by typescript)
- Removed extra params from effects' first overload

Edit: removed the changes not related to effect types, it would be better to clean them up all at once in another PR. 