### PR TITLE
fix(types): fix allowed values for createStore's first parameter

### DIFF
--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -408,11 +408,12 @@ export interface SetStoreFunction<T> {
  *
  * @description https://www.solidjs.com/docs/latest/api#createstore
  */
-export function createStore<T extends StoreNode>(
-  store: T | Store<T>,
-  options?: { name?: string }
+export function createStore<T extends {}>(
+  ...[store, options]: {} extends T
+    ? [store?: T | Store<T>, options?: { name?: string }]
+    : [store: object & (T | Store<T>), options?: { name?: string }]
 ): [get: Store<T>, set: SetStoreFunction<T>] {
-  const unwrappedStore = unwrap(store || {});
+  const unwrappedStore = unwrap((store || {}) as T);
   const isArray = Array.isArray(unwrappedStore);
   if ("_SOLID_DEV_" && typeof unwrappedStore !== "object" && typeof unwrappedStore !== "function")
     throw new Error(

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -801,10 +801,11 @@ describe("Nested Classes", () => {
   setNested("inner", 0, 2);
 };
 
-// cannot create stores from unwrappable
+// createStore initial value
 () => {
-  // @ts-expect-error cannot create store from undefined
-  createStore(undefined);
+  createStore();
+  createStore<{ a?: { b: 1 } }>();
+  createStore(() => 1);
   // @ts-expect-error cannot create store from null
   createStore(null);
   // @ts-expect-error cannot create store from number
@@ -815,8 +816,8 @@ describe("Nested Classes", () => {
   createStore(Symbol());
   // @ts-expect-error cannot create store from bigint
   createStore(BigInt(0));
-  // TODO @ts-expect-error cannot create store from function
-  createStore(() => 1);
+  // @ts-expect-error must provide initial value if {} cannot be assigned to it
+  createStore<{ a: 1 }>();
 };
 
 // recursive


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `npm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `npm run build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`npm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Based on https://github.com/solidjs/solid/blob/5f929b06ac9bab68895b49bd5555aaff09a2b4f0/packages/solid/store/src/store.ts#L415 and https://github.com/solidjs/solid/blob/5f929b06ac9bab68895b49bd5555aaff09a2b4f0/packages/solid/store/src/store.ts#L417, `createStore` accepts falsy (I assume this is to allow calling it without parameters) and function values. As such:

- `createStore<T>()` is allowed if all of T's top-level properties are optional (i.e. `{}` is assignable to T). If the generic is not provided the store is typed as `{}`.
- Removed a `TODO` in type tests that wanted functions to produce an error.

If possible I'd prefer to implement this without needing the rest params trick, using overloads, but to do so would require a type for "any type with no required properties", which afaik is not possible. 

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

`npm run build; npm run test`