### PR TITLE
Fix unowned roots having owner in dev

### DIFF
--- a/.changeset/khaki-ducks-yawn.md
+++ b/.changeset/khaki-ducks-yawn.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Fix unowned roots having owner in dev

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -108,10 +108,11 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: Owner): T {
   const listener = Listener,
     owner = Owner,
     unowned = fn.length === 0,
-    root: Owner =
-      unowned && !"_SOLID_DEV_"
-        ? UNOWNED
-        : { owned: null, cleanups: null, context: null, owner: detachedOwner || owner },
+    root: Owner = unowned
+      ? "_SOLID_DEV_"
+        ? { owned: null, cleanups: null, context: null, owner: null }
+        : UNOWNED
+      : { owned: null, cleanups: null, context: null, owner: detachedOwner || owner },
     updateFn = unowned
       ? "_SOLID_DEV_"
         ? () =>

--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -17,7 +17,7 @@ import {
   createContext,
   useContext,
   getOwner,
-  runWithOwner,
+  runWithOwner
 } from "../src";
 
 import "./MessageChannel";
@@ -305,7 +305,6 @@ describe("Effect grouping of signals", () => {
         try {
           setA(1);
           throw new Error("test");
-          setB(1);
         } catch (e) {
           error = e as Error;
         }
@@ -657,6 +656,22 @@ describe("create and use context", () => {
     const context = createContext<number>();
     const res = useContext(context);
     expect(res).toBe<typeof res>(undefined);
+  });
+});
+
+describe("createRoot", () => {
+  test("roots with dispose function unused are unowned", () => {
+    createRoot(_ => {
+      const root1 = getOwner()!;
+      createRoot(_ => {
+        const root2 = getOwner()!;
+        createRoot(() => {
+          const root3 = getOwner()!;
+          expect(root2.owner).toBe(root1);
+          expect(root3.owner).toBe(null);
+        });
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Suppose you don't provide a callback parameter for the dispose function when using `createRoot`. In that case, it should create an "unowned" (top-level) root that has no owner so there is no way to get the context from the owner it was theoretically called under.
But in development, a new owner is created every time. The UNOWNED owner is never used.

[So in dev it'll have access to context](https://playground.solidjs.com/anonymous/1ae21915-a79b-4177-9c0a-035d15fea029)

[While in prod it doesn't](https://solid-playground.netlify.app/?version=1.6.2#NobwRAdghgtgpmAXGGUCWEwBowBcCeADgsrgM4Ae2YZA9gK4BOAxiWGjIbY7gAQi9GcCABM4jXgF9eAM0a0YvADo1aAGzQiAtACsyAegDucAEYqA3EogcuPfr2ZCouOAGFaEFxVxYHTlwBKtLQ+vPSejFDMANa+9GRuHl580nIKyqoa2noWVlYy4cy4aB68ALLoEAAUAJT8VrwOHmR8rrgUvAC8fnDOiZ5w3gA8UBD4AHxVKsxJg3wyUGpqJlHRKjWWEA2CcLhMELxTB428Q20UAHQACvIAbprivLeL9HCdKmmKMwPeKuPbJ344VwkRiVVqXXG9WOgMa3zoajgFzUtAA5lMwABGC4qOIJdw-XBVc41DZ5GGwxy9QLBIlVAD6dU6UJAANhcOa6iRKPRKgATDjsGF8bNvMT2qTNuzGpIyVsKYCqX0giFwUyWWz2fCuci0RiAMyCvH9ZLiiiSzUnWWbS2NIR7RgHFS5BVSGqSNlDfTna53B6Mf7HOUe+VCUTiNWQ04VDC8fTjXwiWjMejwTwXVG7ACiiLTuAAQvgAJIiDFQQiEdYAQjlYEkAF0gA) (browser console needs to be opened)