### PR TITLE
Warn about unhandled errors (fix #919)

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1575,7 +1575,10 @@ function reset(node: Computation<any>, top?: boolean) {
 
 function handleError(err: any) {
   const fns = ERROR && lookup(Owner, ERROR);
-  if (!fns) throw err;
+  if (!fns) {
+    "_SOLID_DEV_" && console.warn(`Error during Solid code without onError or ErrorBoundary: ${err}`);
+    throw err;
+  }
   fns.forEach((f: (err: any) => void) => f(err));
 }
 


### PR DESCRIPTION
Here's one approach to fixing #919: in dev mode, warn about unhandled errors. The last exception in `try...finally` chain will end up getting thrown as an actual error, and thus duplicated as a warning, but it means that no errors will be unreported.

(Sadly this wouldn't have helped me because I still can't get Solid dev mode working in Meteor, but it would help most people...)

Feel free to edit the message or reject the approach altogether.