### PR TITLE
fix #1493 export DynamicProps

### DIFF
--- a/.changeset/eight-experts-sell.md
+++ b/.changeset/eight-experts-sell.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+fix #1493 export DynamicProps

--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -101,7 +101,9 @@ export function Portal<T extends boolean = false, S extends boolean = false>(pro
   return marker;
 }
 
-type DynamicProps<T extends ValidComponent, P = ComponentProps<T>> = { [K in keyof P]: P[K] } & {
+export type DynamicProps<T extends ValidComponent, P = ComponentProps<T>> = {
+  [K in keyof P]: P[K];
+} & {
   component: T | undefined;
 };
 /**


### PR DESCRIPTION
## Summary

Fixes #1493 - exports `DynamicProps` TypeScript type definition.

## How did you test this change?

I tested locally.  An extra test felt excessive for such a minor change, but I'm happy to add one if desired.
