### PR TITLE
add <rb> element to jsx-runtime

### DIFF
--- a/packages/solid/h/jsx-runtime/src/jsx.d.ts
+++ b/packages/solid/h/jsx-runtime/src/jsx.d.ts
@@ -1910,6 +1910,7 @@ export namespace JSX {
     progress: ProgressHTMLAttributes<HTMLProgressElement>;
     q: QuoteHTMLAttributes<HTMLQuoteElement>;
     rp: HTMLAttributes<HTMLElement>;
+    rb: HTMLAttributes<HTMLElement>;
     rt: HTMLAttributes<HTMLElement>;
     ruby: HTMLAttributes<HTMLElement>;
     s: HTMLAttributes<HTMLElement>;


### PR DESCRIPTION
## Summary

Added the &lt;rb> element to the jsx-runtime. 

The &lt;rb> HTML element is used to delimit the base text component of a &lt;ruby> annotation and was missing in the jsx-runtime resulting in the error "Property 'rb' does not exist on type 'JSX.IntrinsicElements'" when used.