### PR TITLE
createResource support for array source shorthand (like on)

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -576,9 +576,13 @@ export function createResource<T, S>(
     if (refetching && scheduled) return;
     scheduled = false;
     setError((err = undefined));
-    const lookup =
-      array ? (source as unknown as Accessor<any>[]).map((s) => s()) as unknown as S :
-      dynamic ? (source as () => S)() : (source as S);
+    let lookup: S;
+    if (array) {
+      lookup = Array((source as TODO).length) as TODO;
+      for (let i = 0; i < (source as TODO).length; i++)
+        (lookup as TODO)[i] = (source as unknown as Accessor<any>[])[i]();
+    } else
+      lookup = dynamic ? (source as () => S)() : (source as S);
     loadedUnderTransition = (Transition && Transition.running) as boolean;
     if (lookup == null || (lookup as any) === false) {
       loadEnd(pr, untrack(s)!);

--- a/packages/solid/test/resource.spec.ts
+++ b/packages/solid/test/resource.spec.ts
@@ -226,3 +226,51 @@ describe("using Resource with initial Value", () => {
     expect(value.loading).toBe(false);
   });
 });
+
+describe("Test fetch source", () => {
+  test("single string source", async () => {
+    function fetchString(id: string) {
+      return new Promise<string>((resolve) => resolve(id));
+    }
+    let trigger: (v: string) => void,
+      value: Resource<string | undefined>;
+    createRoot(() => {
+      const [id, setId] = createSignal("1");
+      trigger = setId;
+      [value] = createResource(id, fetchString);
+    });
+    await Promise.resolve();
+    expect(value()).toBe("1");
+    trigger("2");
+    await Promise.resolve();
+    expect(value()).toBe("2");
+  });
+
+  test("two string sources", async () => {
+    function fetchStringConcat([one, two]: [string, string]) {
+      return new Promise<string>((resolve) => resolve(one + two));
+    }
+    let trigger1: (v: string) => void,
+      trigger2: (v: string) => void,
+      value: Resource<string | undefined>;
+    createRoot(() => {
+      const [one, setOne] = createSignal("1");
+      const [two, setTwo] = createSignal("A");
+      trigger1 = setOne;
+      trigger2 = setTwo;
+      [value] = createResource([one, two], fetchStringConcat);
+    });
+    await Promise.resolve();
+    expect(value()).toBe("1A");
+    trigger1("2");
+    await Promise.resolve();
+    expect(value()).toBe("2A");
+    trigger2("B");
+    await Promise.resolve();
+    expect(value()).toBe("2B");
+    trigger1("3");
+    await Promise.resolve();
+    expect(value()).toBe("3B");
+  });
+
+});


### PR DESCRIPTION
As [discussed on Discord](https://discord.com/channels/722131463138705510/959923642790187048), this adds the option for an Array-of-Signals source argument for `createResource`.

`createResource([signal1, signal2], ...)` is shorthand for `createResource(() => [signal1(), signal2()], ...)`.  This feels very similar to `on` which accepts a single signal or an array of signals, and I've found myself [desiring](https://github.com/edemaine/cocreate/blob/554cd8619fb10af23d0565bbd0514fc92759fb49/client/tools/room.coffee#L24) [this](https://github.com/edemaine/cocreate/blob/f31ee54d562ef3916dffec1ea9aeaed4d1eed8ce/client/tools/history.coffee#L24) when I want my resource to depend on multiple signals.

One current behavior this forbids: currently you can pass an array as the first argument and it will be treated as a static (not-called) source.

I'm not sure I got the types right, as TypeScript seems to be complaining about the tests I wrote. So if this gets approved functionality-wise, I'll have to summon the TypeScript experts to fix it. But I figured I'd wait until it's decided to be worthwhile.

Note that this uses the ~~`map`~~ Array-of-initial-size optimization from #934. If #934 is rejected, I can remove the initial size.