### PR TITLE
Fix `runWithOwner` breaking change

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -967,8 +967,6 @@ export function runWithOwner<T>(o: Owner, fn: () => T): T | undefined {
   Listener = null;
   try {
     return runUpdates(fn, true)!;
-  } catch (err) {
-    handleError(err);
   } finally {
     Owner = prev;
     Listener = prevListener;

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1482,7 +1482,13 @@ function runTop(node: Computation<any>) {
 }
 
 function runUpdates<T>(fn: () => T, init: boolean) {
-  if (Updates) return fn();
+  if (Updates) {
+    try {
+      return fn();
+    } catch (error) {
+      handleError(error);
+    }
+  }
   let wait = false;
   if (!init) Updates = [];
   if (Effects) wait = true;

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -960,13 +960,13 @@ export function getOwner() {
   return Owner;
 }
 
-export function runWithOwner<T>(o: Owner, fn: () => T): T | undefined {
+export function runWithOwner<T>(o: typeof Owner, fn: () => T): T {
   const prev = Owner;
   const prevListener = Listener;
   Owner = o;
   Listener = null;
   try {
-    return runUpdates(fn, true)!;
+    return fn();
   } finally {
     Owner = prev;
     Listener = prevListener;

--- a/packages/solid/src/server/reactive.ts
+++ b/packages/solid/src/server/reactive.ts
@@ -194,8 +194,6 @@ export function runWithOwner<T>(o: Owner, fn: () => T): T | undefined {
   Owner = o;
   try {
     return fn();
-  } catch (err) {
-    handleError(err);
   } finally {
     Owner = prev;
   }

--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -690,18 +690,37 @@ describe("createRoot", () => {
 });
 
 describe("runWithOwner", () => {
-  test("Top level owner execute and disposal", () => {
+  test("Top level run immediately executes effects", () => {
     let effectRun = false;
     let cleanupRun = false;
     const [owner, dispose] = createRoot(dispose => {
       return [getOwner()!, dispose];
     });
-
     runWithOwner(owner, () => {
       createEffect(() => (effectRun = true));
       onCleanup(() => (cleanupRun = true));
-      expect(effectRun).toBe(false);
+      expect(effectRun).toBe(true);
       expect(cleanupRun).toBe(false);
+    });
+    expect(effectRun).toBe(true);
+    expect(cleanupRun).toBe(false);
+    dispose();
+    expect(cleanupRun).toBe(true);
+  });
+
+  test("Executes and cleans in context of specific owner", () => {
+    let effectRun = false;
+    let cleanupRun = false;
+    const [owner, dispose] = createRoot(dispose => {
+      return [getOwner()!, dispose];
+    });
+    createRoot(() => {
+      runWithOwner(owner, () => {
+        createEffect(() => (effectRun = true));
+        onCleanup(() => (cleanupRun = true));
+        expect(effectRun).toBe(false);
+        expect(cleanupRun).toBe(false);
+      });
     });
     expect(effectRun).toBe(true);
     expect(cleanupRun).toBe(false);


### PR DESCRIPTION
## Summary

Fixes: https://github.com/solidjs/solid/issues/1513

Here is a PR, that will be fixing the mentioned issues as well as preserving error handling and reseting the Listener.

`runWithOwner` will now work exactly the same way as `untrack/runWithListener`, so using it outside of a root or batch (runUpdates) will trigger effects immediately.

## How did you test this change?

`pnpm test`

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
