### PR TITLE
Add option to name context nodes

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1116,18 +1116,28 @@ export interface Context<T> {
  *   Provider: FlowComponent<{ value: T }>;
  *   defaultValue: T;
  * }
- * export function createContext<T>(defaultValue?: T): Context<T | undefined>;
+ * export function createContext<T>(
+ *   defaultValue?: T,
+ *   options?: { name?: string }
+ * ): Context<T | undefined>;
  * ```
  * @param defaultValue optional default to inject into context
+ * @param options allows to set a name in dev mode for debugging purposes
  * @returns The context that contains the Provider Component and that can be used with `useContext`
  *
  * @description https://www.solidjs.com/docs/latest/api#createcontext
  */
-export function createContext<T>(): Context<T | undefined>;
-export function createContext<T>(defaultValue: T): Context<T>;
-export function createContext<T>(defaultValue?: T): Context<T | undefined> {
+export function createContext<T>(
+  defaultValue?: undefined,
+  options?: EffectOptions
+): Context<T | undefined>;
+export function createContext<T>(defaultValue: T, options?: EffectOptions): Context<T>;
+export function createContext<T>(
+  defaultValue?: T,
+  options?: EffectOptions
+): Context<T | undefined> {
   const id = Symbol("context");
-  return { id, Provider: createProvider(id), defaultValue };
+  return { id, Provider: createProvider(id, options), defaultValue };
 }
 
 /**
@@ -1660,7 +1670,7 @@ function resolveChildren(children: JSX.Element): ResolvedChildren {
   return children as ResolvedChildren;
 }
 
-function createProvider(id: symbol) {
+function createProvider(id: symbol, options?: EffectOptions) {
   return function provider(props: FlowProps<{ value: unknown }>) {
     let res;
     createRenderEffect(
@@ -1668,7 +1678,9 @@ function createProvider(id: symbol) {
         (res = untrack(() => {
           Owner!.context = { [id]: props.value };
           return children(() => props.children);
-        }))
+        })),
+      undefined,
+      options
     );
     return res;
   };

--- a/packages/solid/test/dev.spec.ts
+++ b/packages/solid/test/dev.spec.ts
@@ -1,4 +1,14 @@
-import { createRoot, getOwner, createSignal, createEffect, createComponent, createComputed, DEV, Owner } from "../src";
+import {
+  createRoot,
+  getOwner,
+  createSignal,
+  createEffect,
+  createComponent,
+  createComputed,
+  DEV,
+  Owner,
+  createContext
+} from "../src";
 import { createStore } from "../store/src";
 
 describe("Dev features", () => {
@@ -28,6 +38,16 @@ describe("Dev features", () => {
     set1!(7);
     setState1({ middleInitial: "R.", firstName: "Matt" });
     expect(JSON.stringify(DEV.serializeGraph(owner!))).toBe(SNAPSHOTS[1]);
+  });
+
+  test("Context nodes can be named", () => {
+    createRoot(dispose => {
+      const ctx = createContext(undefined, { name: "test" });
+      ctx.Provider({ value: undefined, children: undefined });
+      const ctxNode = getOwner()!.owned![0];
+      expect(ctxNode.name).toBe("test");
+      dispose();
+    });
   });
 
   test("AfterUpdate Hook", () => {
@@ -67,7 +87,7 @@ describe("Dev features", () => {
       const [s3, set3] = createSignal(0);
       createComputed(() => {
         log += "a";
-        set3(s2())
+        set3(s2());
       });
       createEffect(() => {
         log += "b";
@@ -76,7 +96,7 @@ describe("Dev features", () => {
       createEffect(() => {
         log += "c";
         s3();
-      })
+      });
       set1 = set;
     });
     expect(triggered).toBe(1);
@@ -101,5 +121,5 @@ describe("Dev features", () => {
         expect(inner.owner).toBe(root);
       });
     });
-  })
+  });
 });


### PR DESCRIPTION
Context nodes should be able to be named, just as signals and computations.
Without names, context nodes don't have anything besides their value to identify different context nodes.
Luckily since context is provided using a render effect, the `createContext` API could accept the same options argument and pass it to `createRenderEffect`.
Creating context involves creating a global variable that—similarly to createSignal and createMemo—could be used by a babel plugin to automatically fill the name option.