### PR TITLE
Refactor: switch downstream and upstream terms

### DIFF
--- a/packages/solid/bench/prototypes/queue-noarray.cjs
+++ b/packages/solid/bench/prototypes/queue-noarray.cjs
@@ -84,7 +84,7 @@ function createMemo(fn, value, options) {
     if (c.state && (c.source || c.sources)) {
       const updates = Updates;
       Updates = null;
-      c.state === STALE ? updateComputation(c) : lookDownstream(c);
+      c.state === STALE ? updateComputation(c) : lookUpstream(c);
       Updates = updates;
     }
     if (Listener) logRead(c);
@@ -179,7 +179,7 @@ function queueUpdates(o) {
   if (!o.state) {
     if (o.pure) Updates.push(o);
     else Effects.push(o);
-    if (o.observer || o.observers) markUpstream(o);
+    if (o.observer || o.observers) markDownstream(o);
   }
   o.state = STALE;
 }
@@ -230,7 +230,7 @@ function createComputation(fn, init, pure, state = STALE, options) {
 }
 function runTop(node) {
   if (node.state === 0) return;
-  if (node.state === PENDING) return lookDownstream(node);
+  if (node.state === PENDING) return lookUpstream(node);
   const ancestors = [node];
   while ((node = node.owner) && (!node.updatedAt || node.updatedAt < ExecCount)) {
     if (node.state) ancestors.push(node);
@@ -242,7 +242,7 @@ function runTop(node) {
     } else if (node.state === PENDING) {
       const updates = Updates;
       Updates = null;
-      lookDownstream(node);
+      lookUpstream(node);
       Updates = updates;
     }
   }
@@ -278,33 +278,33 @@ function completeUpdates(wait) {
 function runQueue(queue) {
   for (let i = 0; i < queue.length; i++) runTop(queue[i]);
 }
-function lookDownstream(node) {
+function lookUpstream(node) {
   node.state = 0;
-  if (node.source) lookDownstreamNode(node.source)
+  if (node.source) lookUpstreamNode(node.source)
   if (node.sources) {
     for (let i = 0; i < node.sources.length; i += 1) {
-      lookDownstream(node.sources[i]);
+      lookUpstream(node.sources[i]);
     }
   }
 }
-function lookDownstreamNode(source) {
+function lookUpstreamNode(source) {
   if (source.source || source.sources) {
     if (source.state === STALE) runTop(source);
-    else if (source.state === PENDING) lookDownstream(source);
+    else if (source.state === PENDING) lookUpstream(source);
   }
 }
-function markUpstream(node) {
-  if (node.observer) markUpstreamNode(node.observer);
+function markDownstream(node) {
+  if (node.observer) markDownstreamNode(node.observer);
   if (node.observers) {
-    for (let i = 0; i < node.observers.length; i += 1) markUpstreamNode(node.observers[i]);
+    for (let i = 0; i < node.observers.length; i += 1) markDownstreamNode(node.observers[i]);
   }
 }
-function markUpstreamNode(o) {
+function markDownstreamNode(o) {
   if (!o.state) {
     o.state = PENDING;
     if (o.pure) Updates.push(o);
     else Effects.push(o);
-    (o.observer || o.observers) && markUpstream(o);
+    (o.observer || o.observers) && markDownstream(o);
   }
 }
 function cleanNode(node) {

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1162,7 +1162,7 @@ export function readSignal(this: SignalState<any> | Memo<any>) {
     (!runningTransition && (this as Memo<any>).state === STALE) ||
     (runningTransition && (this as Memo<any>).tState === STALE)
       ? updateComputation(this as Memo<any>)
-      : lookDownstream(this as Memo<any>);
+      : lookUpstream(this as Memo<any>);
     Updates = updates;
   }
   if (Listener) {
@@ -1214,7 +1214,7 @@ export function writeSignal(node: SignalState<any> | Memo<any>, value: any, isCo
         if ((TransitionRunning && !o.tState) || (!TransitionRunning && !o.state)) {
           if (o.pure) Updates!.push(o);
           else Effects!.push(o);
-          if ((o as Memo<any>).observers) markUpstream(o as Memo<any>);
+          if ((o as Memo<any>).observers) markDownstream(o as Memo<any>);
         }
         if (TransitionRunning) o.tState = STALE;
         else o.state = STALE;
@@ -1344,7 +1344,7 @@ function runTop(node: Computation<any>) {
     (!runningTransition && node.state === PENDING) ||
     (runningTransition && node.tState === PENDING)
   )
-    return lookDownstream(node);
+    return lookUpstream(node);
   if (node.suspense && untrack(node.suspense.inFallback!))
     return node!.suspense.effects!.push(node!);
   const ancestors = [node];
@@ -1376,7 +1376,7 @@ function runTop(node: Computation<any>) {
     ) {
       const updates = Updates;
       Updates = null;
-      lookDownstream(node, ancestors[0]);
+      lookUpstream(node, ancestors[0]);
       Updates = updates;
     }
   }
@@ -1488,7 +1488,7 @@ function runUserEffects(queue: Computation<any>[]) {
   for (i = resume; i < queue.length; i++) runTop(queue[i]);
 }
 
-function lookDownstream(node: Computation<any>, ignore?: Computation<any>) {
+function lookUpstream(node: Computation<any>, ignore?: Computation<any>) {
   const runningTransition = Transition && Transition.running;
   if (runningTransition) node.tState = 0;
   else node.state = 0;
@@ -1504,12 +1504,12 @@ function lookDownstream(node: Computation<any>, ignore?: Computation<any>) {
         (!runningTransition && source.state === PENDING) ||
         (runningTransition && source.tState === PENDING)
       )
-        lookDownstream(source, ignore);
+        lookUpstream(source, ignore);
     }
   }
 }
 
-function markUpstream(node: Memo<any>) {
+function markDownstream(node: Memo<any>) {
   const runningTransition = Transition && Transition.running;
   for (let i = 0; i < node.observers!.length; i += 1) {
     const o = node.observers![i];
@@ -1518,7 +1518,7 @@ function markUpstream(node: Memo<any>) {
       else o.state = PENDING;
       if (o.pure) Updates!.push(o);
       else Effects!.push(o);
-      (o as Memo<any>).observers && markUpstream(o as Memo<any>);
+      (o as Memo<any>).observers && markDownstream(o as Memo<any>);
     }
   }
 }


### PR DESCRIPTION
Resolves #915.

Fixes those 4 function names accross 5 files:
- markUpstream => markDownstream
- markUpstreamNode => markDownstreamNode
- lookDownstream => lookUpstream
- lookDownstreamNode => lookUpstreamNode