### PR TITLE
fix: createResource null check failing on load

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -642,7 +642,7 @@ export function createResource<T, S, R>(
               refetching
             })
           );
-    if (typeof p !== "object" || !("then" in p)) {
+    if (typeof p !== "object" || !(p && "then" in p)) {
       loadEnd(pr, p);
       return p;
     }


### PR DESCRIPTION
When `createResource` is trying to resolve, it checks with the condition `(typeof p !== "object" || !("then" in p))` so that it knows if it should await for the value. However, `typeof null` is equal to `"object"` and so the condition fails for the promise check.