### PR TITLE
fix mergeProps breaks with function source

### DIFF
--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -101,7 +101,9 @@ export function mergeProps(...sources: any): any {
           enumerable: true,
           get() {
             for (let i = sources.length - 1; i >= 0; i--) {
-              const v = (sources[i] || {})[key];
+              let s = (sources[i] || {});
+              if (typeof s === "function") s = s();
+              const v = s[key];
               if (v !== undefined) return v;
             }
           },


### PR DESCRIPTION
## Summary
When passing a function source into `mergeProps`, it broke it due to a change in v1.6.3. I fixed it.
Solves this issue https://github.com/solidjs/solid-start/issues/523

## How did you test this change?
I tested on a reproduction. I didn't write a test since there are no tests set up for ssr.