### PR TITLE
export Memo insterface from signal.ts

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -343,7 +343,7 @@ export function createReaction(onInvalidate: () => void, options?: EffectOptions
   };
 }
 
-interface Memo<Prev, Next = Prev> extends SignalState<Next>, Computation<Next> {
+export interface Memo<Prev, Next = Prev> extends SignalState<Next>, Computation<Next> {
   tOwned?: Computation<Prev | Next, Next>[];
 }
 


### PR DESCRIPTION
`Memo` was the only *internal* interface that wasn't exported from the module.