### PR TITLE
fix(types): remove `void` as a valid return type for a store setter and improve generic interactions

### DIFF
--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -290,16 +290,14 @@ export type StorePathRange = { from?: number; to?: number; by?: number };
 export type ArrayFilterFn<T> = (item: T, index: number) => boolean;
 
 export type StoreSetter<T, U extends PropertyKey[] = []> =
-  | ((prevState: T, traversed: U) => T | CustomPartial<T> | void)
+  | ((prevState: T, traversed: U) => T | CustomPartial<T>)
   | T
   | CustomPartial<T>;
 
-export type Part<T, K extends KeyOf<T> = KeyOf<T>> = [K] extends [never]
-  ? never // return never if key is never, else it'll return readonly never[] as well
-  :
-      | K
-      | readonly K[]
-      | ([T] extends [readonly unknown[]] ? ArrayFilterFn<T[number]> | StorePathRange : never);
+export type Part<T, K extends KeyOf<T> = KeyOf<T>> =
+  | K
+  | ([K] extends [never] ? never : readonly K[])
+  | ([T] extends [readonly unknown[]] ? ArrayFilterFn<T[number]> | StorePathRange : never);
 
 // shortcut to avoid writing `Exclude<T, NotWrappable>` too many times
 type W<T> = Exclude<T, NotWrappable>;

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -885,6 +885,7 @@ describe("Nested Classes", () => {
   // should allow
   setStore("a", v);
   setStore("b", "a", "c");
+  setStore("b", v, "c");
   // @ts-expect-error TODO generic should index Record
   setStore("c", v, "c");
   const b = store.c[v];
@@ -899,19 +900,23 @@ describe("Nested Classes", () => {
   setStore((v, t) => {
     const expectedT: [] = t;
     t = [] as [];
+    return v;
   });
   setStore("a", (v, t) => {
     const expectedT: ["a"] = t;
     t = ["a"];
+    return v;
   });
   setStore("a", 0, (v, t) => {
     const expectedT: [0, "a"] = t;
     t = [0, "a"];
+    return v;
   });
   // array of keys
-  setStore(["a"], [0 as const], (v, t) => {
+  setStore(["a"], [0], (v, t) => {
     const expectedT: [0, "a"] = t;
     t = [0, "a"];
+    return v;
   });
   // callback
   setStore(
@@ -920,12 +925,14 @@ describe("Nested Classes", () => {
     (v, t) => {
       const expectedT: [number, "a"] = t;
       t = [0, "a"];
+      return v;
     }
   );
   // { from, to, by }
   setStore(["a"], {}, (v, t) => {
     const expectedT: [number, "a"] = t;
     t = [0, "a"];
+    return v;
   });
 };
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `npm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `npm run build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`npm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

- Slightly improve interactions with generic types
- Remove `void` as a possible return type for a store setter (not sure why it was there to begin with)

## How did you test this change?

Changes in where errors occur are marked with `// !!! changed`:

Old: https://tsplay.dev/WPRZ5N
New: https://tsplay.dev/NlEvxm

(Some `SetStoreFunction` overloads are commented out to improve loading times)

For reference here is why `void` should not be valid: https://playground.solidjs.com/?hash=-1986110315&version=1.4.1