### PR TITLE
DEV: Assign components props to its owner node

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1024,13 +1024,14 @@ export function resumeEffects(e: Computation<any>[]) {
   e.length = 0;
 }
 
-export interface DevComponent<T> extends Partial<Memo<JSX.Element, JSX.Element>> {
+export interface DevComponent<T> extends Memo<JSX.Element> {
   props: T;
+  componentName: string;
 }
 
 // Dev
 export function devComponent<T>(Comp: (props: T) => JSX.Element, props: T) {
-  const c = createComputation<JSX.Element, JSX.Element>(
+  const c = createComputation(
     () =>
       untrack(() => {
         Object.assign(Comp, { [$DEVCOMP]: true });
@@ -1044,7 +1045,7 @@ export function devComponent<T>(Comp: (props: T) => JSX.Element, props: T) {
   c.observerSlots = null;
   c.state = 0;
   c.componentName = Comp.name;
-  updateComputation(c as Memo<JSX.Element>);
+  updateComputation(c);
   return c.tValue !== undefined ? c.tValue : c.value;
 }
 

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -476,10 +476,7 @@ export type InitializedResourceOptions<T, S = unknown> = ResourceOptions<T, S> &
   initialValue: T;
 };
 
-export type ResourceReturn<T, R = unknown> = [
-  Resource<T>,
-  ResourceActions<T | undefined, R>
-];
+export type ResourceReturn<T, R = unknown> = [Resource<T>, ResourceActions<T | undefined, R>];
 
 export type InitializedResourceReturn<T, R = unknown> = [
   InitializedResource<T>,
@@ -1027,9 +1024,13 @@ export function resumeEffects(e: Computation<any>[]) {
   e.length = 0;
 }
 
+export interface DevComponent<T> extends Partial<Memo<JSX.Element, JSX.Element>> {
+  props: T;
+}
+
 // Dev
 export function devComponent<T>(Comp: (props: T) => JSX.Element, props: T) {
-  const c: Partial<Memo<JSX.Element, JSX.Element>> = createComputation<JSX.Element, JSX.Element>(
+  const c = createComputation<JSX.Element, JSX.Element>(
     () =>
       untrack(() => {
         Object.assign(Comp, { [$DEVCOMP]: true });
@@ -1037,7 +1038,8 @@ export function devComponent<T>(Comp: (props: T) => JSX.Element, props: T) {
       }),
     undefined,
     true
-  );
+  ) as DevComponent<T>;
+  c.props = props;
   c.observers = null;
   c.observerSlots = null;
   c.state = 0;


### PR DESCRIPTION
Adds `DevComponent` interface for the components owner node.
```ts
export interface DevComponent<T> extends Memo<JSX.Element> {
  props: T;
  componentName: string;
}
```
Assigns `props` object to the component owner node, so that the debugger can access them.