### PR TITLE
Format/Cleanup

### DIFF
--- a/.changeset/giant-peas-exercise.md
+++ b/.changeset/giant-peas-exercise.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Format/Cleanup Types and code style

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -1,56 +1,60 @@
 export {
-  createRoot,
-  createSignal,
-  createEffect,
-  createRenderEffect,
-  createComputed,
-  createReaction,
-  createDeferred,
-  createSelector,
-  createMemo,
-  createResource,
-  onMount,
-  onCleanup,
-  onError,
-  untrack,
-  batch,
-  on,
-  enableScheduling,
-  enableExternalSource,
-  startTransition,
-  useTransition,
-  createContext,
-  useContext,
-  children,
-  getListener,
-  getOwner,
-  runWithOwner,
-  equalFn,
   $DEVCOMP,
   $PROXY,
-  $TRACK
+  $TRACK,
+  batch,
+  children,
+  createComputed,
+  createContext,
+  createDeferred,
+  createEffect,
+  createMemo,
+  createReaction,
+  createRenderEffect,
+  createResource,
+  createRoot,
+  createSelector,
+  createSignal,
+  enableExternalSource,
+  enableScheduling,
+  equalFn,
+  getListener,
+  getOwner,
+  on,
+  onCleanup,
+  onError,
+  onMount,
+  runWithOwner,
+  startTransition,
+  untrack,
+  useContext,
+  useTransition
 } from "./reactive/signal.js";
 export type {
   Accessor,
-  Setter,
-  Signal,
-  SignalOptions,
-  Resource,
-  ResourceActions,
-  ResourceSource,
-  ResourceOptions,
-  ResourceReturn,
-  ResourceFetcher,
-  ResourceFetcherInfo,
+  AccessorArray,
   ChildrenReturn,
   Context,
-  ReturnTypes,
-  Owner,
+  EffectFunction,
   InitializedResource,
   InitializedResourceOptions,
-  InitializedResourceReturn
+  InitializedResourceReturn,
+  MemoOptions,
+  NoInfer,
+  OnEffectFunction,
+  Owner,
+  Resource,
+  ResourceActions,
+  ResourceFetcher,
+  ResourceFetcherInfo,
+  ResourceOptions,
+  ResourceReturn,
+  ResourceSource,
+  ReturnTypes,
+  Setter,
+  Signal,
+  SignalOptions
 } from "./reactive/signal.js";
-
 
 export * from "./reactive/observable.js";
 export * from "./reactive/scheduler.js";
@@ -62,7 +66,7 @@ type JSXElement = JSX.Element;
 export type { JSXElement, JSX };
 
 // dev
-import { writeSignal, serializeGraph, registerGraph, hashValue } from "./reactive/signal.js";
+import { hashValue, registerGraph, serializeGraph, writeSignal } from "./reactive/signal.js";
 let DEV: {
   writeSignal: typeof writeSignal;
   serializeGraph: typeof serializeGraph;

--- a/packages/solid/src/reactive/observable.ts
+++ b/packages/solid/src/reactive/observable.ts
@@ -1,4 +1,13 @@
-import { Accessor, createEffect, createRoot, createSignal, getOwner, onCleanup, Setter, Signal, untrack } from "./signal.js";
+import {
+  Accessor,
+  createEffect,
+  createRoot,
+  createSignal,
+  getOwner,
+  onCleanup,
+  Setter,
+  untrack
+} from "./signal.js";
 
 // Note: This will add Symbol.observable globally for all TypeScript users,
 // however, we are not polyfilling Symbol.observable. Ensuring the type for
@@ -13,10 +22,10 @@ declare global {
 export type ObservableObserver<T> =
   | ((v: T) => void)
   | {
-    next?: (v: T) => void;
-    error?: (v: any) => void;
-    complete?: (v: boolean) => void;
-  };
+      next?: (v: T) => void;
+      error?: (v: any) => void;
+      complete?: (v: boolean) => void;
+    };
 /**
  * creates a simple observable from a signal's accessor to be used with the `from` operator of observable libraries like e.g. rxjs
  * ```typescript
@@ -34,22 +43,21 @@ export function observable<T>(input: Accessor<T>) {
         throw new TypeError("Expected the observer to be an object.");
       }
 
-      const handler = typeof observer === 'function'
-        ? observer
-        : observer.next && observer.next.bind(observer);
+      const handler =
+        typeof observer === "function" ? observer : observer.next && observer.next.bind(observer);
 
       if (!handler) {
-        return { unsubscribe() { } };
+        return { unsubscribe() {} };
       }
 
-      const dispose = createRoot((disposer) => {
+      const dispose = createRoot(disposer => {
         createEffect(() => {
           const v = input();
           untrack(() => handler(v));
         });
 
         return disposer;
-      })
+      });
 
       if (getOwner()) onCleanup(dispose);
 
@@ -69,13 +77,15 @@ export function observable<T>(input: Accessor<T>) {
   };
 }
 
-export function from<T>(producer: ((setter: Setter<T | undefined>) => () => void) | {
-  subscribe: (fn: (v: T) => void) => (() => void) | { unsubscribe: () => void };
-}): Accessor<T | undefined> {
+export function from<T>(
+  producer:
+    | ((setter: Setter<T | undefined>) => () => void)
+    | { subscribe: (fn: (v: T) => void) => (() => void) | { unsubscribe: () => void } }
+): Accessor<T | undefined> {
   const [s, set] = createSignal<T | undefined>(undefined, { equals: false });
   if ("subscribe" in producer) {
-    const unsub = producer.subscribe((v) => set(() => v));
-    onCleanup(() => "unsubscribe" in unsub ? unsub.unsubscribe() : unsub())
+    const unsub = producer.subscribe(v => set(() => v));
+    onCleanup(() => ("unsubscribe" in unsub ? unsub.unsubscribe() : unsub()));
   } else {
     const clean = producer(set);
     onCleanup(clean);

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -53,10 +53,9 @@ function wrap<T extends StoreNode>(value: T, name?: string): T {
       for (let i = 0, l = keys.length; i < l; i++) {
         const prop = keys[i];
         if (desc[prop].get) {
-          const get = desc[prop].get!.bind(p);
           Object.defineProperty(value, prop, {
             enumerable: desc[prop].enumerable,
-            get
+            get: desc[prop].get!.bind(p)
           });
         }
       }


### PR DESCRIPTION
- Organize exports (alphabetically)
- export not exported types from signal.ts (`AccessorArray`, `EffectFunction`, `MemoOptions`, `NoInfer`, `OnEffectFunction`)
- Format observable.ts
- abstract `ComputationState` type in signal.ts
- inline `get` of defined property in store.ts