### PR TITLE
Fixed the return type of the `Symbol.observable` method in the generated `.d.ts`

### DIFF
--- a/.changeset/small-pianos-marry.md
+++ b/.changeset/small-pianos-marry.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Fixed the return type of the `Symbol.observable` method of the `observable` in the generated `.d.ts`

--- a/packages/solid/src/reactive/observable.ts
+++ b/packages/solid/src/reactive/observable.ts
@@ -19,6 +19,13 @@ declare global {
   }
 }
 
+interface Observable<T> {
+  subscribe(observer: ObservableObserver<T>): {
+    unsubscribe(): void;
+  };
+  [Symbol.observable](): Observable<T>;
+}
+
 export type ObservableObserver<T> =
   | ((v: T) => void)
   | {
@@ -36,7 +43,7 @@ export type ObservableObserver<T> =
  * ```
  * description https://www.solidjs.com/docs/latest/api#observable
  */
-export function observable<T>(input: Accessor<T>) {
+export function observable<T>(input: Accessor<T>): Observable<T> {
   return {
     subscribe(observer: ObservableObserver<T>) {
       if (!(observer instanceof Object) || observer == null) {


### PR DESCRIPTION
Notice how the return type in the generated `.d.ts` is currently just `any`:
```ts
export declare function observable<T>(input: Accessor<T>): {
    subscribe(observer: ObservableObserver<T>): {
        unsubscribe(): void;
    };
    [Symbol.observable](): any;
};
```
You can verify this easily and quickly here: https://unpkg.com/browse/solid-js@1.6.9/types/reactive/observable.d.ts#L26

It seems that TS can't emit the computed type when it depends on the `this` outside of the class context and when `this` refers to an "anonymous type". You can verify this in this [TS playground](https://www.typescriptlang.org/play?ts=4.9.4#code/C4TwDgpgBAggxnCBnJB7ATgHgCoD4oC8UAFAJSH7YDcAUDQCYRwA2AhutAObOoBGrzKAG8aUKAEsAdsAjoAZq0RQAyiAC2vVMwDCqSUmDoArnGAZhosVA6t6e5iCh8ksgG6tezCAC4oSdZrMtGIAvjRhNBAAHmAYwFByRpKm4npOvC7o7p4QOLjEUmBGwL7wiCgYeeQiYnB6BulIhBZWfkYZcOjivBDEzm6yvkJtHV09vsRwvBOS0SVQ2OQE+K6o4vRL+GQUUKvrUCHVlq0cwEboki2tVklI7Uid3b3VIQA0x1YhwZ-vrQDaxFUGi0ADp+lkPF4oAAfaFQABEAAFEeDsl54eRWE1QJBUHIVAFQajIRAALrbGrXU7nS7AAAW4iaWKgOIgeMa31CvysSHEajAXmwyGAFI+YmpFxZDKQHzCoW+EsuzloYSAA) in the ".D.TS" tab. It's a TypeScript issue - I didn't have time to look if it's already reported though, I might do that later.

Note that within the package itself when TS sees the source files the type of this property is correct. It's purely an issue with the declaration emit.

By adding an explicit type declaration for this we enable the correct declaration emit. I confirmed this locally:
```ts
export declare function observable<T>(input: Accessor<T>): Observable<T>;
```