### PR TITLE
fix(solid): safeguard sharedConfig.load in Suspense

### DIFF
--- a/packages/solid/src/render/Suspense.ts
+++ b/packages/solid/src/render/Suspense.ts
@@ -138,9 +138,9 @@ export function Suspense(props: { fallback?: JSX.Element; children: JSX.Element 
       resolved: false
     },
     owner = getOwner();
-  if (sharedConfig.context) {
+  if (sharedConfig.context && sharedConfig.load) {
     const key = sharedConfig.context.id + sharedConfig.context.count;
-    p = sharedConfig.load!(key);
+    p = sharedConfig.load(key);
     if (p) {
       if (typeof p !== "object" || !("then" in p)) p = Promise.resolve(p);
       const [s, set] = createSignal(undefined, { equals: false });


### PR DESCRIPTION
Should the `sharedConfig.load()` call be safeguarded in Suspense? I see it safeguarded in other places. I am trying to use Suspense in an Astro app and line 143 throws an error because `load` is undefined.