### PR TITLE
fix: non-conforming code

### DIFF
--- a/packages/solid/rollup.config.js
+++ b/packages/solid/rollup.config.js
@@ -2,7 +2,7 @@ import nodeResolve from "@rollup/plugin-node-resolve";
 import babel from "@rollup/plugin-babel";
 import cleanup from "rollup-plugin-cleanup";
 import replace from "@rollup/plugin-replace";
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath } from "node:url";
 
 const plugins = [
   nodeResolve({
@@ -48,7 +48,7 @@ export default [
         '"_SOLID_DEV_"': false,
         preventAssignment: true,
         delimiters: ["", ""]
-      }),
+      })
     ].concat(plugins)
   },
   {
@@ -149,7 +149,7 @@ export default [
         '"_DX_DEV_"': false,
         preventAssignment: true,
         delimiters: ["", ""]
-      }),
+      })
     ].concat(plugins)
   },
   {
@@ -200,7 +200,7 @@ export default [
         '"_DX_DEV_"': false,
         preventAssignment: true,
         delimiters: ["", ""]
-      }),
+      })
     ].concat(plugins)
   },
   {


### PR DESCRIPTION
1. change single quotes to double quotes.
2. remove useless commas.

```js
// packages/solid/rollup.config.js

import { fileURLToPath } from "node:url";
```

![image](https://user-images.githubusercontent.com/96212026/189312611-05f55120-0c82-4d3b-87f5-917c2d75fa73.png)

![image](https://user-images.githubusercontent.com/96212026/189313280-5d627af4-5cbd-4467-a62f-b81fd16eb8a4.png)
