### PR TITLE
fix: setter type incorrectly erroring with unions

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -127,6 +127,8 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: Owner): T {
 export type Accessor<T> = () => T;
 
 export type Setter<T> = (undefined extends T ? () => undefined : {}) &
+  (<U extends T>(value: (prev: T) => U) => U) &
+  (<U extends T>(value: Exclude<U, Function>) => U) &
   (<U extends T>(value: Exclude<U, Function> | ((prev: T) => U)) => U);
 
 export type Signal<T> = [get: Accessor<T>, set: Setter<T>];

--- a/packages/solid/test/signals.type-tests.ts
+++ b/packages/solid/test/signals.type-tests.ts
@@ -791,6 +791,12 @@ const sf14: (() => number) | string | undefined = stringOrFunc2();
 // @ts-expect-error return value might be undefined
 const sf15: (() => number) | string = stringOrFunc2();
 
+const [stringOrNumber, setStringOrNumber] = createSignal<string | number>(1);
+setStringOrNumber(1 as number | string);
+setStringOrNumber(1);
+setStringOrNumber("" as number | string);
+setStringOrNumber("");
+
 function createGenericSignal<T>(): Signal<T | undefined> {
   const [generic, setGeneric] = createSignal<T>();
   const customSet: Setter<T | undefined> = (v?) => setGeneric(v);


### PR DESCRIPTION
- Added two overloads to preserve existing functionality while also fixing the issue
- Added a test for this case

Fixes the issue described in https://github.com/solidjs/solid/issues/972#issuecomment-1124337736