### PR TITLE
fix: wrong `mutate` callback types of createResource with initialValue

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -447,7 +447,7 @@ export type Resource<T> = Unresolved | Pending | Ready<T> | Refreshing<T> | Erro
 export type InitializedResource<T> = Ready<T> | Refreshing<T> | Errored;
 
 export type ResourceActions<T, R = unknown> = {
-  mutate: Setter<T | undefined>;
+  mutate: Setter<T>;
   refetch: (info?: R) => T | Promise<T> | undefined | null;
 };
 
@@ -476,7 +476,10 @@ export type InitializedResourceOptions<T, S = unknown> = ResourceOptions<T, S> &
   initialValue: T;
 };
 
-export type ResourceReturn<T, R = unknown> = [Resource<T>, ResourceActions<T, R>];
+export type ResourceReturn<T, R = unknown> = [
+  Resource<T>,
+  ResourceActions<T | undefined, R>
+];
 
 export type InitializedResourceReturn<T, R = unknown> = [
   InitializedResource<T>,

--- a/packages/solid/test/resource.type-tests.ts
+++ b/packages/solid/test/resource.type-tests.ts
@@ -1,4 +1,10 @@
-import { createResource, ResourceReturn, createSignal, Resource } from "../src";
+import {
+  createResource,
+  ResourceReturn,
+  createSignal,
+  Resource,
+  Setter
+} from "../src";
 import { InitializedResource, InitializedResourceReturn } from "../src/reactive/signal";
 
 type Assert<T extends true> = T;
@@ -52,6 +58,9 @@ type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y 
       }
     }
   );
+
+  type ResourceActions = typeof resourceReturn[1];
+  type Tests = Assert<Equals<ResourceActions['mutate'], Setter<number>>>;
 }
 
 // without initialValue
@@ -74,6 +83,9 @@ type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y 
       }
     }
   );
+
+  type ResourceActions = typeof resourceReturn[1];
+  type Tests = Assert<Equals<ResourceActions['mutate'], Setter<number | undefined>>>;
 }
 
 // with source, fetcher, initialValue


### PR DESCRIPTION
As the documentation says, the prev() acessor of a createResource with initialValue should never return undefined.
```
Setting an `initialValue` in the options will mean that both the prev() accessor and the resource should never return undefined (if that is wanted, you need to extend the type with undefined)
```

Using solid-js@1.5, while using a `createResource` with an initial value, the `mutate` callback previous value is inferred as T | undefined instead of T. 

Here a small playground comparing old types which didn't have this type issue:

![image](https://user-images.githubusercontent.com/37072694/186919748-33d49bc2-bd13-463b-ae1a-15c895c37039.png)
https://stackblitz.com/edit/vitejs-vite-8em7ud?file=src%2FApp.tsx,src%2Fsolid-1.4.tsx