### PR TITLE
mergeProps wrap functional sources in a memo. #1321

### DIFF
--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -179,6 +179,7 @@ function resolveSource(s: any) {
 }
 
 export function mergeProps<T extends unknown[]>(...sources: T): MergeProps<T> {
+  sources = sources.map(source => typeof source === "function" ? createMemo(source) : source)
   if (sources.some(s => s && ($PROXY in (s as T) || typeof s === "function"))) {
     return new Proxy(
       {


### PR DESCRIPTION
wrap functional sources, provided to `mergeProps()` in a memo. 

```js
<div {...functionalSource} />
```

prevent "over calling" as shown in #1321, sources get evaluated 4 times on mounting alone.

The memo guards the result of the function, and ensure user provided function is only called once, until a reactive trigger.

Downsides:
1. create a memo for every function source (more memory, overhead)
2. double wrapping:  if a source function is already a memo it will be wrapped too. (solid does not provide a way to introspect its primitives, to prevent that)
 

fixes: #1321 
