### PR TITLE
Replace stores' usage of `__proto__` with `Object.getPrototypeOf`

### DIFF
--- a/packages/solid/store/src/server.ts
+++ b/packages/solid/store/src/server.ts
@@ -6,7 +6,7 @@ export function isWrappable(obj: any) {
   return (
     obj != null &&
     typeof obj === "object" &&
-    (obj.__proto__ === Object.prototype || Array.isArray(obj))
+    (Object.getPrototypeOf(obj) === Object.prototype || Array.isArray(obj))
   );
 }
 

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -41,10 +41,14 @@ function wrap<T extends StoreNode>(value: T, name?: string): T {
 
 export function isWrappable<T>(obj: T | NotWrappable): obj is T;
 export function isWrappable(obj: any) {
+  let proto;
   return (
     obj != null &&
     typeof obj === "object" &&
-    (obj[$PROXY] || !obj.__proto__ || obj.__proto__ === Object.prototype || Array.isArray(obj))
+    (obj[$PROXY] ||
+      !(proto = Object.getPrototypeOf(obj)) ||
+      proto === Object.prototype ||
+      Array.isArray(obj))
   );
 }
 


### PR DESCRIPTION
`__proto__` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) and Deno does not support it.
