### PR TITLE
splitProps - make prop configurable by default (fix:#1301)

### DIFF
--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -247,7 +247,8 @@ export function splitProps<T, K extends [readonly (keyof T)[], ...(readonly (key
               },
               set() {
                 return true;
-              }
+              }, 
+              configurable: true
             }
       );
     }


### PR DESCRIPTION
## Summary
fix regression with the non-proxied implementation. (Introduced in 1.6)


consistency between when the props is provided or not.
https://playground.solidjs.com/?hash=-720374730&version=1.6.0

will also address the case of `splitProps` `mergeProps` #1301 
when working with default props setup.

