### PR TITLE
splitProps - mark undefined keys in non proxy splitting.

### DIFF
--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -212,7 +212,7 @@ export function mergeProps<T extends unknown[]>(...sources: T): MergeProps<T> {
     if (sources[i]) {
       const descriptors = Object.getOwnPropertyDescriptors(sources[i])
       for( let k in descriptors){
-          if((v[Undefined] && v[Undefined].has(k))){
+          if((sources[i][Undefined] && sources[i][Undefined].has(k))){
             delete descriptors[k]
           }
       }


### PR DESCRIPTION
mergeProps - skip undefined keys from splitProps.

- non proxy only. 
- splitProps, will track keys that were specified, but were not defined in the object, when splitting. 
- `mergeProps`, skip merging undefined marked keys (returned by `splitProps`)


alternative fix(pr): https://github.com/solidjs/solid/pull/1317

may fix(issue): https://github.com/solidjs/solid/issues/1316


only tested in patched playground