### PR TITLE
Add generic to onCleanup

### DIFF
--- a/.changeset/fast-ligers-argue.md
+++ b/.changeset/fast-ligers-argue.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Add generic to onCleanup

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -921,9 +921,11 @@ export function onMount(fn: () => void) {
  * onCleanup - run an effect once before the reactive scope is disposed
  * @param fn an effect that should run only once on cleanup
  *
+ * @returns the same {@link fn} function that was passed in
+ *
  * @description https://www.solidjs.com/docs/latest/api#oncleanup
  */
-export function onCleanup(fn: () => void) {
+export function onCleanup<T extends () => any>(fn: T): T {
   if (Owner === null)
     "_SOLID_DEV_" &&
       console.warn("cleanups created outside a `createRoot` or `render` will never be run");


### PR DESCRIPTION
I think that the types for `onCleanup` could be better.
Since it returns the `fn` param as is, a generic could be used to keep the type of its return value.

```ts
const cleanup = () => 123

// before
onCleanup(cleanup) // T: () => void

// after
onCleanup(cleanup) // T: () => number
```

Probably has almost no value, but it's "more correct" 🤷‍♂️

But it could make it a little bit clearer that the returned function is the one passed in, and not a function to unsubscribe from the cleanup as it is also a common API pattern