### PR TITLE
fix exactOptionalPropertyTypes when using css modules

### DIFF
--- a/packages/solid/h/jsx-runtime/src/jsx.d.ts
+++ b/packages/solid/h/jsx-runtime/src/jsx.d.ts
@@ -603,7 +603,7 @@ export namespace JSX {
 
   interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
     accessKey?: FunctionMaybe<string>;
-    class?: FunctionMaybe<string>;
+    class?: FunctionMaybe<string> | undefined;
     contenteditable?: FunctionMaybe<boolean | "inherit">;
     contextmenu?: FunctionMaybe<string>;
     dir?: FunctionMaybe<HTMLDir>;
@@ -1090,7 +1090,7 @@ export namespace JSX {
     tabindex?: FunctionMaybe<number | string>;
   }
   interface StylableSVGAttributes {
-    class?: FunctionMaybe<string>;
+    class?: FunctionMaybe<string> | undefined;
     style?: FunctionMaybe<CSSProperties | string>;
   }
   interface TransformableSVGAttributes {


### PR DESCRIPTION
This fixes typesscript's `exactOptionalPropertyTypes` when using css modules

```
Types of property 'class' are incompatible.
    Type 'string | undefined' is not assignable to type 'string'.
      Type 'undefined' is not assignable to type 'string'.
```

I just added a `| undefined` to check for class property