### PR TITLE
Typescript: disallow setting readonly store props

### DIFF
--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -380,20 +380,22 @@ type KeyOf<T> = number extends keyof T // have to check this otherwise ts won't 
 
 type MutableKeyOf<T> = KeyOf<T> & keyof PickMutable<T>;
 
-type Rest<T, U extends PropertyKey[], K extends KeyOf<T> = KeyOf<T>> =
-  K extends keyof PickMutable<T>
+// rest must specify at least one (additional) key, followed by a StoreSetter if the key is mutable.
+type Rest<
+  T,
+  U extends PropertyKey[],
+  K extends KeyOf<T> = KeyOf<T> 
+> = K extends keyof PickMutable<T>
   ? [Part<T, K>, ...RestSetterOrContinue<T[K], [K, ...U]>]
   : K extends KeyOf<K>
-    ? [Part<T, K>, ...RestContinue<T[K], [K, ...U]>]
-    : never;
+  ? [Part<T, K>, ...RestContinue<T[K], [K, ...U]>]
+  : never;
 
 type RestContinue<T, U extends PropertyKey[]> = 0 extends 1 & T
-    ? [...Part<any>[], StoreSetter<any, PropertyKey[]>]
-    : Rest<T, U>;
+  ? [...Part<any>[], StoreSetter<any, PropertyKey[]>]
+  : Rest<T, U>;
 
