### PR TITLE
feat: call components with `.call` to allow libs to provide class components with static `.call` methods

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1031,7 +1031,7 @@ export function devComponent<T>(Comp: (props: T) => JSX.Element, props: T) {
     () =>
       untrack(() => {
         Object.assign(Comp, { [$DEVCOMP]: true });
-        return Comp(props);
+        return Comp.call(Comp, props);
       }),
     undefined,
     true

--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -65,10 +65,7 @@ export type FlowComponent<P = {}, C = JSX.Element> = Component<FlowProps<P, C>>;
 /** @deprecated: use `ParentProps` instead */
 export type PropsWithChildren<P = {}> = ParentProps<P>;
 
-export type ValidComponent =
-  | keyof JSX.IntrinsicElements
-  | Component<any>
-  | (string & {});
+export type ValidComponent = keyof JSX.IntrinsicElements | Component<any> | (string & {});
 
 /**
  * Takes the props of the passed component and returns its type
@@ -77,13 +74,11 @@ export type ValidComponent =
  * ComponentProps<typeof Portal> // { mount?: Node; useShadow?: boolean; children: JSX.Element }
  * ComponentProps<'div'> // JSX.HTMLAttributes<HTMLDivElement>
  */
-export type ComponentProps<T extends ValidComponent> =
-  T extends Component<infer P>
-    ? P
-    :
-  T extends keyof JSX.IntrinsicElements
-    ? JSX.IntrinsicElements[T]
-    : Record<string, unknown>;
+export type ComponentProps<T extends ValidComponent> = T extends Component<infer P>
+  ? P
+  : T extends keyof JSX.IntrinsicElements
+  ? JSX.IntrinsicElements[T]
+  : Record<string, unknown>;
 
 /**
  * Type of `props.ref`, for use in `Component` or `props` typing.
@@ -99,7 +94,7 @@ export function createComponent<T>(Comp: Component<T>, props: T): JSX.Element {
       setHydrateContext(nextHydrateContext());
       const r = "_SOLID_DEV_"
         ? devComponent(Comp, props || ({} as T))
-        : untrack(() => Comp(props || ({} as T)));
+        : untrack(() => Comp.call(Comp, props || ({} as T)));
       setHydrateContext(c);
       return r;
     }


### PR DESCRIPTION
Also formatted with prettier, some unformatted code got by in previous commits.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

Thanks @fabiospampinato for ideating and ending with this idea.

Calling components as `Comp.call(Comp, props)` allows for classes to be used as components if they have a `static call` method. Existing function components work the same, and this is what a class could look like:

```js
class ShowCount {
  static call(Comp, props) {
    return new Comp().template(props)
  }

  foo = 123

  template(props) {
    return <div>Count is {props.count} and foo is {this.foo}</div>
  }
}

function NonClassComp() {
  return <ShowCount count={456} />
}
```

## How did you test this change?

