### PR TITLE
Fix mutable descriptor

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1031,7 +1031,7 @@ export function devComponent<T>(Comp: (props: T) => JSX.Element, props: T) {
     () =>
       untrack(() => {
         Object.assign(Comp, { [$DEVCOMP]: true });
-        return Comp(props);
+        return Comp.call(Comp, props);
       }),
     undefined,
     true

--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -65,10 +65,7 @@ export type FlowComponent<P = {}, C = JSX.Element> = Component<FlowProps<P, C>>;
 /** @deprecated: use `ParentProps` instead */
 export type PropsWithChildren<P = {}> = ParentProps<P>;
 
-export type ValidComponent =
-  | keyof JSX.IntrinsicElements
-  | Component<any>
-  | (string & {});
+export type ValidComponent = keyof JSX.IntrinsicElements | Component<any> | (string & {});
 
 /**
  * Takes the props of the passed component and returns its type
@@ -77,13 +74,11 @@ export type ValidComponent =
  * ComponentProps<typeof Portal> // { mount?: Node; useShadow?: boolean; children: JSX.Element }
  * ComponentProps<'div'> // JSX.HTMLAttributes<HTMLDivElement>
  */
-export type ComponentProps<T extends ValidComponent> =
-  T extends Component<infer P>
-    ? P
-    :
-  T extends keyof JSX.IntrinsicElements
-    ? JSX.IntrinsicElements[T]
-    : Record<string, unknown>;
+export type ComponentProps<T extends ValidComponent> = T extends Component<infer P>
+  ? P
+  : T extends keyof JSX.IntrinsicElements
+  ? JSX.IntrinsicElements[T]
+  : Record<string, unknown>;
 
 /**
  * Type of `props.ref`, for use in `Component` or `props` typing.
@@ -99,7 +94,7 @@ export function createComponent<T>(Comp: Component<T>, props: T): JSX.Element {
       setHydrateContext(nextHydrateContext());
       const r = "_SOLID_DEV_"
         ? devComponent(Comp, props || ({} as T))
-        : untrack(() => Comp(props || ({} as T)));
+        : untrack(() => Comp.call(Comp, props || ({} as T)));
       setHydrateContext(c);
       return r;
     }

--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -10,7 +10,6 @@ import {
   $NAME,
   StoreNode,
   setProperty,
-  proxyDescriptor,
   ownKeys
 } from "./store.js";
 
@@ -43,8 +42,14 @@ const proxyTraps: ProxyHandler<StoreNode> = {
   },
 
   has(target, property) {
-    if (property === $RAW || property === $PROXY || property === $TRACK ||
-        property === $NODE || property === "__proto__") return true;
+    if (
+      property === $RAW ||
+      property === $PROXY ||
+      property === $TRACK ||
+      property === $NODE ||
+      property === "__proto__"
+    )
+      return true;
     const tracked = getDataNodes(target)[property];
     tracked && tracked();
     return property in target;
@@ -64,6 +69,25 @@ const proxyTraps: ProxyHandler<StoreNode> = {
 
   getOwnPropertyDescriptor: proxyDescriptor
 };
+
+function proxyDescriptor(target: StoreNode, property: PropertyKey) {
+  const desc = Reflect.getOwnPropertyDescriptor(target, property);
+  if (
+    !desc ||
+    desc.get ||
+    desc.set ||
+    !desc.configurable ||
+    property === $PROXY ||
+    property === $NODE ||
+    property === $NAME
+  )
+    return desc;
+
+  desc.get = () => target[$PROXY][property];
+  desc.set = v => (target[$PROXY][property] = v);
+
+  return desc;
+}
 
 function wrap<T extends StoreNode>(value: T, name?: string): T {
   let p = value[$PROXY];


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

Similar to a store proxy's descriptor trap, except this adds the `set`ter, assuming that mutables are mutable.

I'm not sure if we should convert a value descriptor to an accessor though, but that may be a different topic. For example, maybe `getOwnPropertyDescriptor` on a value descriptor just counts as a read (tracked), nothing more; and `defineProperty` with a value descriptor would be a write and would trigger.

## How did you test this change?

Not tested yet.
