### PR TITLE
Add `has` trap for accurate `in` with stores and mutables

### DIFF
--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -21,7 +21,7 @@ const proxyTraps: ProxyHandler<StoreNode> = {
     if (property === $TRACK) return trackSelf(target);
     const nodes = getDataNodes(target);
     const tracked = nodes[property];
-    let value = tracked ? nodes[property]() : target[property];
+    let value = tracked ? tracked() : target[property];
     if (property === $NODE || property === "__proto__") return value;
 
     if (!tracked) {
@@ -37,6 +37,13 @@ const proxyTraps: ProxyHandler<StoreNode> = {
     return isWrappable(value)
       ? wrap(value, "_SOLID_DEV_" && target[$NAME] && `${target[$NAME]}:${property.toString()}`)
       : value;
+  },
+
+  has(target, property) {
+    if (property === $RAW || property === $PROXY || property === $TRACK ||
+        property === $NODE || property === "__proto__") return true;
+    getDataNodes(target)[property]?(); // track
+    return property in target;
   },
 
   set(target, property, value) {

--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -42,7 +42,8 @@ const proxyTraps: ProxyHandler<StoreNode> = {
   has(target, property) {
     if (property === $RAW || property === $PROXY || property === $TRACK ||
         property === $NODE || property === "__proto__") return true;
-    getDataNodes(target)[property]?.(); // track
+    const tracked = getDataNodes(target)[property];
+    tracked && tracked();
     return property in target;
   },
 

--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -42,7 +42,7 @@ const proxyTraps: ProxyHandler<StoreNode> = {
   has(target, property) {
     if (property === $RAW || property === $PROXY || property === $TRACK ||
         property === $NODE || property === "__proto__") return true;
-    getDataNodes(target)[property]?(); // track
+    getDataNodes(target)[property]?.(); // track
     return property in target;
   },
 

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -162,7 +162,7 @@ const proxyTraps: ProxyHandler<StoreNode> = {
   has(target, property) {
     if (property === $RAW || property === $PROXY || property === $TRACK ||
         property === $NODE || property === "__proto__") return true;
-    getDataNodes(target)[property]?(); // track
+    getDataNodes(target)[property]?.(); // track
     return property in target;
   },
 

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -159,6 +159,13 @@ const proxyTraps: ProxyHandler<StoreNode> = {
       : value;
   },
 
+  has(target, property) {
+    if (property === $RAW || property === $PROXY || property === $TRACK ||
+        property === $NODE || property === "__proto__") return true;
+    getDataNodes(target)[property]?(); // track
+    return property in target;
+  },
+
   set() {
     if ("_SOLID_DEV_") console.warn("Cannot mutate a Store directly");
     return true;

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -162,7 +162,8 @@ const proxyTraps: ProxyHandler<StoreNode> = {
   has(target, property) {
     if (property === $RAW || property === $PROXY || property === $TRACK ||
         property === $NODE || property === "__proto__") return true;
-    getDataNodes(target)[property]?.(); // track
+    const tracked = getDataNodes(target)[property];
+    tracked && tracked();
     return property in target;
   },
 


### PR DESCRIPTION
## Summary

Fixes #1107 by adding `has` trap to Stores and Mutables, so that code like `if ('prop' in store) store.prop()` is properly reactive. In Discord it's also been requested that `$TRACK in store` should return `true`, so I also added support for that (and other node types, to match `get` — notably missing `$NAME` though).

## How did you test this change?

I haven't tested this yet, sorry, in particular because I still can't build Solid and run tests locally. But hopefully it's still useful, at least as a proof of concept? Feel free to reimplement it...

## Update: read before merging

[As discussed in #reactivity channel](https://discord.com/channels/722131463138705510/751355413701591120/996345879621537792), this might need special handling for `delete`d properties. Depends how we want to interpret `setStore(..., undefined)`...