### PR TITLE
Fix a typo in the benchmarks

### DIFF
--- a/packages/solid/bench/bench.cjs
+++ b/packages/solid/bench/bench.cjs
@@ -249,7 +249,7 @@ function updateComputations2to1(n, sources) {
 
 function updateComputations4to1(n, sources) {
   var [get1, set1] = sources[0],
-    [get2] = sources[1];
+    [get2] = sources[1],
     [get3] = sources[2],
     [get4] = sources[3];
   createComputed(function () { return get1() + get2() + get3() + get4(); });


### PR DESCRIPTION
I was running this benchmark in `"type": "module"` and it caught this error due to modules running in strict mode.