### PR TITLE
refactor: remove DeepReadonly/Mutable from stores

### DIFF
--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -1,5 +1,5 @@
 import { batch } from "solid-js";
-import { setProperty, unwrap, isWrappable, StoreNode, $RAW, DeepMutable, DeepReadonly } from "./store";
+import { setProperty, unwrap, isWrappable, StoreNode, $RAW } from "./store";
 
 export type ReconcileOptions = {
   key?: string | null;
@@ -136,9 +136,9 @@ const setterTraps: ProxyHandler<StoreNode> = {
 };
 
 // Immer style mutation style
-export function produce<T>(fn: (state: DeepMutable<T>) => void): (state: T) => T {
+export function produce<T>(fn: (state: T) => void): (state: T) => T {
   return state => {
-    if (isWrappable(state)) fn(new Proxy(state, setterTraps) as DeepMutable<T>);
+    if (isWrappable(state)) fn(new Proxy(state, setterTraps));
     return state;
   };
 }

--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -82,7 +82,7 @@ function wrap<T extends StoreNode>(value: T, name?: string): T {
 }
 
 export function createMutable<T extends StoreNode>(state: T, options?: { name?: string }): T {
-  const unwrappedStore = unwrap<T>(state || {});
+  const unwrappedStore = unwrap(state || {});
   if ("_SOLID_DEV_" && typeof unwrappedStore !== "object" && typeof unwrappedStore !== "function")
     throw new Error(
       `Unexpected type ${typeof unwrappedStore} received when initializing 'createMutable'. Expected an object.`

--- a/packages/solid/store/src/server.ts
+++ b/packages/solid/store/src/server.ts
@@ -1,4 +1,4 @@
-import type { DeepMutable, SetStoreFunction, Store } from "store";
+import type { SetStoreFunction, Store } from "store";
 
 export const $RAW = Symbol("state-raw");
 
@@ -10,7 +10,7 @@ export function isWrappable(obj: any) {
   );
 }
 
-export function unwrap<T>(item: any): T {
+export function unwrap<T>(item: T): T {
   return item;
 }
 
@@ -111,9 +111,9 @@ export function reconcile<T extends U, U>(
 }
 
 // Immer style mutation style
-export function produce<T>(fn: (state: DeepMutable<T>) => void): (state: T) => T {
+export function produce<T>(fn: (state: T) => void): (state: T) => T {
   return state => {
-    if (isWrappable(state)) fn(state as DeepMutable<T>);
+    if (isWrappable(state)) fn(state);
     return state;
   };
 }

--- a/packages/solid/store/test/mutable.spec.ts
+++ b/packages/solid/store/test/mutable.spec.ts
@@ -73,9 +73,9 @@ describe("Simple update modes", () => {
 
   test("Test Array", () => {
     const todos = createMutable([
-        { id: 1, title: "Go To Work", done: true },
-        { id: 2, title: "Eat Lunch", done: false }
-      ]);
+      { id: 1, title: "Go To Work", done: true },
+      { id: 2, title: "Eat Lunch", done: false }
+    ]);
     todos[1].done = true;
     todos.push({ id: 3, title: "Go Home", done: false });
     expect(Array.isArray(todos)).toBe(true);
@@ -92,7 +92,7 @@ describe("Unwrapping Edge Cases", () => {
       s = unwrap({ ...state });
     expect(s.data.user.firstName).toBe("John");
     expect(s.data.user.lastName).toBe("Snow");
-    // check if proxy still
+    // @ts-ignore check if proxy still
     expect(s.data.user[$RAW]).toBeUndefined();
   });
   test("Unwrap nested frozen array", () => {
@@ -102,7 +102,7 @@ describe("Unwrapping Edge Cases", () => {
       s = unwrap({ data: state.data.slice(0) });
     expect(s.data[0].user.firstName).toBe("John");
     expect(s.data[0].user.lastName).toBe("Snow");
-    // check if proxy still
+    // @ts-ignore check if proxy still
     expect(s.data[0].user[$RAW]).toBeUndefined();
   });
   test("Unwrap nested frozen state array", () => {
@@ -112,7 +112,7 @@ describe("Unwrapping Edge Cases", () => {
       s = unwrap({ ...state });
     expect(s.data[0].user.firstName).toBe("John");
     expect(s.data[0].user.lastName).toBe("Snow");
-    // check if proxy still
+    // @ts-ignore check if proxy still
     expect(s.data[0].user[$RAW]).toBeUndefined();
   });
 });
@@ -120,7 +120,7 @@ describe("Unwrapping Edge Cases", () => {
 describe("Tracking State changes", () => {
   test("Track a state change", () => {
     createRoot(() => {
-      const state = createMutable({ data: 2 })
+      const state = createMutable({ data: 2 });
       let executionCount = 0;
 
       expect.assertions(2);
@@ -144,8 +144,8 @@ describe("Tracking State changes", () => {
   test("Track a nested state change", () => {
     createRoot(() => {
       const state = createMutable({
-          user: { firstName: "John", lastName: "Smith" }
-        })
+        user: { firstName: "John", lastName: "Smith" }
+      });
       let executionCount = 0;
 
       expect.assertions(2);
@@ -240,7 +240,7 @@ describe("Batching", () => {
       expect(state.data).toBe(1);
       state.data = 2;
       expect(state.data).toBe(1);
-    })
+    });
     expect(state.data).toBe(2);
   });
   test("Respects batch in array", () => {
@@ -249,7 +249,7 @@ describe("Batching", () => {
       expect(state[0]).toBe(1);
       state[0] = 2;
       expect(state[0]).toBe(1);
-    })
+    });
     expect(state[0]).toBe(2);
   });
   test("Respects batch in array mutate", () => {
@@ -258,7 +258,7 @@ describe("Batching", () => {
       expect(state.length).toBe(1);
       state[1] = 2;
       expect(state.length).toBe(1);
-    })
+    });
     expect(state.length).toBe(2);
-  })
-})
+  });
+});

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -14,7 +14,6 @@ describe("State immutablity", () => {
   test("Setting a property", () => {
     const [state] = createStore({ name: "John" });
     expect(state.name).toBe("John");
-    // @ts-expect-error cannot mutate a store directly
     state.name = "Jake";
     expect(state.name).toBe("John");
   });
@@ -22,7 +21,7 @@ describe("State immutablity", () => {
   test("Deleting a property", () => {
     const [state] = createStore({ name: "John" });
     expect(state.name).toBe("John");
-    // @ts-ignore
+    // @ts-expect-error can't delete required property
     delete state.name;
     expect(state.name).toBe("John");
   });
@@ -31,7 +30,6 @@ describe("State immutablity", () => {
     const [state, setState] = createStore({ name: "John" });
     expect(state.name).toBe("John");
     setState(() => {
-      // @ts-expect-error cannot mutate a store directly
       state.name = "Jake";
     });
     expect(state.name).toBe("John");
@@ -151,7 +149,6 @@ describe("Array setState modes", () => {
   test("Update Specific", () => {
     const [state, setState] = createStore([1, 2, 3, 4, 5]);
     setState([1, 3], (r, t) => {
-      // @ts-ignore traversed types are wrong and incomplete
       expect(typeof t[0]).toBe("number");
       return r * 2;
     });
@@ -167,7 +164,6 @@ describe("Array setState modes", () => {
     setState(
       (r, i) => Boolean(i % 2),
       (r, t) => {
-        // @ts-ignore
         expect(typeof t[0]).toBe("number");
         return r * 2;
       }
@@ -181,7 +177,6 @@ describe("Array setState modes", () => {
   test("Update traversal range", () => {
     const [state, setState] = createStore([1, 2, 3, 4, 5]);
     setState({ from: 1, to: 4, by: 2 }, (r, t) => {
-      // @ts-ignore
       expect(typeof t[0]).toBe("number");
       return r * 2;
     });
@@ -194,7 +189,6 @@ describe("Array setState modes", () => {
   test("Update traversal range defaults", () => {
     const [state, setState] = createStore([1, 2, 3, 4, 5]);
     setState({}, (r, t) => {
-      // @ts-ignore
       expect(typeof t[0]).toBe("number");
       return r * 2;
     });
@@ -214,7 +208,7 @@ describe("Unwrapping Edge Cases", () => {
       s = unwrap({ ...state });
     expect(s.data.user.firstName).toBe("John");
     expect(s.data.user.lastName).toBe("Snow");
-    // check if proxy still
+    // @ts-ignore check if proxy still
     expect(s.data.user[$RAW]).toBeUndefined();
   });
   test("Unwrap nested frozen array", () => {
@@ -224,7 +218,7 @@ describe("Unwrapping Edge Cases", () => {
       s = unwrap({ data: state.data.slice(0) });
     expect(s.data[0].user.firstName).toBe("John");
     expect(s.data[0].user.lastName).toBe("Snow");
-    // check if proxy still
+    // @ts-ignore check if proxy still
     expect(s.data[0].user[$RAW]).toBeUndefined();
   });
   test("Unwrap nested frozen state array", () => {
@@ -234,7 +228,7 @@ describe("Unwrapping Edge Cases", () => {
       s = unwrap({ ...state });
     expect(s.data[0].user.firstName).toBe("John");
     expect(s.data[0].user.lastName).toBe("Snow");
-    // check if proxy still
+    // @ts-ignore check if proxy still
     expect(s.data[0].user[$RAW]).toBeUndefined();
   });
 });
@@ -575,7 +569,7 @@ describe("Batching", () => {
       expect(state.data).toBe(1);
       setState("data", 2);
       expect(state.data).toBe(1);
-    })
+    });
     expect(state.data).toBe(2);
   });
   test("Respects batch in array", () => {
@@ -584,7 +578,7 @@ describe("Batching", () => {
       expect(state[0]).toBe(1);
       setState(0, 2);
       expect(state[0]).toBe(1);
-    })
+    });
     expect(state[0]).toBe(2);
   });
   test("Respects batch in array mutate", () => {
@@ -593,10 +587,10 @@ describe("Batching", () => {
       expect(state.length).toBe(1);
       setState([...state, 2]);
       expect(state.length).toBe(1);
-    })
+    });
     expect(state.length).toBe(2);
-  })
-})
+  });
+});
 
 describe("State wrapping", () => {
   test("Setting plain object", () => {
@@ -767,22 +761,22 @@ describe("Nested Classes", () => {
   setStore("data", 1, "world");
 };
 
-// cannot mutate a store directly
-() => {
-  const [store, setStore] = createStore({ a: 1, nested: { a: 1 } });
-  // @ts-expect-error cannot set
-  store.a = 1;
-  // @ts-expect-error cannot set
-  store.nested.a = 1;
-  // @ts-expect-error cannot delete
-  delete store.a;
-  // @ts-expect-error cannot delete
-  delete store.nested.a;
-  // @ts-expect-error cannot set in setter
-  setStore(s => (s.a = 1));
-  // @ts-expect-error cannot set in setter
-  setStore(s => (s.nested.a = 1));
-};
+// // cannot mutate a store directly
+// () => {
+//   const [store, setStore] = createStore({ a: 1, nested: { a: 1 } });
+//   // @ts-expect-error cannot set
+//   store.a = 1;
+//   // @ts-expect-error cannot set
+//   store.nested.a = 1;
+//   // @ts-expect-error cannot delete
+//   delete store.a;
+//   // @ts-expect-error cannot delete
+//   delete store.nested.a;
+//   // @ts-expect-error cannot set in setter
+//   setStore(s => (s.a = 1));
+//   // @ts-expect-error cannot set in setter
+//   setStore(s => (s.nested.a = 1));
+// };
 
 // cannot mutate unnested classes
 () => {
@@ -880,9 +874,7 @@ describe("Nested Classes", () => {
   setStore("b", "a", "c");
   // @ts-expect-error TODO generic should index Record
   setStore("c", v, "c");
-  // @ts-expect-error TODO generic should index Record
   const b = store.c[v];
-  // @ts-expect-error string should be assignable to string
   const c: typeof b = "1";
   const d = a.c[v];
   const e: typeof d = "1";


### PR DESCRIPTION
The previous discussion on discord preferred more accurate types (readonly).
It may be time to revisit that decision.

Although typing stores as deeply readonly allows typescript to catch attempts at mutating stores, it has its own issues:

- Poor interoperability with existing code which may not be typed readonly despite being immutable
- Confusing errors for users with less typescript experience
- Classes are incorrectly made readonly since typescript can't differentiate classes and objects; currently this has an awkward workaround (#888)

The latter is an issue not initially considered. Additionally it seems that getters in object literals passed straight to createStore are unable to use `this`: https://playground.solidjs.com/?hash=-1721851158&version=1.4.1 (not sure if fixable -- not going to try unless this PR doesn't go through)

This PR removes all uses of `DeepReadonly` and `DeepMutable` and marks them deprecated.

It also:

- Types `unwrap` based on the item being unwrapped.
- Types `isWrappable` as a type guard.

based on #892.