### PR TITLE
fix: change createResource refetch return type

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -407,7 +407,10 @@ export interface Resource<T> extends Accessor<T> {
   error: any;
 }
 
-export type ResourceActions<T> = { mutate: Setter<T>; refetch: (info?: unknown) => void };
+export type ResourceActions<T> = {
+  mutate: Setter<T>;
+  refetch: (info?: unknown) => T | Promise<T> | undefined | null;
+};
 
 export type ResourceReturn<T> = [Resource<T>, ResourceActions<T>];
 


### PR DESCRIPTION
- Changed the return type from `void` to `Promise<T> | T | undefined | null`

I see a similar change https://github.com/solidjs/solid/commit/f1c25b01066fac8c53120893fe8eca96c61cbd04 which also makes the function always return a promise. I'm not sure how to apply similar changes here, so this PR only contains type changes since they can be further narrowed later. 