### PR TITLE
(WIP) add importsNotUsedAsValues:error to tsconfig, fix resulting code errors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "newLine": "LF",
     "moduleResolution": "node",
     "strict": true,
+    "importsNotUsedAsValues": "error",
     "jsx": "preserve"
   },
   "exclude": ["node_modules"]


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

Solid leaves type imports behind, causing some systems to try to import non-existing things at runtime.

This relates to the node vs web structure. The app in question `import`s `lume`, which `import`s `solid-js/html`, etc, however does not use these APIs on the backend, only on the client.

The workaround for the app is to use `await import('lume')` in client-side code, so it is ignored in SvelteKit pre-rendering.

Here's a sample error:

```
file:///Users/trusktr/src/project/node_modules/.pnpm/solid-js@1.4.8/node_modules/solid-js/html/dist/html.js:1
import { effect, style, insert, spread, createComponent, delegateEvents, classList, mergeProps, dynamicProperty, setAttribute, setAttributeNS, addEventListener, Aliases, PropAliases, Properties, ChildProperties, DelegatedEvents, SVGElements, SVGNamespace } from 'solid-js/web';
                                                                                                                                                                 ^^^^^^^
SyntaxError: The requested module 'solid-js/web' does not provide an export named 'Aliases'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:190:5)
SyntaxError: The requested module 'solid-js/web' does not provide an export named 'Aliases'
file:///Users/trusktr/src/project/node_modules/.pnpm/@sveltejs+kit@1.0.0-next.438_svelte@3.55.1+vite@3.0.9/node_modules/@sveltejs/kit/src/core/prerender/prerender.js:50
                                throw new Error(format_error(details, config));
                                      ^

Error: 500 /
    at file:///Users/trusktr/src/project/node_modules/.pnpm/@sveltejs+kit@1.0.0-next.438_svelte@3.55.1+vite@3.0.9/node_modules/@sveltejs/kit/src/core/prerender/prerender.js:50:11
    at save (file:///Users/trusktr/src/project/node_modules/.pnpm/@sveltejs+kit@1.0.0-next.438_svelte@3.55.1+vite@3.0.9/node_modules/@sveltejs/kit/src/core/prerender/prerender.js:339:4)
    at visit (file:///Users/trusktr/src/project/node_modules/.pnpm/@sveltejs+kit@1.0.0-next.438_svelte@3.55.1+vite@3.0.9/node_modules/@sveltejs/kit/src/core/prerender/prerender.js:226:3)
```

## How did you test this change?

Not done yet, need to test and update code