### PR TITLE
DEV: Add a way to observe stores

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -35,8 +35,8 @@ let rootCount = 0;
 const [transPending, setTransPending] = /*@__PURE__*/ createSignal(false);
 
 declare global {
-  var _$afterUpdate: () => void;
-  var _$afterCreateRoot: (root: Owner) => void;
+  var _$afterUpdate: (() => void) | undefined;
+  var _$afterCreateRoot: ((root: Owner) => void) | undefined;
 }
 
 export interface SignalState<T> {

--- a/packages/solid/store/src/index.ts
+++ b/packages/solid/store/src/index.ts
@@ -14,3 +14,7 @@ export type {
 } from "./store.js";
 export * from "./mutable.js";
 export * from "./modifiers.js";
+
+// dev
+import { $NAME, $NODE, $ON_UPDATE, isWrappable } from "./store.js";
+export const DEV = "_SOLID_DEV_" ? ({ $NAME, $NODE, $ON_UPDATE, isWrappable } as const) : undefined;

--- a/packages/solid/store/src/index.ts
+++ b/packages/solid/store/src/index.ts
@@ -16,5 +16,5 @@ export * from "./mutable.js";
 export * from "./modifiers.js";
 
 // dev
-import { $NAME, $NODE, $ON_UPDATE, isWrappable } from "./store.js";
-export const DEV = "_SOLID_DEV_" ? ({ $NAME, $NODE, $ON_UPDATE, isWrappable } as const) : undefined;
+import { $NAME, $NODE, isWrappable } from "./store.js";
+export const DEV = "_SOLID_DEV_" ? ({ $NAME, $NODE, isWrappable } as const) : undefined;

--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -117,7 +117,7 @@ export function reconcile<T extends U, U>(
   return state => {
     if (!isWrappable(state) || !isWrappable(v)) return v;
     const res = applyState(v, { [$ROOT]: state }, $ROOT, merge, key);
-    return res === undefined ? state as T : res as T;
+    return res === undefined ? (state as T) : res;
   };
 }
 
@@ -145,7 +145,7 @@ const setterTraps: ProxyHandler<StoreNode> = {
 };
 
 // Immer style mutation style
-export function produce<T>(fn: (state: T) => void): (state: T) => T {
+export function produce<T extends object>(fn: (state: T) => void): (state: T) => T {
   return state => {
     if (isWrappable(state)) {
       let proxy;

--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -145,14 +145,14 @@ const setterTraps: ProxyHandler<StoreNode> = {
 };
 
 // Immer style mutation style
-export function produce<T extends object>(fn: (state: T) => void): (state: T) => T {
+export function produce<T>(fn: (state: T) => void): (state: T) => T {
   return state => {
     if (isWrappable(state)) {
       let proxy;
       if (!(proxy = producers.get(state as Record<keyof T, T[keyof T]>))) {
         producers.set(
           state as Record<keyof T, T[keyof T]>,
-          (proxy = new Proxy(state, setterTraps))
+          (proxy = new Proxy(state as Extract<T, object>, setterTraps))
         );
       }
       fn(proxy);

--- a/packages/solid/store/src/server.ts
+++ b/packages/solid/store/src/server.ts
@@ -135,3 +135,5 @@ export function produce<T>(fn: (state: T) => void): (state: T) => T {
     return state;
   };
 }
+
+export const DEV = undefined;

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -1,9 +1,31 @@
-import { getListener, batch, DEV, $PROXY, $TRACK, Accessor, createSignal } from "solid-js";
+import { getListener, batch, DEV, $PROXY, $TRACK, createSignal } from "solid-js";
+
 export const $RAW = Symbol("store-raw"),
   $NODE = Symbol("store-node"),
-  $NAME = Symbol("store-name");
+  $NAME = Symbol("store-name"),
+  $ON_UPDATE = Symbol("store-on-update");
 
-export type StoreNode = Record<PropertyKey, any>;
+type DataNode = {
+  (): any;
+  $(value?: any): void;
+};
+type DataNodes = Record<PropertyKey, DataNode>;
+
+export type OnStoreNodeUpdate = (
+  state: StoreNode,
+  property: PropertyKey,
+  value: StoreNode | NotWrappable,
+  deleting: boolean
+) => void;
+export interface StoreNode {
+  [$ON_UPDATE]?: {
+    [Symbol.iterator](): IterableIterator<OnStoreNodeUpdate>;
+  };
+  [$NAME]?: string;
+  [$NODE]?: DataNodes;
+  [key: PropertyKey]: any;
+}
+
 export namespace SolidStore {
   export interface Unwrappable {}
 }
@@ -54,6 +76,17 @@ export function isWrappable(obj: any) {
   );
 }
 
+/**
+ * Returns the underlying data in the store without a proxy.
+ * @param item store proxy object
+ * @example
+ * ```js
+ * const initial = {}
+ * const [state, setState] = createStore(initial)
+ * console.log(initial == state) // false
+ * console.log(initial == unwrap(state)) // true
+ * ```
+ */
 export function unwrap<T>(item: T, set?: Set<unknown>): T;
 export function unwrap<T>(item: any, set = new Set()): T {
   let result, unwrapped, v, prop;
@@ -74,7 +107,7 @@ export function unwrap<T>(item: any, set = new Set()): T {
       desc = Object.getOwnPropertyDescriptors(item);
     for (let i = 0, l = keys.length; i < l; i++) {
       prop = keys[i];
-      if ((desc as any)[prop].get) continue;
+      if (desc[prop].get) continue;
       v = item[prop];
       if ((unwrapped = unwrap(v, set)) !== v) item[prop] = unwrapped;
     }
@@ -82,14 +115,14 @@ export function unwrap<T>(item: any, set = new Set()): T {
   return item;
 }
 
-export function getDataNodes(target: StoreNode) {
+export function getDataNodes(target: StoreNode): DataNodes {
   let nodes = target[$NODE];
   if (!nodes) Object.defineProperty(target, $NODE, { value: (nodes = {}) });
   return nodes;
 }
 
-export function getDataNode(nodes: Record<string, any>, property: string | symbol, value: any) {
-  return nodes[property as string] || (nodes[property as string] = createDataNode(value));
+export function getDataNode(nodes: DataNodes, property: PropertyKey, value: any) {
+  return nodes[property] || (nodes[property] = createDataNode(value));
 }
 
 export function proxyDescriptor(target: StoreNode, property: PropertyKey) {
@@ -126,8 +159,8 @@ function createDataNode(value?: any) {
     equals: false,
     internal: true
   });
-  (s as Accessor<any> & { $: (v: any) => void }).$ = set;
-  return s as Accessor<any> & { $: (v: any) => void };
+  (s as DataNode).$ = set;
+  return s as DataNode;
 }
 
 const proxyTraps: ProxyHandler<StoreNode> = {
@@ -193,6 +226,10 @@ export function setProperty(
   deleting: boolean = false
 ) {
   if (!deleting && state[property] === value) return;
+  if ("_SOLID_DEV_" && state[$ON_UPDATE]) {
+    for (const cb of state[$ON_UPDATE]) cb(state, property, value, deleting);
+  }
+
   const prev = state[property];
   const len = state.length;
   if (value === undefined) {
@@ -200,7 +237,7 @@ export function setProperty(
   } else state[property] = value;
   let nodes = getDataNodes(state),
     node;
-  if ((node = getDataNode(nodes, property as string, prev))) node.$(() => value);
+  if ((node = getDataNode(nodes, property, prev))) node.$(() => value);
 
   if (Array.isArray(state) && state.length !== len)
     (node = getDataNode(nodes, "length", len)) && node.$(state.length);

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -15,7 +15,7 @@ export type OnStoreNodeUpdate = (
   state: StoreNode,
   property: PropertyKey,
   value: StoreNode | NotWrappable,
-  deleting: boolean
+  prev: StoreNode | NotWrappable
 ) => void;
 export interface StoreNode {
   [$ON_UPDATE]?: {
@@ -224,19 +224,17 @@ export function setProperty(
   property: PropertyKey,
   value: any,
   deleting: boolean = false
-) {
+): void {
   if (!deleting && state[property] === value) return;
+  const prev = state[property],
+    len = state.length;
   if ("_SOLID_DEV_" && state[$ON_UPDATE]) {
-    for (const cb of state[$ON_UPDATE]) cb(state, property, value, deleting);
+    for (const cb of state[$ON_UPDATE]) cb(state, property, value, prev);
   }
-
-  const prev = state[property];
-  const len = state.length;
-  if (value === undefined) {
-    delete state[property];
-  } else state[property] = value;
+  if (value === undefined) delete state[property];
+  else state[property] = value;
   let nodes = getDataNodes(state),
-    node;
+    node: DataNode;
   if ((node = getDataNode(nodes, property, prev))) node.$(() => value);
 
   if (Array.isArray(state) && state.length !== len)

--- a/packages/solid/test/dev.spec.ts
+++ b/packages/solid/test/dev.spec.ts
@@ -9,7 +9,7 @@ import {
   Owner,
   createContext
 } from "../src";
-import { createStore } from "../store/src";
+import { createStore, unwrap } from "../store/src";
 
 describe("Dev features", () => {
   test("Reactive graph serialization", () => {
@@ -121,5 +121,18 @@ describe("Dev features", () => {
         expect(inner.owner).toBe(root);
       });
     });
+  });
+
+  test("OnStoreNodeUpdate Hook", () => {
+    const cb = jest.fn();
+    global._$onStoreNodeUpdate = cb;
+    const [s, set] = createStore({ firstName: "John", lastName: "Smith", inner: { foo: 1 } });
+    expect(cb).toHaveBeenCalledTimes(0);
+    set({ firstName: "Matt" });
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith(unwrap(s), "firstName", "Matt", "John");
+    set("inner", "foo", 2);
+    expect(cb).toHaveBeenCalledTimes(2);
+    expect(cb).toHaveBeenCalledWith(unwrap(s.inner), "foo", 2, 1);
   });
 });


### PR DESCRIPTION
- ~~Adds a dev-only ability to observe stores by adding a new `$ON_UPDATE` symbol.~~
- the dev APIs are bundled into a `DEV` object, as in the core module (not sure if it should be called `STORE_DEV` to avoid conflicts, but it's probably whatever)
- Some typings got cleaned up too (nothing in public APIs though)
- Added a jsdoc comment to `unwrap` because why not

~~Draft because I still want to confirm if this is enough, and maybe add some unit tests.~~