### PR TITLE
fix: dont skip memo for cached lazy components

### DIFF
--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -306,9 +306,6 @@ export function lazy<T extends Component<any>>(
     } else if (!comp) {
       const [s] = createResource<T>(() => (p || (p = fn())).then(mod => mod.default));
       comp = s;
-    } else {
-      const c = comp();
-      if (c) return c(props);
     }
     let Comp: T | undefined;
     return createMemo(


### PR DESCRIPTION
## Summary
IS: If a lazy component was cached during previous renders, `lazy` currently skips the [createMemo](https://github.com/solidjs/solid/blob/e6e1d26b408eb3626bbad4b4f2899b8b6d363d07/packages/solid/src/render/component.ts#L314) code and instead just returns the cached component [L308](https://github.com/solidjs/solid/blob/e6e1d26b408eb3626bbad4b4f2899b8b6d363d07/packages/solid/src/render/component.ts#L308). This breaks HMR.
SHOULD: The `createMemo` code should run, even if the component is cached.

## How did you test this change?

I used a simple test setup with the code bellow and the official vite dev server (p.s the problem is also reproducable in solid-start)

Video before fix, broken HMR:

https://user-images.githubusercontent.com/4012401/206270134-cebe81cf-8c67-45c2-9f84-aaa543923e97.mp4

Video with fix, fixed HMR:

https://user-images.githubusercontent.com/4012401/206270426-2ec4665c-aec9-40ee-96dd-d7258044e115.mp4

P.S: i also successfully tested this fix in my solid-start project were the bug first happened on a more complex setup.

**Reproduction code**:

App.jsx
```jsx
import styles from './App.module.css';
import { createSignal, For, lazy } from 'solid-js';

const LazyBox = lazy(async () => (await import('./Box')))

function App() {
  const [boxes, setBoxes] = createSignal(['']);
  return (
    <div class={styles.App}>
      <header class={styles.header}>
        <button style={{ "margin-bottom": "50px"}}onClick={() => setBoxes([...boxes(), ''])}>Add box</button>
        <div style={{ "max-width": "900px", "flex-wrap": "wrap", display: "flex", gap: "10px" }}>
          <For each={boxes()}>
            {(box) => <LazyBox />}
          </For>
        </div>
      </header>
    </div>
  );
}

export default App;
```

Box.jsx
```jsx
const Box = () => {
  return (
    <div
      style={{
        "font-weight": "bold",
        color: "white",
        display: "flex",
        "align-items": "center",
        "justify-content": "center",
        "background-color": "blue",
        height: "100px",
        width: "100px",
      }}
    >
      hello world
    </div>
  );
};

export default Box;
```

## Writing a new test
Since the problem is related to HMR I am not 100% sure how to write a test for this fix 😅...
