### PR TITLE
fix: add explicit extensions and exports fields

### DIFF
--- a/packages/solid/jest.config.cjs
+++ b/packages/solid/jest.config.cjs
@@ -1,4 +1,7 @@
 module.exports = {
+  moduleNameMapper: {
+    "(.+)\\.js": "$1"
+  },
   verbose: false,
   collectCoverageFrom: ["src/**/*.ts", "store/src/**/*.ts", "web/src/**/*.ts", "!**/*.d.ts", "!src/server/*.ts", "!store/src/**/server.ts"],
   transformIgnorePatterns: ["node_modules/?!(dom-expressions)"]

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -40,86 +40,146 @@
     ".": {
       "browser": {
         "development": {
-          "import": "./dist/dev.js",
+          "import": {
+            "types": "./types/index.d.ts",
+            "default": "./dist/dev.js"
+          },
           "require": "./dist/dev.cjs"
         },
-        "import": "./dist/solid.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/solid.js"
+        },
         "require": "./dist/solid.cjs"
       },
       "node": {
-        "import": "./dist/server.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/server.js"
+        },
         "require": "./dist/server.cjs"
       },
       "development": {
-        "import": "./dist/dev.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/dev.js"
+        },
         "require": "./dist/dev.cjs"
       },
-      "import": "./dist/solid.js",
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/solid.js"
+      },
       "require": "./dist/solid.cjs"
     },
     "./dist/*": "./dist/*",
     "./store": {
       "browser": {
         "development": {
-          "import": "./store/dist/dev.js",
+          "import": {
+            "types": "./store/types/index.d.ts",
+            "default": "./store/dist/dev.js"
+          },
           "require": "./store/dist/dev.cjs"
         },
-        "import": "./store/dist/store.js",
+        "import": {
+          "types": "./store/types/index.d.ts",
+          "default": "./store/dist/store.js"
+        },
         "require": "./store/dist/store.cjs"
       },
       "node": {
-        "import": "./store/dist/server.js",
+        "import": {
+          "types": "./store/types/index.d.ts",
+          "default": "./store/dist/server.js"
+        },
         "require": "./store/dist/server.cjs"
       },
       "development": {
-        "import": "./store/dist/dev.js",
+        "import": {
+          "types": "./store/types/index.d.ts",
+          "default": "./store/dist/dev.js"
+        },
         "require": "./store/dist/dev.cjs"
       },
-      "import": "./store/dist/store.js",
+      "import": {
+        "types": "./store/types/index.d.ts",
+        "default": "./store/dist/store.js"
+      },
       "require": "./store/dist/store.cjs"
     },
     "./store/dist/*": "./store/dist/*",
     "./web": {
       "browser": {
         "development": {
-          "import": "./web/dist/dev.js",
+          "import": {
+            "types": "./web/types/index.d.ts",
+            "default": "./web/dist/dev.js"
+          },
           "require": "./web/dist/dev.cjs"
         },
-        "import": "./web/dist/web.js",
+        "import": {
+          "types": "./web/types/index.d.ts",
+          "default": "./web/dist/web.js"
+        },
         "require": "./web/dist/web.cjs"
       },
       "node": {
-        "import": "./web/dist/server.js",
+        "import": {
+          "types": "./web/types/index.d.ts",
+          "default": "./web/dist/server.js"
+        },
         "require": "./web/dist/server.cjs"
       },
       "development": {
-        "import": "./web/dist/dev.js",
+        "import": {
+          "types": "./web/types/index.d.ts",
+          "default": "./web/dist/dev.js"
+        },
         "require": "./web/dist/dev.cjs"
       },
-      "import": "./web/dist/web.js",
+      "import": {
+        "types": "./web/types/index.d.ts",
+        "default": "./web/dist/web.js"
+      },
       "require": "./web/dist/web.cjs"
     },
     "./web/dist/*": "./web/dist/*",
     "./universal": {
       "development": {
-        "import": "./universal/dist/dev.js",
+        "import": {
+          "types": "./universal/types/index.d.ts",
+          "default": "./universal/dist/dev.js"
+        },
         "require": "./universal/dist/dev.cjs"
       },
-      "import": "./universal/dist/universal.js",
+      "import": {
+        "types": "./universal/types/index.d.ts",
+        "default": "./universal/dist/universal.js"
+      },
       "require": "./universal/dist/universal.cjs"
     },
     "./universal/dist/*": "./universal/dist/*",
     "./h": {
-      "import": "./h/dist/h.js",
+      "import": {
+        "types": "./h/types/index.d.ts",
+        "default": "./h/dist/h.js"
+      },
       "require": "./h/dist/h.cjs"
     },
     "./h/jsx-runtime": {
-      "import": "./h/jsx-runtime/dist/jsx.js",
+      "import": {
+        "types": "./h/jsx-runtime/types/index.d.ts",
+        "default": "./h/jsx-runtime/dist/jsx.js"
+      },
       "require": "./h/jsx-runtime/dist/jsx.cjs"
     },
     "./h/dist/*": "./h/dist/*",
     "./html": {
-      "import": "./html/dist/html.js",
+      "import": {
+        "types": "./html/types/index.d.ts",
+        "default": "./html/dist/html.js"
+      },
       "require": "./html/dist/html.cjs"
     },
     "./html/dist/*": "./html/dist/*"

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -29,7 +29,7 @@ export {
   $DEVCOMP,
   $PROXY,
   $TRACK
-} from "./reactive/signal";
+} from "./reactive/signal.js";
 export type {
   Accessor,
   Setter,
@@ -42,19 +42,19 @@ export type {
   Context,
   ReturnTypes,
   Owner
-} from "./reactive/signal";
+} from "./reactive/signal.js";
 
