### PR TITLE
Fill name option of some primitives in dev

### DIFF
--- a/packages/solid/src/reactive/array.ts
+++ b/packages/solid/src/reactive/array.ts
@@ -1,4 +1,12 @@
-import { onCleanup, createRoot, untrack, createSignal, Accessor, Setter, $TRACK } from "./signal.js";
+import {
+  onCleanup,
+  createRoot,
+  untrack,
+  createSignal,
+  Accessor,
+  Setter,
+  $TRACK
+} from "./signal.js";
 
 const FALLBACK = Symbol("fallback");
 function dispose(d: (() => void)[]) {
@@ -134,7 +142,7 @@ export function mapArray<T, U>(
     function mapper(disposer: () => void) {
       disposers[j] = disposer;
       if (indexes) {
-        const [s, set] = createSignal(j);
+        const [s, set] = "_SOLID_DEV_" ? createSignal(j, { name: "index" }) : createSignal(j);
         indexes[j] = set;
         return mapFn(newItems[j], s);
       }
@@ -210,7 +218,9 @@ export function indexArray<T, U>(
     });
     function mapper(disposer: () => void) {
       disposers[i] = disposer;
-      const [s, set] = createSignal(newItems[i]);
+      const [s, set] = "_SOLID_DEV_"
+        ? createSignal(newItems[i], { name: "value" })
+        : createSignal(newItems[i]);
       signals[i] = set;
       return mapFn(s, i);
     }

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1166,7 +1166,9 @@ export type ChildrenReturn = Accessor<ResolvedChildren> & { toArray: () => Resol
  */
 export function children(fn: Accessor<JSX.Element>): ChildrenReturn {
   const children = createMemo(fn);
-  const memo = createMemo(() => resolveChildren(children()));
+  const memo = "_SOLID_DEV_"
+    ? createMemo(() => resolveChildren(children()), undefined, { name: "children" })
+    : createMemo(() => resolveChildren(children()));
   (memo as ChildrenReturn).toArray = () => {
     const c = memo();
     return Array.isArray(c) ? c : c != null ? [c] : [];


### PR DESCRIPTION
`Show`, `For`, `children`, and other primitives are used frequently so it would be nice to see their internal names instead of autogenerated. Having these names would help in understanding their purpose and behavior.

![image](https://user-images.githubusercontent.com/24491503/202767725-f9e760d2-a8ba-4010-8475-fbdd4079a553.png)

vs

![image](https://user-images.githubusercontent.com/24491503/202768670-b837dc9f-1083-47fa-a9a0-2cf7a9e294a2.png)

Since the options object doesn't get tree-shaken out of the built application bundle, I included them only in dev, but it's hard to only target one output here without doing any changes to the other ...and avoid duplicating the source code too much.