### PR TITLE
fix `Dynamic` type

### DIFF
--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -100,9 +100,7 @@ export function Portal<T extends boolean = false, S extends boolean = false>(pro
   return marker;
 }
 
-type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
-
-type DynamicProps<T extends ValidComponent> = Expand<ComponentProps<T>> & {
+type DynamicProps<T extends ValidComponent, P = ComponentProps<T>> = { [K in keyof P]: P[K] } & {
   component: T | undefined;
 };
 /**

--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -100,7 +100,9 @@ export function Portal<T extends boolean = false, S extends boolean = false>(pro
   return marker;
 }
 
-type DynamicProps<T extends ValidComponent> = ComponentProps<T> & {
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+
+type DynamicProps<T extends ValidComponent> = Expand<ComponentProps<T>> & {
   component: T | undefined;
 };
 /**


### PR DESCRIPTION
## Summary

Currently, `Dynamic` can't infer props from `component` and will fail to type check them
```
<Dynamic component="a" href={2} />
```
This PR tries to fix this with [`Expand`](https://stackoverflow.com/a/57683652/6808116)

I also didn't format with prettier as I'm not sure it's intentional

trailing comma here, (might help with git diff probably)
https://github.com/solidjs/solid/blob/dcfd8ceeedb3e5d98e548a83cf2063c16b18926a/packages/solid/web/src/index.ts#L15

but not here
https://github.com/solidjs/solid/blob/dcfd8ceeedb3e5d98e548a83cf2063c16b18926a/packages/solid/web/src/index.ts#L29

missing semi
https://github.com/solidjs/solid/blob/dcfd8ceeedb3e5d98e548a83cf2063c16b18926a/packages/solid/web/src/index.ts#L115