### PR TITLE
add `_$afterCreateRoot` hook to handle new roots in dev

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -35,6 +35,7 @@ let rootCount = 0;
 
 declare global {
   var _$afterUpdate: () => void;
+  var _$afterCreateRoot: (root: Owner) => void;
 }
 
 export interface SignalState<T> {
@@ -120,7 +121,10 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: Owner): T {
         : fn
       : () => fn(() => cleanNode(root));
 
-  if ("_SOLID_DEV_" && owner) root.name = `${(owner as Computation<any>).name}-r${rootCount++}`;
+  if ("_SOLID_DEV_") {
+    if (owner) root.name = `${owner.name}-r${rootCount++}`;
+    globalThis._$afterCreateRoot && globalThis._$afterCreateRoot(root);
+  }
 
   Owner = root;
   Listener = null;

--- a/packages/solid/test/dev.spec.ts
+++ b/packages/solid/test/dev.spec.ts
@@ -1,11 +1,5 @@
-import {
-  createRoot,
-  getOwner,
-  createSignal,
-  createEffect,
-  createComponent,
-  DEV
-} from "../src";
+import { createRoot, getOwner, createSignal, createEffect, createComponent, DEV } from "../src";
+import { Owner } from "../src/reactive/signal";
 import { createStore } from "../store/src";
 
 describe("Dev features", () => {
@@ -20,7 +14,7 @@ describe("Dev features", () => {
       const [state, setState] = createStore({ firstName: "John", lastName: "Smith" });
       setState1 = setState;
       return "";
-    }
+    };
     createRoot(() => {
       owner = getOwner();
       const [s, set] = createSignal(5);
@@ -61,5 +55,21 @@ describe("Dev features", () => {
     expect(triggered).toBe(2);
     setState1({ middleInitial: "R.", firstName: "Matt" });
     expect(triggered).toBe(3);
-  })
+  });
+
+  test("AfterCreateRoot Hook", () => {
+    const captured: Owner[] = [];
+    global._$afterCreateRoot = root => captured.push(root);
+    createRoot(() => {
+      const root = getOwner()!;
+      expect(captured.length).toBe(1);
+      expect(captured[0]).toBe(root);
+      createRoot(_ => {
+        const inner = getOwner()!;
+        expect(captured.length).toBe(2);
+        expect(captured[1]).toBe(inner);
+        expect(inner.owner).toBe(root);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Solid's internal reactivity graph has this problem where roots created with `createRoot` don't have to be added to its detachedOwner object — it's enough that they are able to get to the context walking upwards.
But not for devtools, all the `createRoot` calls are effectively invisible for a debugger that wants to walk downwards to analyze the tree. And roots are very common — components such as `<For>`, `<Index>` and `<Suspense>`; primitives that want to control disposal like `createLazyMemo`; and even `render` function that is creating the main branch of the reactive tree.

Having a special hook that would fire with every newly created root would let us handle all of those cases.

Then it could be used easily for tracking:
```ts
import { registerRoot } from "solid-devtools";
window._$afterCreateRoot = (root) => {
   registerRoot(root);
}
```

Related discussion: https://github.com/solidjs/solid/discussions/860
And devtools issue: https://github.com/thetarnav/solid-devtools/issues/15

## How did you test this change?

Added a new test case to [`dev.spec.ts`](https://github.com/solidjs/solid/compare/main...thetarnav:handle-new-roots?expand=1#diff-e56c67a2f45b2acf11609b6dc85426c42257396fda3a4ef7ac9a703741a40304)