### PR TITLE
Fixes "The value for 'sideEffects' must be a boolean or an array [package.json]"

### DIFF
--- a/packages/solid-element/package.json
+++ b/packages/solid-element/package.json
@@ -12,7 +12,7 @@
   "files": [
     "dist"
   ],
-  "sideEffects": "false",
+  "sideEffects": false,
   "scripts": {
     "prebuild": "npm run clean",
     "clean": "rimraf dist/",


### PR DESCRIPTION
## Summary

I'm currently trying out solid with solid-element & esbuild.
While compiling I got following warning on every build:

```
▲ [WARNING] The value for "sideEffects" must be a boolean or an array [package.json]

    node_modules/solid-element/package.json:15:17:
      15 │   "sideEffects": "false",
         ╵                  ^

```

This PR aims to fix this warning.

## How did you test this change?

I linked it locally into my project and the warning vanished.