### PR TITLE
Respect Promises in resource first.

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -416,7 +416,7 @@ export type ResourceReturn<T> = [Resource<T>, ResourceActions<T>];
 
 export type ResourceSource<S> = S | false | null | undefined | (() => S | false | null | undefined);
 
-export type ResourceFetcher<S, T> = (k: S, info: ResourceFetcherInfo<T>) => T | Promise<T>;
+export type ResourceFetcher<S, T> = Promise<T> | (() => Promise<T>) | ((k: S, info: ResourceFetcherInfo<T>) => T);
 
 export type ResourceFetcherInfo<T> = { value: T | undefined; refetching?: unknown };
 

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -412,11 +412,11 @@ export type ResourceActions<T> = {
   refetch: (info?: unknown) => T | Promise<T> | undefined | null;
 };
 
-export type ResourceReturn<T> = [Resource<T>, ResourceActions<T>];
+export type ResourceReturn<T, RT = T extends PromiseLike<infer U> ? U : T> = [Resource<RT>, ResourceActions<RT>];
 
 export type ResourceSource<S> = S | false | null | undefined | (() => S | false | null | undefined);
 
-export type ResourceFetcher<S, T> = (() => Promise<T>) | ((k: S, info: ResourceFetcherInfo<T>) => T);
+export type ResourceFetcher<S, T> = (k: S, info: ResourceFetcherInfo<T>) => (T | PromiseLike<T>) | ((arg?: T) => Promise<T>);
 
 export type ResourceFetcherInfo<T> = { value: T | undefined; refetching?: unknown };
 
@@ -615,7 +615,7 @@ export function createResource<T, S>(
   });
   if (dynamic) createComputed(() => load(false));
   else load(false);
-  return [read as Resource<T>, { refetch: load, mutate: set } as ResourceActions<T>];
+  return [read as Resource<any>, { refetch: load, mutate: set } as ResourceActions<any>];
 }
 
 let Resources: Set<(info: unknown) => any>;

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -416,7 +416,7 @@ export type ResourceReturn<T> = [Resource<T>, ResourceActions<T>];
 
 export type ResourceSource<S> = S | false | null | undefined | (() => S | false | null | undefined);
 
-export type ResourceFetcher<S, T> = Promise<T> | (() => Promise<T>) | ((k: S, info: ResourceFetcherInfo<T>) => T);
+export type ResourceFetcher<S, T> = (() => Promise<T>) | ((k: S, info: ResourceFetcherInfo<T>) => T);
 
 export type ResourceFetcherInfo<T> = { value: T | undefined; refetching?: unknown };
 

--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -225,7 +225,7 @@ export function lazy<T extends Component<any>>(
       const [s] = createResource<T>(() => (p || (p = fn())).then(mod => mod.default), {
         globalRefetch: false
       });
-      comp = s;
+      comp = s as () => T;
     } else {
       const c = comp();
       if (c) return c(props);


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/17229619/164910096-5489cf74-fb20-4f36-bacb-fe0ae58bdf70.png)

After:
![image](https://user-images.githubusercontent.com/17229619/164910159-dfb61900-6fef-4abf-9c38-42d592d321cd.png)

Btw, I'm not sure `createResource` handles `() => {}` and `() => Promise` in same manner.
upd: Seems it could harm someone by passing hidden ```lookup, {
          value: s(),
          refetching
        }``` as params to function with optional args.