-export * from "./reactive/observable";
-export * from "./reactive/scheduler";
-export * from "./reactive/array";
-export * from "./render";
+export * from "./reactive/observable.js";
+export * from "./reactive/scheduler.js";
+export * from "./reactive/array.js";
+export * from "./render/index.js";
 
-import type { JSX } from "./jsx";
+import type { JSX } from "./jsx.js";
 type JSXElement = JSX.Element;
 export type { JSXElement, JSX };
 
 // dev
-import { writeSignal, serializeGraph, registerGraph, hashValue } from "./reactive/signal";
+import { writeSignal, serializeGraph, registerGraph, hashValue } from "./reactive/signal.js";
 let DEV: {
   writeSignal: typeof writeSignal;
   serializeGraph: typeof serializeGraph;

--- a/packages/solid/src/reactive/array.ts
+++ b/packages/solid/src/reactive/array.ts
@@ -1,4 +1,4 @@
-import { onCleanup, createRoot, untrack, createSignal, Accessor, Setter, $TRACK } from "./signal";
+import { onCleanup, createRoot, untrack, createSignal, Accessor, Setter, $TRACK } from "./signal.js";
 
 const FALLBACK = Symbol("fallback");
 function dispose(d: (() => void)[]) {

--- a/packages/solid/src/reactive/observable.ts
+++ b/packages/solid/src/reactive/observable.ts
@@ -1,4 +1,4 @@
-import { Accessor, createComputed, createRoot, createSignal, getOwner, onCleanup, Setter, untrack } from "./signal";
+import { Accessor, createComputed, createRoot, createSignal, getOwner, onCleanup, Setter, untrack } from "./signal.js";
 
 // Note: This will add Symbol.observable globally for all TypeScript users,
 // however, we are not polyfilling Symbol.observable. Ensuring the type for

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1,9 +1,9 @@
 // Inspired by S.js by Adam Haile, https://github.com/adamhaile/S
 
-import { requestCallback, Task } from "./scheduler";
-import { setHydrateContext, sharedConfig } from "../render/hydration";
-import type { JSX } from "../jsx";
-import type { FlowComponent, FlowProps } from "../render";
+import { requestCallback, Task } from "./scheduler.js";
+import { setHydrateContext, sharedConfig } from "../render/hydration.js";
+import type { JSX } from "../jsx.js";
+import type { FlowComponent, FlowProps } from "../render/index.js";
 
 export const equalFn = <T>(a: T, b: T) => a === b;
 export const $PROXY = Symbol("solid-proxy");

--- a/packages/solid/src/render/Suspense.ts
+++ b/packages/solid/src/render/Suspense.ts
@@ -1,4 +1,4 @@
-import { createComponent } from "./component";
+import { createComponent } from "./component.js";
 import {
   createRoot,
   createSignal,
@@ -11,9 +11,9 @@ import {
   Accessor,
   onCleanup,
   getOwner
-} from "../reactive/signal";
-import { HydrationContext, setHydrateContext, sharedConfig } from "./hydration";
-import type { JSX } from "../jsx";
+} from "../reactive/signal.js";
+import { HydrationContext, setHydrateContext, sharedConfig } from "./hydration.js";
+import type { JSX } from "../jsx.js";
 
 type SuspenseListRegistryItem = {
   inFallback: Accessor<boolean>;

--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -6,9 +6,9 @@ import {
   devComponent,
   $PROXY,
   $DEVCOMP
-} from "../reactive/signal";
-import { sharedConfig, nextHydrateContext, setHydrateContext } from "./hydration";
-import type { JSX } from "../jsx";
+} from "../reactive/signal.js";
+import { sharedConfig, nextHydrateContext, setHydrateContext } from "./hydration.js";
+import type { JSX } from "../jsx.js";
 
 let hydrationEnabled = false;
 export function enableHydration() {

--- a/packages/solid/src/render/flow.ts
+++ b/packages/solid/src/render/flow.ts
@@ -7,10 +7,10 @@ import {
   Accessor,
   Setter,
   onCleanup
-} from "../reactive/signal";
-import { mapArray, indexArray } from "../reactive/array";
-import { sharedConfig } from "./hydration";
-import type { JSX } from "../jsx";
+} from "../reactive/signal.js";
+import { mapArray, indexArray } from "../reactive/array.js";
+import { sharedConfig } from "./hydration.js";
+import type { JSX } from "../jsx.js";
 
 /**
  * creates a list elements from a list

--- a/packages/solid/src/render/index.ts
+++ b/packages/solid/src/render/index.ts
@@ -1,4 +1,4 @@
-export * from "./component";
-export * from "./flow";
-export * from "./Suspense"
-export { sharedConfig } from "./hydration";
+export * from "./component.js";
+export * from "./flow.js";
+export * from "./Suspense.js"
+export { sharedConfig } from "./hydration.js";

--- a/packages/solid/src/server/index.ts
+++ b/packages/solid/src/server/index.ts
@@ -29,7 +29,7 @@ export {
   $DEVCOMP,
   DEV,
   enableExternalSource
-} from "./reactive";
+} from "./reactive.js";
 
 export {
   mergeProps,
@@ -52,9 +52,9 @@ export {
   createUniqueId,
   lazy,
   sharedConfig
-} from "./rendering";
+} from "./rendering.js";
 
-export type { Component, Resource } from "./rendering";
+export type { Component, Resource } from "./rendering.js";
 
 
 

--- a/packages/solid/src/server/reactive.ts
+++ b/packages/solid/src/server/reactive.ts
@@ -1,4 +1,4 @@
-import type { JSX } from "../jsx";
+import type { JSX } from "../jsx.js";
 
 export const equalFn = <T>(a: T, b: T) => a === b;
 export const $PROXY = Symbol("solid-proxy");

--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -11,8 +11,8 @@ import {
   onCleanup,
   cleanNode,
   BRANCH
-} from "./reactive";
-import type { JSX } from "../jsx";
+} from "./reactive.js";
+import type { JSX } from "../jsx.js";
 
 export type Component<P = {}> = (props: P) => JSX.Element;
 export type VoidProps<P = {}> = P & { children?: never };

--- a/packages/solid/store/package.json
+++ b/packages/solid/store/package.json
@@ -14,21 +14,36 @@
     ".": {
       "browser": {
         "development": {
-          "import": "./dist/dev.js",
+          "import": {
+            "types": "./types/index.d.ts",
+            "default": "./dist/dev.js"
+          },
           "require": "./dist/dev.cjs"
         },
-        "import": "./dist/store.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/store.js"
+        },
         "require": "./dist/store.cjs"
       },
       "node": {
-        "import": "./dist/server.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/server.js"
+        },
         "require": "./dist/server.cjs"
       },
       "development": {
-        "import": "./dist/dev.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/dev.js"
+        },
         "require": "./dist/dev.cjs"
       },
-      "import": "./dist/store.js",
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/store.js"
+      },
       "require": "./dist/store.cjs"
     }
   }

--- a/packages/solid/store/src/index.ts
+++ b/packages/solid/store/src/index.ts
@@ -1,4 +1,4 @@
-export { createStore, unwrap, $RAW } from "./store";
+export { createStore, unwrap, $RAW } from "./store.js";
 export type {
   Store,
   SetStoreFunction,
@@ -11,6 +11,6 @@ export type {
   Part,
   DeepReadonly,
   DeepMutable
-} from "./store";
-export * from "./mutable";
-export * from "./modifiers";
+} from "./store.js";
+export * from "./mutable.js";
+export * from "./modifiers.js";

--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -1,4 +1,4 @@
-import { setProperty, unwrap, isWrappable, StoreNode, $RAW } from "./store";
+import { setProperty, unwrap, isWrappable, StoreNode, $RAW } from "./store.js";
 
 const $ROOT = Symbol("store-root");
 

--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -12,7 +12,7 @@ import {
   setProperty,
   proxyDescriptor,
   ownKeys
-} from "./store";
+} from "./store.js";
 
 const proxyTraps: ProxyHandler<StoreNode> = {
   get(target, property, receiver) {

--- a/packages/solid/store/src/server.ts
+++ b/packages/solid/store/src/server.ts
@@ -1,4 +1,4 @@
-import type { SetStoreFunction, Store } from "store";
+import type { SetStoreFunction, Store } from "./store.js";
 
 export const $RAW = Symbol("state-raw");
 

--- a/packages/solid/universal/package.json
+++ b/packages/solid/universal/package.json
@@ -8,10 +8,16 @@
   "exports": {
     ".": {
       "development": {
-        "import": "./dist/dev.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/dev.js"
+        },
         "require": "./dist/dev.cjs"
       },
-      "import": "./dist/universal.js",
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/universal.js"
+      },
       "require": "./dist/universal.cjs"
     }
   }

--- a/packages/solid/universal/src/index.ts
+++ b/packages/solid/universal/src/index.ts
@@ -1,5 +1,5 @@
-import { createRenderer as createRendererDX } from "./universal";
-import type { RendererOptions, Renderer } from "./universal";
+import { createRenderer as createRendererDX } from "./universal.js";
+import type { RendererOptions, Renderer } from "./universal.js";
 import { mergeProps } from "solid-js";
 
 export function createRenderer<NodeType>(options: RendererOptions<NodeType>): Renderer<NodeType> {

--- a/packages/solid/web/package.json
+++ b/packages/solid/web/package.json
@@ -14,21 +14,36 @@
     ".": {
       "browser": {
         "development": {
-          "import": "./dist/dev.js",
+          "import": {
+            "types": "./types/index.d.ts",
+            "default": "./dist/dev.js"
+          },
           "require": "./dist/dev.cjs"
         },
-        "import": "./dist/web.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/web.js"
+        },
         "require": "./dist/web.cjs"
       },
       "node": {
-        "import": "./dist/server.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/server.js"
+        },
         "require": "./dist/server.cjs"
       },
       "development": {
-        "import": "./dist/dev.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/dev.js"
+        },
         "require": "./dist/dev.cjs"
       },
-      "import": "./dist/web.js",
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/web.js"
+      },
       "require": "./dist/web.cjs"
     }
   }

--- a/packages/solid/web/server/index.ts
+++ b/packages/solid/web/server/index.ts
@@ -1,4 +1,4 @@
-import { ssrElement } from "./server";
+import { ssrElement } from "./server.js";
 import { splitProps, Component, JSX } from "solid-js";
 
 export * from "./server";

--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -1,4 +1,4 @@
-import { getNextElement, insert, spread, SVGElements, hydrate as hydrateCore } from "./client";
+import { getNextElement, insert, spread, SVGElements, hydrate as hydrateCore } from "./client.js";
 import {
   createSignal,
   createMemo,
@@ -15,7 +15,7 @@ import {
   ValidComponent,
 } from "solid-js";
 
-export * from "./client";
+export * from "./client.js";
 
 export {
   For,
@@ -29,7 +29,7 @@ export {
   mergeProps
 } from "solid-js";
 
-export * from "./server-mock";
+export * from "./server-mock.js";
 export const isServer = false;
 const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 

--- a/packages/solid/web/src/jsx.ts
+++ b/packages/solid/web/src/jsx.ts
@@ -1,1 +1,1 @@
-export { JSX } from "../.."
+export type { JSX } from "../../types/jsx.js"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `npm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `npm run build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`npm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Following the trace of https://discord.com/channels/722131463138705510/783844647528955931/999968111937736764, I have found out the culprit of solid-js's problem with typescript and specifically NodeNext setting. The extensions in the .d.ts files must be defined explicitly, as well as have the correct `exports.import.types` being set. This pull request does exactly that. 

Adding extensions won't break existing typescript codebases.
See this comment: https://github.com/microsoft/TypeScript/issues/16577#issuecomment-754941937

This PR depends on: https://github.com/ryansolid/dom-expressions/pull/154
## How did you test this change?
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

Published a new version locally and tested pet projects using solid and checked the type output and inference of exports from 'solid-js' when using NodeNext `module` and `moduleResolution`.