### PR TITLE
Add build instructions to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ We can't wait to see what you build!
 ## Building Solid
 
 This repository uses [pnpm](https://pnpm.io/) and
-[Turbo](https://turbo.hotwired.dev/).
+[Turborepo](https://turborepo.org/).
 If you want to build Solid from scratch, use the following steps:
 
 1. `pnpm install` (install all dependencies)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,3 +83,14 @@ Contributing to ecosystem projects is just as important as contributing to Solid
 If you haven't found any interesting information on this page then we encourage you to start hacking at a Solid related utility or package that does. Building useful tools for fellow OSS ecosystem and Solid users enhances the whole platform.
 
 We can't wait to see what you build!
+
+## Building Solid
+
+This repository uses [pnpm](https://pnpm.io/) and
+[Turbo](https://turbo.hotwired.dev/).
+If you want to build Solid from scratch, use the following steps:
+
+1. `pnpm install` (install all dependencies)
+2. `pnpm run build`
+
+You can then run all tests via `pnpm test`.


### PR DESCRIPTION
## Summary

It's not trivial to build Solid, especially if you're not familiar with Lerna, and especially if you're on Windows. This adds the basics to CONTRIBUTING.md (somewhat similar to the PR template, but that's kind of late in the game for someone getting started with tweaking Solid). The Windows workaround is something we found on Discord for being able to build (though tests still don't quite work for me, but it's a starting point).