### PR TITLE
feat(types): allow setting unions in stores

### DIFF
--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -714,7 +714,7 @@ describe("Nested Classes", () => {
 
 // type tests
 
-// NotWrappable keys are ignored
+// setter ignores NotWrappable keys (unsafe)
 () => {
   const [, setStore] = createStore<{
     a?:
@@ -724,6 +724,29 @@ describe("Nested Classes", () => {
         };
   }>({});
   setStore("a", "b", "c", "d", "e", "f", "g", "h");
+};
+
+// setter can set type unions as if it were a member (unsafe)
+() => {
+  interface Game {
+    name: string;
+  }
+  interface Boardgame extends Game {
+    type: "boardgame";
+    nested: { pieces: number };
+  }
+  interface VideoGame extends Game {
+    type: "videogame";
+    otherNested: { platform: "Sony" | "Mircosoft" | "Nintendo" };
+  }
+  type GameUnion = Boardgame | VideoGame;
+  const [games, setGames] = createStore<GameUnion[]>([
+    { name: "Settlers", nested: { pieces: 240 } } as Boardgame,
+    { name: "Zelda", otherNested: { platform: "Nintendo" } } as VideoGame
+  ]);
+
+  games[0].type === "boardgame" && games[0].nested.pieces;
+  setGames(0, "nested", "pieces", Math.floor(Math.random() * 100));
 };
 
 // keys are narrowed


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `npm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `npm run build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`npm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
This makes it so that:
```ts
const [store, setStore] = createStore([{ a: 1 }, { b: 2 }]);
setStore(0, "a", 1); // currently error, now ok
```
Which is potentially unsafe, but is already allowed if e.g. `{ b: 2 }` was a `NotWrappable` instead.

There are performance concerns with this implementation.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->