### PR TITLE
fix: MergeProps is not inferring the types correctly

### DIFF
--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -136,30 +136,30 @@ const propTraps: ProxyHandler<{
   }
 };
 
-type Simplify<T> = T extends object ? { [K in keyof T]: T[K] } : T;
-type UnboxLazy<T> = T extends () => infer U ? U : T;
-type RequiredKeys<T> = keyof { [K in keyof T as T extends { [_ in K]: unknown } ? K : never]: 0 };
-type Override<T, U> = {
-  // all keys in T which are not overridden by U
-  [K in keyof Omit<T, RequiredKeys<U>>]: T[K] | Exclude<U[K & keyof U], undefined>;
-} & {
-  // all keys in U except those which are merged into T
-  [K in keyof Omit<U, Exclude<keyof T, RequiredKeys<U>>>]:
-    | Exclude<U[K], undefined>
-    | (undefined extends U[K] ? (K extends keyof T ? T[K] : undefined) : never);
-};
-export type MergeProps<T extends unknown[], Curr = {}> = T extends [infer Next, ...infer Rest]
-  ? MergeProps<
-      Rest,
-      Next extends object
-        ? Next extends Function
-          ? Curr
-          : Next extends infer TNext
-          ? Override<Curr, UnboxLazy<TNext>>
-          : Curr
-        : Curr
-    >
-  : Simplify<Curr>;
+type Override<T, U> = T extends any
+  ? U extends any
+    ? {
+        [K in keyof T]: K extends keyof U
+          ? undefined extends U[K]
+            ? Exclude<U[K], undefined> | T[K]
+            : U[K]
+          : T[K];
+      } & {
+        [K in keyof U]: K extends keyof T
+          ? undefined extends U[K]
+            ? Exclude<U[K], undefined> | T[K]
+            : U[K]
+          : U[K];
+      }
+    : T & U
+  : T & U;
+
+export type MergeProps<T extends unknown[], Curr = {}> = T extends [
+  infer Next | (() => infer Next),
+  ...infer Rest
+]
+  ? MergeProps<Rest, Override<Curr, Next>>
+  : Curr;
 
 function resolveSource(s: any) {
   return (s = typeof s === "function" ? s() : s) == null ? {} : s;

--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -151,7 +151,13 @@ type Override<T, U> = {
 export type MergeProps<T extends unknown[], Curr = {}> = T extends [infer Next, ...infer Rest]
   ? MergeProps<
       Rest,
-      Next extends object ? (Next extends Function ? Curr : Override<Curr, UnboxLazy<Next>>) : Curr
+      Next extends object
+        ? Next extends Function
+          ? Curr
+          : Next extends infer TNext
+          ? Override<Curr, UnboxLazy<TNext>>
+          : Curr
+        : Curr
     >
   : Simplify<Curr>;
 

--- a/packages/solid/test/component.type-tests.ts
+++ b/packages/solid/test/component.type-tests.ts
@@ -93,7 +93,6 @@ type TestM3 = Assert<IsRequiredProperty<M3, "a", number>>;
 const m4 = mergeProps({ a: 1 }, 1, null, undefined, () => 1, "", 3, { a: 1 });
 type M4 = typeof m4;
 type TestM4 = Assert<IsExact<M4, { a: number }>>;
-
 // @ts-expect-error mergeProps requires at least one param
 mergeProps();
 
@@ -108,3 +107,22 @@ type TestS2 = Assert<IsExact<S2, { b: number }>>;
 const [s3] = splitProps({ a: 1, b: 2 }, ["a"]);
 type S3 = typeof s3;
 type TestS3 = Assert<IsExact<S3, { a: number }>>;
+
+type S4Type = { a: { aProp: string, test: string }, b: {  bProp: number, test: string }};
+function m5<T extends keyof S4Type = 'a'>(
+  props: {prop: 'a' | 'b'} & {as: T} & Omit<S4Type[T], 'any'>
+) {
+  const defaultProperties = {prop: 'a'};
+  const test1 = mergeProps(defaultProperties, props);
+  // TODO: Currently this takes only properties of left side when using Omit. This should throw an error but currently not since test1.prop is string.
+  // @ts-expect-error Type "''" is not assignable to type "'a' | 'b'"
+  test1.prop = '';
+  // TODO: should not throw error
+  test1.as;
+
+  const test2 = mergeProps(defaultProperties, props as {prop: 'a' | 'b'} & {as: T} & S4Type[T]);
+  // @ts-expect-error Type "''" is not assignable to type "'a' | 'b'"
+  test2.prop = '';
+  test2.as;
+  test2.test = '';
+}


### PR DESCRIPTION
This pr tries to fix partially the issue related of mergeProps return type issue with generics types. #982
There are some issues still not resolved and I would like your advice / opinion to continue

I think the Override type has something missing but I didn't manage to get a definitive fix😢, currently with the extra inference the returned object mostly return the correct type, but fails when using Omit

Playground
https://playground.solidjs.com/?hash=-238626028&version=1.4.1

