### PR TITLE
fix: `<Show keyed>` with a function child not keyed when the function does not have an argument

### DIFF
--- a/.changeset/modern-readers-applaud.md
+++ b/.changeset/modern-readers-applaud.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Fix skipped rerun of a child function of `Show` component when it doesn't a parameter.

--- a/packages/solid/src/render/flow.ts
+++ b/packages/solid/src/render/flow.ts
@@ -108,7 +108,7 @@ export function Show<T>(props: {
       const c = condition();
       if (c) {
         const child = props.children;
-        const fn = typeof child === "function" && child.length > 0;
+        const fn = typeof child === "function";
         strictEqual = keyed || fn;
         return fn ? untrack(() => (child as any)(c as T)) : child;
       }


### PR DESCRIPTION
## Summary

Fix #1508

## How did you test this change?

No tests added as I don't think this needs tests, but LMK if otherwise