-type RestSetterOrContinue<T, U extends PropertyKey[]> =
-  | [StoreSetter<T, U>]
-  | RestContinue<T, U>
+type RestSetterOrContinue<T, U extends PropertyKey[]> = [StoreSetter<T, U>] | RestContinue<T, U>;
 
 export interface SetStoreFunction<T> {
   <
@@ -412,7 +414,10 @@ export interface SetStoreFunction<T> {
     k5: Part<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>, K5>,
     k6: Part<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>, K6>,
     k7: Part<W<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>[K6]>, K7>,
-    setter: StoreSetter<W<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>[K6]>[K7], [K7, K6, K5, K4, K3, K2, K1]>
+    setter: StoreSetter<
+      W<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>[K6]>[K7],
+      [K7, K6, K5, K4, K3, K2, K1]
+    >
   ): void;
   <
     K1 extends KeyOf<W<T>>,
@@ -420,7 +425,7 @@ export interface SetStoreFunction<T> {
     K3 extends KeyOf<W<W<W<T>[K1]>[K2]>>,
     K4 extends KeyOf<W<W<W<W<T>[K1]>[K2]>[K3]>>,
     K5 extends KeyOf<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>>,
-    K6 extends KeyOf<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>>,
+    K6 extends KeyOf<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>>
   >(
     k1: Part<W<T>, K1>,
     k2: Part<W<W<T>[K1]>, K2>,
@@ -456,7 +461,11 @@ export interface SetStoreFunction<T> {
     k4: Part<W<W<W<W<T>[K1]>[K2]>[K3]>, K4>,
     setter: StoreSetter<W<W<W<W<T>[K1]>[K2]>[K3]>[K4], [K4, K3, K2, K1]>
   ): void;
-  <K1 extends KeyOf<W<T>>, K2 extends KeyOf<W<W<T>[K1]>>, K3 extends MutableKeyOf<W<W<W<T>[K1]>[K2]>>>(
+  <
+    K1 extends KeyOf<W<T>>,
+    K2 extends KeyOf<W<W<T>[K1]>>,
+    K3 extends MutableKeyOf<W<W<W<T>[K1]>[K2]>>
+  >(
     k1: Part<W<T>, K1>,
     k2: Part<W<W<T>[K1]>, K2>,
     k3: Part<W<W<W<T>[K1]>[K2]>, K3>,
@@ -477,7 +486,7 @@ export interface SetStoreFunction<T> {
     K4 extends KeyOf<W<W<W<W<T>[K1]>[K2]>[K3]>>,
     K5 extends KeyOf<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>>,
     K6 extends KeyOf<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>>,
-    K7 extends KeyOf<W<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>[K6]>>,
+    K7 extends KeyOf<W<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>[K6]>>
   >(
     k1: Part<W<T>, K1>,
     k2: Part<W<W<T>[K1]>, K2>,

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -340,14 +340,26 @@ export type CustomPartial<T> = T extends readonly unknown[]
     : { [x: number]: T[number] }
   : Partial<T>;
 
+export type PickMutable<T> = {
+  [K in keyof T as (
+    <U>() => U extends { [V in K]: T[V] } ? 1 : 2) extends 
+    <U>() => U extends { -readonly [V in K]: T[V]; } ? 1 : 2
+  ? K : never ]: T[K] 
+};
+
 export type StorePathRange = { from?: number; to?: number; by?: number };
 
 export type ArrayFilterFn<T> = (item: T, index: number) => boolean;
 
+export type PropStoreSetter<T, K extends keyof T, U extends PropertyKey[] = []> =
+  Extract<K, keyof T> extends keyof PickMutable<T>
+    ? StoreSetter<T[K],U>
+    : never;
+
 export type StoreSetter<T, U extends PropertyKey[] = []> =
-  | ((prevState: T, traversed: U) => T | CustomPartial<T>)
   | T
-  | CustomPartial<T>;
+  | CustomPartial<T>
+  | ((prevState: T, traversed: U) => T | CustomPartial<T>)
 
 export type Part<T, K extends KeyOf<T> = KeyOf<T>> =
   | K
@@ -413,7 +425,7 @@ export interface SetStoreFunction<T> {
     k4: Part<W<W<W<W<T>[K1]>[K2]>[K3]>, K4>,
     k5: Part<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>, K5>,
     k6: Part<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>, K6>,
-    setter: StoreSetter<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>[K6], [K6, K5, K4, K3, K2, K1]>
+    setter: PropStoreSetter<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>, K6, [K6, K5, K4, K3, K2, K1]>
   ): void;
   <
     K1 extends KeyOf<W<T>>,
@@ -427,7 +439,7 @@ export interface SetStoreFunction<T> {
     k3: Part<W<W<W<T>[K1]>[K2]>, K3>,
     k4: Part<W<W<W<W<T>[K1]>[K2]>[K3]>, K4>,
     k5: Part<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>, K5>,
-    setter: StoreSetter<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5], [K5, K4, K3, K2, K1]>
+    setter: PropStoreSetter<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>, K5, [K5, K4, K3, K2, K1]>
   ): void;
   <
     K1 extends KeyOf<W<T>>,
@@ -439,21 +451,21 @@ export interface SetStoreFunction<T> {
     k2: Part<W<W<T>[K1]>, K2>,
     k3: Part<W<W<W<T>[K1]>[K2]>, K3>,
     k4: Part<W<W<W<W<T>[K1]>[K2]>[K3]>, K4>,
-    setter: StoreSetter<W<W<W<W<T>[K1]>[K2]>[K3]>[K4], [K4, K3, K2, K1]>
+    setter: PropStoreSetter<W<W<W<W<T>[K1]>[K2]>[K3]>, K4, [K4, K3, K2, K1]>
   ): void;
   <K1 extends KeyOf<W<T>>, K2 extends KeyOf<W<W<T>[K1]>>, K3 extends KeyOf<W<W<W<T>[K1]>[K2]>>>(
     k1: Part<W<T>, K1>,
     k2: Part<W<W<T>[K1]>, K2>,
     k3: Part<W<W<W<T>[K1]>[K2]>, K3>,
-    setter: StoreSetter<W<W<W<T>[K1]>[K2]>[K3], [K3, K2, K1]>
+    setter: PropStoreSetter<W<W<W<T>[K1]>[K2]>, K3, [K3, K2, K1]>
   ): void;
   <K1 extends KeyOf<W<T>>, K2 extends KeyOf<W<W<T>[K1]>>>(
     k1: Part<W<T>, K1>,
     k2: Part<W<W<T>[K1]>, K2>,
-    setter: StoreSetter<W<W<T>[K1]>[K2], [K2, K1]>
+    setter: PropStoreSetter<W<W<T>[K1]>, K2, [K2, K1]>
   ): void;
-  <K1 extends KeyOf<W<T>>>(k1: Part<W<T>, K1>, setter: StoreSetter<W<T>[K1], [K1]>): void;
-  (setter: StoreSetter<T, []>): void;
+  <K1 extends KeyOf<W<T>>>(k1: Part<W<T>, K1>, setter: PropStoreSetter<W<T>, K1, [K1]>): void;
+  (setter: PropStoreSetter<[T], 0, []>): void;
 }
 
 /**

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -341,25 +341,30 @@ export type CustomPartial<T> = T extends readonly unknown[]
   : Partial<T>;
 
 export type PickMutable<T> = {
-  [K in keyof T as (
-    <U>() => U extends { [V in K]: T[V] } ? 1 : 2) extends 
-    <U>() => U extends { -readonly [V in K]: T[V]; } ? 1 : 2
-  ? K : never ]: T[K] 
+  [K in keyof T as (<U>() => U extends { [V in K]: T[V] } ? 1 : 2) extends <U>() => U extends {
+    -readonly [V in K]: T[V];
+  }
+    ? 1
+    : 2
+    ? K
+    : never]: T[K];
 };
 
 export type StorePathRange = { from?: number; to?: number; by?: number };
 
 export type ArrayFilterFn<T> = (item: T, index: number) => boolean;
 
-export type PropStoreSetter<T, K extends keyof T, U extends PropertyKey[] = []> =
-  Extract<K, keyof T> extends keyof PickMutable<T>
-    ? StoreSetter<T[K],U>
-    : never;
+export type PropStoreSetter<T, K extends keyof T, U extends PropertyKey[] = []> = Extract<
+  K,
+  keyof T
+> extends keyof PickMutable<T>
+  ? StoreSetter<T[K], U>
+  : never;
 
 export type StoreSetter<T, U extends PropertyKey[] = []> =
   | T
   | CustomPartial<T>
-  | ((prevState: T, traversed: U) => T | CustomPartial<T>)
+  | ((prevState: T, traversed: U) => T | CustomPartial<T>);
 
 export type Part<T, K extends KeyOf<T> = KeyOf<T>> =
   | K

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -743,22 +743,30 @@ describe("Nested Classes", () => {
 
 // Cannot update readonly keys
 () => {
-  const [, setStore] = createStore({
-    get i() {
-      return 1;
-    },
-    j: {
-      get k() {
-        return 1;
-      }
-    }
-  });
+  const [, setK1] = createStore({ get i() { return 1; }});
   // @ts-expect-error i is readonly
-  setStore("i", 3);
-  // TODO @ts-expect-error i is readonly
-  setStore({ i: 3 });
-  // TODO @ts-expect-error k is readonly
-  setStore("j", { k: 3 });
+  setK1("i", 2);
+  const [, setK2] = createStore({ i: { get j() { return 1; }}});
+  // @ts-expect-error j is readonly
+  setK2("i", "j", 3);
+  const [, setK3] = createStore({ i: { j: { get k() { return 1; }}}});
+  // @ts-expect-error k is readonly
+  setK3("i", "j", "k", 4);
+  const [, setK4] = createStore({ i: { j: { k: { get l() { return 1; }}}}});
+  // @ts-expect-error l is readonly
+  setK4("i", "j", "k", "l", 5);
+  const [, setK5] = createStore({ i: { j: { k: { l: { get m() { return 1; }}}}}});
+  // @ts-expect-error m is readonly
+  setK5("i", "j", "k", "l", "m", 6);
+  const [, setK6] = createStore({ i: { j: { k: { l: { m: { get n() { return 1; }}}}}}});
+  // TODO @ts-expect-error n is readonly, nesting too deep?
+  setK6("i", "j", "k", "l", "m", "n", 7);
+  const [, setK7] = createStore({ i: { j: { k: { l: { m: { n: { get o() { return 1; }}}}}}}});
+  // @ts-expect-error o is readonly, but has unreadable error due to method overloading
+  setK7("i", "j", "k", "l", "m", "n", "o", 8);
+  const [, setKn] = createStore({ i: { j: { k: { l: { m: { n: { o: { get p() { return 1; }}}}}}}}});
+  // @ts-expect-error p is readonly
+  setKn("i", "j", "k", "l", "m", "n", "o", "p", 9);
 };
 
 // keys are narrowed

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -743,14 +743,23 @@ describe("Nested Classes", () => {
 
 // Cannot update readonly keys
 () => {
-  const [, setStore] = createStore({ get i() { return 1 }, j: { get k() { return 1 }}});
+  const [, setStore] = createStore({
+    get i() {
+      return 1;
+    },
+    j: {
+      get k() {
+        return 1;
+      }
+    }
+  });
   // @ts-expect-error i is readonly
-  setStore('i', 3);
+  setStore("i", 3);
   // TODO @ts-expect-error i is readonly
-  setStore({ i : 3 });
+  setStore({ i: 3 });
   // TODO @ts-expect-error k is readonly
-  setStore('j', { k: 3 });
-}
+  setStore("j", { k: 3 });
+};
 
 // keys are narrowed
 () => {

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -741,6 +741,17 @@ describe("Nested Classes", () => {
   setStore("a", "b", "c", "d", "e", "f", "g", "h");
 };
 
+// Cannot update readonly keys
+() => {
+  const [, setStore] = createStore({ get i() { return 1 }, j: { get k() { return 1 }}});
+  // @ts-expect-error i is readonly
+  setStore('i', 3);
+  // TODO @ts-expect-error i is readonly
+  setStore({ i : 3 });
+  // TODO @ts-expect-error k is readonly
+  setStore('j', { k: 3 });
+}
+
 // keys are narrowed
 () => {
   const [store, setStore] = createStore({ a: { b: 1 }, c: { d: 2 } });

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -743,28 +743,32 @@ describe("Nested Classes", () => {
 
 // Cannot update readonly keys
 () => {
-  const [, setK1] = createStore({ get i() { return 1; }});
+  const [, setK1] = createStore({} as { readonly i: number });
   // @ts-expect-error i is readonly
   setK1("i", 2);
-  const [, setK2] = createStore({ i: { get j() { return 1; }}});
+  const [, setK2] = createStore({} as { i: { readonly j: number } });
   // @ts-expect-error j is readonly
   setK2("i", "j", 3);
-  const [, setK3] = createStore({ i: { j: { get k() { return 1; }}}});
+  const [, setK3] = createStore({} as { i: { j: { readonly k: number } } });
   // @ts-expect-error k is readonly
   setK3("i", "j", "k", 4);
-  const [, setK4] = createStore({ i: { j: { k: { get l() { return 1; }}}}});
+  const [, setK4] = createStore({} as { i: { j: { k: { readonly l: number } } } });
   // @ts-expect-error l is readonly
   setK4("i", "j", "k", "l", 5);
-  const [, setK5] = createStore({ i: { j: { k: { l: { get m() { return 1; }}}}}});
+  const [, setK5] = createStore({} as { i: { j: { k: { l: { readonly m: number } } } } });
   // @ts-expect-error m is readonly
   setK5("i", "j", "k", "l", "m", 6);
-  const [, setK6] = createStore({ i: { j: { k: { l: { m: { get n() { return 1; }}}}}}});
+  const [, setK6] = createStore({} as { i: { j: { k: { l: { m: { readonly n: number } } } } } });
   // TODO @ts-expect-error n is readonly, nesting too deep?
   setK6("i", "j", "k", "l", "m", "n", 7);
-  const [, setK7] = createStore({ i: { j: { k: { l: { m: { n: { get o() { return 1; }}}}}}}});
+  const [, setK7] = createStore(
+    {} as { i: { j: { k: { l: { m: { n: { readonly o: number } } } } } } }
+  );
   // @ts-expect-error o is readonly, but has unreadable error due to method overloading
   setK7("i", "j", "k", "l", "m", "n", "o", 8);
-  const [, setKn] = createStore({ i: { j: { k: { l: { m: { n: { o: { get p() { return 1; }}}}}}}}});
+  const [, setKn] = createStore(
+    {} as { i: { j: { k: { l: { m: { n: { o: { readonly p: number } } } } } } } }
+  );
   // @ts-expect-error p is readonly
   setKn("i", "j", "k", "l", "m", "n", "o", "p", 9);
 };


### PR DESCRIPTION
## Summary

Resolves (part of) the issue posed in #1359. Limits store setters to non-readonly properties in the store. This fix only addresses usage of the store setter by path (`setStore("a", "b", value)`). Setting by object (`setStore({ a: { b: value }})`) cannot be checked without impact.

If we would type check setting by object, setters like `setStore("el", {} as Element)` would stop working because the `Element` interface contains readonly props.

## How did you test this change?

I added a test for a store setter by path and two TODO's which address the remaining issue when setting by object.

```bash
packages/solid $ pnpm test
> Test Suites: 23 passed, 23 total
> Tests:       378 passed, 378 total
> Snapshots:   0 total
> Time:        14.132 s
> Ran all test suites.
```