### PR TITLE
fix(types): add missing ref prop to Portal

### DIFF
--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -48,10 +48,16 @@ export const hydrate: typeof hydrateCore = (...args) => {
  *
  * @description https://www.solidjs.com/docs/latest/api#%3Cportal%3E
  */
-export function Portal(props: {
+export function Portal<T extends boolean = false, S extends boolean = false>(props: {
   mount?: Node;
-  useShadow?: boolean;
-  isSVG?: boolean;
+  useShadow?: T;
+  isSVG?: S;
+  ref?:
+    | (S extends true ? SVGGElement : HTMLDivElement)
+    | ((
+        el: (T extends true ? { readonly shadowRoot: ShadowRoot } : {}) &
+          (S extends true ? SVGGElement : HTMLDivElement)
+      ) => void);
   children: JSX.Element;
 }) {
   const { useShadow } = props,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `npm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `npm run build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`npm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

- Adds the missing `ref` prop to `<Portal>`. 
- If `isSVG`, the element in `ref` is `SVGGElement`, otherwise it is `HTMLDivElement`.
- If `useShadow`, the element in `ref` has a non-null `shadowRoot` property.
- `ref` is unused when mounting to `document.head`, however there is no way to detect this as `HTMLHeadElement` is typed identically to `HTMLElement`.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

See https://tsplay.dev/mb0P2w.