### PR TITLE
<Portal/> make host property configurable on the container element.

### DIFF
--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -90,7 +90,8 @@ export function Portal<T extends boolean = false, S extends boolean = false>(pro
     Object.defineProperty(container, "host", {
       get() {
         return marker.parentNode;
-      }
+      },
+      configurable: true
     });
     insert(renderRoot, renderPortal());
     mount.appendChild(container);


### PR DESCRIPTION
## Summary
make **host** property configurable, the host property is used by the internal solid event delegation logic.
making the host configurable

can open up the ability to:

1. stop internal event delegation from propagating 
2. redirect delegation/propagating to a different host



example for stopping bubbling (requires patch to work)
https://playground.solidjs.com/?hash=-2129189668&version=1.4.1