### PR TITLE
Fix createMutable to handle reactivity in case element is undefined

### DIFF
--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -1,6 +1,6 @@
 import { setProperty, unwrap, isWrappable, StoreNode, $RAW } from "./store";
 
-const $ROOT = Symbol("store-root")
+const $ROOT = Symbol("store-root");
 
 export type ReconcileOptions = {
   key?: string | null;
@@ -139,7 +139,7 @@ const setterTraps: ProxyHandler<StoreNode> = {
   },
 
   deleteProperty(target, property) {
-    setProperty(target, property, undefined);
+    setProperty(target, property, undefined, true);
     return true;
   }
 };

--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -45,7 +45,7 @@ const proxyTraps: ProxyHandler<StoreNode> = {
   },
 
   deleteProperty(target, property) {
-    batch(() => setProperty(target, property, undefined));
+    batch(() => setProperty(target, property, undefined, true));
     return true;
   },
 

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -174,8 +174,8 @@ const proxyTraps: ProxyHandler<StoreNode> = {
   getOwnPropertyDescriptor: proxyDescriptor
 };
 
-export function setProperty(state: StoreNode, property: PropertyKey, value: any) {
-  if (state[property] === value) return;
+export function setProperty(state: StoreNode, property: PropertyKey, value: any, deleting: boolean = false) {
+  if (!deleting && state[property] === value) return;
   const prev = state[property];
   const len = state.length;
   if (value === undefined) {

--- a/packages/solid/store/test/mutable.spec.ts
+++ b/packages/solid/store/test/mutable.spec.ts
@@ -87,8 +87,8 @@ describe("Simple update modes", () => {
 describe("Unwrapping Edge Cases", () => {
   test("Unwrap nested frozen state object", () => {
     const state = createMutable({
-        data: Object.freeze({ user: { firstName: "John", lastName: "Snow" } })
-      }),
+      data: Object.freeze({ user: { firstName: "John", lastName: "Snow" } })
+    }),
       s = unwrap({ ...state });
     expect(s.data.user.firstName).toBe("John");
     expect(s.data.user.lastName).toBe("Snow");
@@ -97,8 +97,8 @@ describe("Unwrapping Edge Cases", () => {
   });
   test("Unwrap nested frozen array", () => {
     const state = createMutable({
-        data: [{ user: { firstName: "John", lastName: "Snow" } }]
-      }),
+      data: [{ user: { firstName: "John", lastName: "Snow" } }]
+    }),
       s = unwrap({ data: state.data.slice(0) });
     expect(s.data[0].user.firstName).toBe("John");
     expect(s.data[0].user.lastName).toBe("Snow");
@@ -107,8 +107,8 @@ describe("Unwrapping Edge Cases", () => {
   });
   test("Unwrap nested frozen state array", () => {
     const state = createMutable({
-        data: Object.freeze([{ user: { firstName: "John", lastName: "Snow" } }])
-      }),
+      data: Object.freeze([{ user: { firstName: "John", lastName: "Snow" } }])
+    }),
       s = unwrap({ ...state });
     expect(s.data[0].user.firstName).toBe("John");
     expect(s.data[0].user.lastName).toBe("Snow");
@@ -138,6 +138,25 @@ describe("Tracking State changes", () => {
       state.data = 5;
       // same value again should not retrigger
       state.data = 5;
+    });
+  });
+
+  test("Deleting an undefined property", () => {
+    createRoot(() => {
+      const state = createMutable({
+        firstName: "John",
+        lastName: undefined,
+      });
+
+      expect.assertions(2);
+      let executionCount = 0;
+      createComputed(() => {
+        state.lastName;
+        executionCount++;
+      });
+      //this should retrigger the execution despite it being undefined
+      delete state.lastName;
+      expect(executionCount).toBe(2);
     });
   });
 
@@ -177,9 +196,9 @@ describe("Handling functions in state", () => {
 
   test("Track function change", () => {
     createRoot(() => {
-      const state = createMutable<{ fn: () => number }>({
-          fn: () => 1
-        }),
+      const state = createMutable<{ fn: () => number; }>({
+        fn: () => 1
+      }),
         getValue = createMemo(() => state.fn());
       state.fn = () => 2;
       expect(getValue()).toBe(2);
@@ -201,8 +220,8 @@ describe("Setting state from Effects", () => {
   test("Select Promise", done => {
     createRoot(async () => {
       const p = new Promise<string>(resolve => {
-          setTimeout(resolve, 20, "promised");
-        }),
+        setTimeout(resolve, 20, "promised");
+      }),
         state = createMutable({ data: "" });
       p.then(v => (state.data = v));
       await p;


### PR DESCRIPTION
## Summary

Fix for issue #1111 

## How did you test this change?

I was unable to run the test in local (i'll try again) but i've added a test in the test suite that should be run by the CI i guess.