### PR TITLE
Replace for/push loop with Array of initial size

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -841,9 +841,12 @@ export function on<S extends Accessor<unknown> | Accessor<unknown>[] | [], Next,
   let prevInput: ReturnTypes<S>;
   let defer = options && options.defer;
   return (prevValue: Init | Next) => {
-    const input: ReturnTypes<S> = isArray
-      ? deps.map((d) => d()) as ReturnTypes<S>
-      : deps() as ReturnTypes<S>;
+    let input: ReturnTypes<S>;
+    if (isArray) {
+      input = Array(deps.length) as ReturnTypes<S>;
+      for (let i = 0; i < deps.length; i++)
+        (input as TODO[])[i] = deps[i]();
+    } else input = (deps as () => S)() as ReturnTypes<S>;
     if (defer) {
       defer = false;
       // this aspect of first run on deferred is hidden from end user and should not affect types

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -841,11 +841,9 @@ export function on<S extends Accessor<unknown> | Accessor<unknown>[] | [], Next,
   let prevInput: ReturnTypes<S>;
   let defer = options && options.defer;
   return (prevValue: Init | Next) => {
-    let input: ReturnTypes<S>;
-    if (isArray) {
-      input = [] as TODO;
-      for (let i = 0; i < deps.length; i++) (input as TODO[]).push((deps as Array<() => S>)[i]());
-    } else input = (deps as () => S)() as TODO;
+    const input: ReturnTypes<S> = isArray
+      ? deps.map((d) => d()) as ReturnTypes<S>
+      : deps() as ReturnTypes<S>;
     if (defer) {
       defer = false;
       // this aspect of first run on deferred is hidden from end user and should not affect types


### PR DESCRIPTION
I noticed this bit of code which builds an array via `push` incrementally instead of just calling `map`. I believe `map` is faster because it can pre-allocate an array of the right size. [This jsbench](https://jsbench.me/qwl1y4xyud/1) confirms my hypothesis. The code is also shorter and cleaner.

Or is `map` being avoided on purpose for compatibility? It's ECMAScript 5. [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map#browser_compatibility); [Can I use](https://caniuse.com/?search=array.map).

[[discussion on Discord](https://discord.com/channels/722131463138705510/963927238405935174)]