### PR TITLE
fix: spreading non-object props

### DIFF
--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -31,17 +31,18 @@ export type ComponentProps<T extends keyof JSX.IntrinsicElements | Component<any
     ? JSX.IntrinsicElements[T]
     : {};
 export function createComponent<T>(Comp: (props: T) => JSX.Element, props: T): JSX.Element {
+  if (props == null || typeof props !== "object") props = {} as T;
   if (hydrationEnabled) {
     if (sharedConfig.context) {
       const c = sharedConfig.context;
       setHydrateContext(nextHydrateContext());
-      const r = "_SOLID_DEV_" ? devComponent(Comp, props) : untrack(() => Comp(props as T));
+      const r = "_SOLID_DEV_" ? devComponent(Comp, props) : untrack(() => Comp(props));
       setHydrateContext(c);
       return r;
     }
   }
   if ("_SOLID_DEV_") return devComponent(Comp, props);
-  return untrack(() => Comp(props as T));
+  return untrack(() => Comp(props));
 }
 
 function trueFn() {
@@ -87,7 +88,7 @@ type UnboxIntersection<T> = T extends { 0: infer U } ? U : never;
 type MergeProps<T extends any[]> = UnboxIntersection<UnionToIntersection<BoxedTupleTypes<T>>>;
 
 function resolveSource(s: any) {
-  return typeof s === "function" ? s() : s;
+  return (s = typeof s === "function" ? s() : s) == null || typeof s !== "object" ? {} : s;
 }
 
 export function mergeProps<T extends any[]>(...sources: T): MergeProps<T>;

--- a/packages/solid/test/component.spec.ts
+++ b/packages/solid/test/component.spec.ts
@@ -35,6 +35,15 @@ describe("CreateComponent", () => {
       expect(out).toBe("Hi dynamic");
     });
   });
+  test("non-object props are replaced with empty props", () => {
+    createRoot(() => {
+      const nonObjects = [null, undefined, 1, "string", () => "function"];
+      nonObjects.forEach(nonObject => {
+        const out = createComponent(p => p, nonObject);
+        expect(out).toEqual({});
+      });
+    });
+  });
 });
 
 describe("Set Default Props", () => {
@@ -116,6 +125,11 @@ describe("Merge Signal", () => {
     expect(res[0]).toBe("ji");
     expect(res[1]).toBe("h");
     expect(res.length).toBe(2);
+  });
+
+  test("non-objects are ignored", () => {
+    const props = mergeProps({ a: 1 }, 1, null, undefined, "string", () => 1);
+    expect(props).toEqual({ a: 1 });
   });
 });
 


### PR DESCRIPTION
- `createComponent` passes an empty object instead of non-object props which are spread
- `mergeProps` treats non-object sources as empty objects
- added tests

fixes #958

@ryansolid removed the `Object.keys` thing. I wanted to bring it closer to how native spreads worked but don't think it's feasible. Could also limit the check to `== null`, or falsy, not sure what the best thing to do is. 