### PR TITLE
fix: server `lazy` shouldn't run import fn without Component

### DIFF
--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -410,7 +410,7 @@ export function lazy<T extends Component<any>>(
   fn: () => Promise<{ default: T }>
 ): T & { preload: () => Promise<{ default: T }> } {
   let resolved: T;
-  let p;
+  let p: () => Promise<{ default: T }>;
   let load = () => {
     if (!p) {
       p = fn();

--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -419,6 +419,7 @@ export function lazy<T extends Component<any>>(
     return p;
   }
   const contexts = new Set<SuspenseContextType>();
+  !'_SOLID_DEV_' && load();
   const wrap: Component<ComponentProps<T>> & {
     preload?: () => Promise<{ default: T }>;
   } = props => {

--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -410,7 +410,7 @@ export function lazy<T extends Component<any>>(
   fn: () => Promise<{ default: T }>
 ): T & { preload: () => Promise<{ default: T }> } {
   let resolved: T;
-  let p: () => Promise<{ default: T }>;
+  let p: Promise<{ default: T }>;
   let load = () => {
     if (!p) {
       p = fn();

--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -410,12 +410,19 @@ export function lazy<T extends Component<any>>(
   fn: () => Promise<{ default: T }>
 ): T & { preload: () => Promise<{ default: T }> } {
   let resolved: T;
-  const p = fn();
+  let p;
+  let load = () => {
+    if (!p) {
+      p = fn();
+      p.then(mod => (resolved = mod.default));
+    }
+    return p;
+  }
   const contexts = new Set<SuspenseContextType>();
-  p.then(mod => (resolved = mod.default));
   const wrap: Component<ComponentProps<T>> & {
     preload?: () => Promise<{ default: T }>;
   } = props => {
+    load();
     const id = sharedConfig.context!.id.slice(0, -1);
     if (resolved) return resolved(props);
     const ctx = useContext(SuspenseContext);
@@ -431,7 +438,7 @@ export function lazy<T extends Component<any>>(
       });
     return "";
   };
-  wrap.preload = () => p;
+  wrap.preload = load;
   return wrap as T & { preload: () => Promise<{ default: T }> };
 }
 


### PR DESCRIPTION
## Summary

Currently, during `lazy` on the server, we fetch the dynamically imported file immediately in the `lazy` called regardless of whether the Component was rendered or not. I am not sure of the motivation of this, maybe on the server dynamic imports are not costly?

But when using vite, we rely on dynamic imports to make development faster since those imports shouldnt be fetched (in vite's case, loaded, transformed with plugins, etc.) until the Component is rendered. We already have `preload` helper on lazy loaded Component to preload things if required. Or maybe this can be a production time optimization on the server for lazy, but its removes the benefits of code-splitting (maybe there are none on the server). During dev, we definetely need the lazy Components to remain lazy.