### PR TITLE
perf: with createMemo typings

### DIFF
--- a/packages/solid/src/server/reactive.ts
+++ b/packages/solid/src/server/reactive.ts
@@ -223,10 +223,10 @@ function resolveChildren(children: any): unknown {
 
 function createProvider(id: symbol) {
   return function provider(props: { value: unknown; children: any }) {
-    return createMemo(() => {
+    return createMemo<JSX.Element>(() => {
       Owner!.context = { [id]: props.value };
       return children(() => props.children);
-    }) as unknown as JSX.Element;
+    });
   };
 }
 

--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -112,9 +112,9 @@ type DynamicProps<T extends ValidComponent> = ComponentProps<T> & {
  */
 export function Dynamic<T extends ValidComponent>(props: DynamicProps<T>): Accessor<JSX.Element> {
   const [p, others] = splitProps(props, ["component"]);
-  const cached = createMemo(() => p.component)
+  const cached = createMemo<Function | string>(() => p.component)
   return createMemo(() => {
-    const component = cached() as Function | string;
+    const component = cached();
     switch (typeof component) {
       case "function":
         if ("_DX_DEV_") Object.assign(component, { [$DEVCOMP]: true });


### PR DESCRIPTION
As in the type definition of `createMemo`, 
```typescript
createMemo<T>(fn: (v?: T) => T, value?: undefined, options?: {
  equals?: false | ((prev: T, next: T) => boolean);
  name?: string;
}): () => T
```
we can automatically infer the type of `cache` directly using the paradigm