### PR TITLE
DEV: remove autogenerated names

### DIFF
--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -43,8 +43,14 @@ const proxyTraps: ProxyHandler<StoreNode> = {
   },
 
   has(target, property) {
-    if (property === $RAW || property === $PROXY || property === $TRACK ||
-        property === $NODE || property === "__proto__") return true;
+    if (
+      property === $RAW ||
+      property === $PROXY ||
+      property === $TRACK ||
+      property === $NODE ||
+      property === "__proto__"
+    )
+      return true;
     const tracked = getDataNodes(target)[property];
     tracked && tracked();
     return property in target;
@@ -98,13 +104,13 @@ export function createMutable<T extends StoreNode>(state: T, options?: { name?: 
     throw new Error(
       `Unexpected type ${typeof unwrappedStore} received when initializing 'createMutable'. Expected an object.`
     );
-  const wrappedStore = wrap(
-    unwrappedStore,
-    "_SOLID_DEV_" && ((options && options.name) || DEV.hashValue(unwrappedStore))
-  );
+  const wrappedStore = wrap(unwrappedStore, "_SOLID_DEV_" && options && options.name);
   if ("_SOLID_DEV_") {
-    const name = (options && options.name) || DEV.hashValue(unwrappedStore);
-    DEV.registerGraph(name, { value: unwrappedStore });
+    const s: { value: unknown; name?: string; id?: string } = {
+      value: unwrappedStore,
+      name: options && options.name
+    };
+    s.id = DEV.registerGraph(undefined, s);
   }
   return wrappedStore;
 }

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -158,8 +158,14 @@ const proxyTraps: ProxyHandler<StoreNode> = {
   },
 
   has(target, property) {
-    if (property === $RAW || property === $PROXY || property === $TRACK ||
-        property === $NODE || property === "__proto__") return true;
+    if (
+      property === $RAW ||
+      property === $PROXY ||
+      property === $TRACK ||
+      property === $NODE ||
+      property === "__proto__"
+    )
+      return true;
     const tracked = getDataNodes(target)[property];
     tracked && tracked();
     return property in target;
@@ -180,7 +186,12 @@ const proxyTraps: ProxyHandler<StoreNode> = {
   getOwnPropertyDescriptor: proxyDescriptor
 };
 
-export function setProperty(state: StoreNode, property: PropertyKey, value: any, deleting: boolean = false) {
+export function setProperty(
+  state: StoreNode,
+  property: PropertyKey,
+  value: any,
+  deleting: boolean = false
+) {
   if (!deleting && state[property] === value) return;
   const prev = state[property];
   const len = state.length;
@@ -423,13 +434,13 @@ export function createStore<T extends object = {}>(
     throw new Error(
       `Unexpected type ${typeof unwrappedStore} received when initializing 'createStore'. Expected an object.`
     );
-  const wrappedStore = wrap(
-    unwrappedStore,
-    "_SOLID_DEV_" && ((options && options.name) || DEV.hashValue(unwrappedStore))
-  );
+  const wrappedStore = wrap(unwrappedStore, "_SOLID_DEV_" && options && options.name);
   if ("_SOLID_DEV_") {
-    const name = (options && options.name) || DEV.hashValue(unwrappedStore);
-    DEV.registerGraph(name, { value: unwrappedStore });
+    const s: { value: unknown; name?: string; id?: string } = {
+      value: unwrappedStore,
+      name: options && options.name
+    };
+    s.id = DEV.registerGraph(undefined, s);
   }
   function setStore(...args: any[]): void {
     batch(() => {

--- a/packages/solid/test/dev.spec.ts
+++ b/packages/solid/test/dev.spec.ts
@@ -1,4 +1,13 @@
-import { createRoot, getOwner, createSignal, createEffect, createComponent, createComputed, DEV, Owner } from "../src";
+import {
+  createRoot,
+  getOwner,
+  createSignal,
+  createEffect,
+  createComponent,
+  createComputed,
+  DEV,
+  Owner
+} from "../src";
 import { createStore } from "../store/src";
 
 describe("Dev features", () => {
@@ -6,8 +15,8 @@ describe("Dev features", () => {
     let owner: ReturnType<typeof getOwner>, set1: (v: number) => number, setState1: any;
 
     const SNAPSHOTS = [
-      `{"s1773325850":5,"s1773325850-1":5,"c-1":{"explicit":6},"CustomComponent:c-2":{"s533736025":{"firstName":"John","lastName":"Smith"}}}`,
-      `{"s1773325850":7,"s1773325850-1":5,"c-1":{"explicit":6},"CustomComponent:c-2":{"s533736025":{"firstName":"Matt","lastName":"Smith","middleInitial":"R."}}}`
+      `{"s1":5,"s2":5,"c1":{"s4":6},"CustomComponent:c2":{"s3":{"firstName":"John","lastName":"Smith"}}}`,
+      `{"s1":7,"s2":5,"c1":{"s4":6},"CustomComponent:c2":{"s3":{"firstName":"Matt","lastName":"Smith","middleInitial":"R."}}}`
     ];
     const CustomComponent = () => {
       const [state, setState] = createStore({ firstName: "John", lastName: "Smith" });
@@ -67,7 +76,7 @@ describe("Dev features", () => {
       const [s3, set3] = createSignal(0);
       createComputed(() => {
         log += "a";
-        set3(s2())
+        set3(s2());
       });
       createEffect(() => {
         log += "b";
@@ -76,7 +85,7 @@ describe("Dev features", () => {
       createEffect(() => {
         log += "c";
         s3();
-      })
+      });
       set1 = set;
     });
     expect(triggered).toBe(1);
@@ -101,5 +110,5 @@ describe("Dev features", () => {
         expect(inner.owner).toBe(root);
       });
     });
-  })
+  });
 });


### PR DESCRIPTION
- remove autogenerated owner and signal names
- add unique id to owners and signals
- remove `componentName` to instead use the `name` prop (component owners can be identified by the fact that `props` field exists)

My goal is to separate the autogenerated (`"c-1-1-1-1-1..."`, `"s-951856283"`) names from explicit user names, as the user names are the only ones I want to display to users. But the generated names occupy the same field.
The individual owners can be identified by a simple id, which I'm doing now, but it can be added here as a replacement for the generated names.
Alternatively id and name could still be merged. e.g. with a format: `<id>:<name>`. But that's just serialization, so probably a task for the devtools.

The `hashValue` and `serializeGraph` functions are interesting but do not have a use now.
They can still be called from the `DEV` object if necessary.

Not sure if I'm not missing something here... especially around stores, as I haven't gotten to them in the devtools so I don't know yet what's important there.
So it'll be useful for me, but the details probably will change in the future.