### PR TITLE
refactor(types): change `createStore` types for a clearer error message

### DIFF
--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -412,10 +412,10 @@ export interface SetStoreFunction<T> {
  *
  * @description https://www.solidjs.com/docs/latest/api#createstore
  */
-export function createStore<T extends {}>(
+export function createStore<T extends object = {}>(
   ...[store, options]: {} extends T
     ? [store?: T | Store<T>, options?: { name?: string }]
-    : [store: object & (T | Store<T>), options?: { name?: string }]
+    : [store: T | Store<T>, options?: { name?: string }]
 ): [get: Store<T>, set: SetStoreFunction<T>] {
   const unwrappedStore = unwrap((store || {}) as T);
   const isArray = Array.isArray(unwrappedStore);


### PR DESCRIPTION
Specifically, this change targets these differences:

- Initializing a store with a generic type which is not restricted to `object` now shows `Argument of type 'T' is not assignable to parameter of type 'object | undefined'. Type 'T' is not assignable to type 'object'` instead of `Argument of type '[T]' is not assignable to parameter of type '{} extends T ? [store?: T | undefined, options?: { name?: string | undefined; } | undefined] : [store: object & T, options?: { name?: string | undefined; } | undefined]'`.

- Initializing a store with a non-generic, non-object type now shows that the expected parameter type is `object | undefined` instead of `never` (or `{} | undefined` if trying to use `null`).