### PR TITLE
fix: `observable()` typings

### DIFF
--- a/packages/solid/src/reactive/observable.ts
+++ b/packages/solid/src/reactive/observable.ts
@@ -10,10 +10,6 @@ declare global {
   }
 }
 
-function getSymbol() {
-  return Symbol.observable || "@@observable";
-}
-
 export type ObservableObserver<T> =
   | ((v: T) => void)
   | {
@@ -32,7 +28,6 @@ export type ObservableObserver<T> =
  * description https://www.solidjs.com/docs/latest/api#observable
  */
 export function observable<T>(input: Accessor<T>) {
-  const $$observable = getSymbol();
   return {
     subscribe(observer: ObservableObserver<T>) {
       if (!(observer instanceof Object) || observer == null) {
@@ -64,10 +59,12 @@ export function observable<T>(input: Accessor<T>) {
         }
       };
     },
-    [$$observable]() {
-      return this as {
-        subscribe(observer: ObservableObserver<T>): { unsubscribe(): void }
-      };
+    // Here we're intentionally using `Symbol.observable || "@@observable"` directly
+    // without assigning it to an intermediary variable (e.g. we aren't doing
+    // `const $$observable = Symbol.observable || "@@observable"`).
+    // See for more info: https://github.com/solidjs/solid/pull/1118
+    [Symbol.observable || "@@observable"]() {
+      return this;
     }
   };
 }


### PR DESCRIPTION
## Summary

This contains a typescript-typings only change to complement #1115. Apologies for the quick followup PR, but I realized the need for this right after #1115 was merged.

The problem with #1115 is that, despite adding the global `Symbol.observable` type, the internal `getSymbol()` helper function used by `observable()` still returns the type `symbol` (not `Symbol.observable`). Because of this, in #1115 `observable()` has the type signature:

```ts
function observable<T>(input: Accessor<T>): {
    [x: symbol]: () => {
        subscribe(observer: ObservableObserver<T>): {
            unsubscribe(): void;
        };
    }
    subscribe(observer: ObservableObserver<T>): {
        unsubscribe(): void;
    };
}
```

RXJS's [`from()`](https://rxjs.dev/api/index/function/from) (and I assume other observable libraries) roughly expect the signature:

```ts
{
    [Symbol.observable]: () => {
        subscribe(observer: ObservableObserver<T>): {
            unsubscribe(): void;
        };
    }
}
```

The difference being that the type `[Symbol.observable]: () => ...;` is not the same as `[x: symbol]: () => ...;`. Because of this, doing `from(observable(mySignal))` still produces a type error in typescript (though it works fine at runtime).

As far as I can tell, for typescript to be happy we can't assign `Symbol.observable || "@@observable"` to an intermediary variable (i.e. no `const $$observable = Symbol.observable || "@@observable"`) as doing so collapses the type from `Symbol.observable` to just `symbol`. Instead, we need to use `Symbol.observable || "@@observable"` in the object returned by `observable()` directly. Only by using `Symbol.observable || "@@observable"` directly is the result properly typed. It seems like there must be some other way of properly specifying the type of an intermediary variable as `Symbol.observable`, but I'm not sure what it is. For example these don't work:

```ts
const $$observable = Symbol.observable || "@@observable" as Symbol.observable;
const $$observable = Symbol.observable || "@@observable" as typeof Symbol['observable'];
```

The solution contained in this PR (simply using `Symbol.observable || "@@observable"` directly) seems fine given how small the change is.

## How did you test this change?

See this StackBlitz example: https://stackblitz.com/edit/vitejs-vite-v8m2ga?file=src%2Fobservable.ts

After navigating to the example, scroll to line 114 in the `src/observable.ts` file. Notice functions `test1()` and `test2()` and see how `test2()` (which is the code as it exists in #1115) is generating a type error but `test1()` does not.