### PR TITLE
Support null for detachedOwner in createRoot

### DIFF
--- a/.changeset/gentle-rules-accept.md
+++ b/.changeset/gentle-rules-accept.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Support null for detachedOwner in createRoot

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -111,7 +111,7 @@ export type RootFunction<T> = (dispose: () => void) => T;
  *
  * @description https://www.solidjs.com/docs/latest/api#createroot
  */
-export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: Owner): T {
+export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: typeof Owner): T {
   const listener = Listener,
     owner = Owner,
     unowned = fn.length === 0,
@@ -119,7 +119,12 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: Owner): T {
       ? "_SOLID_DEV_"
         ? { owned: null, cleanups: null, context: null, owner: null }
         : UNOWNED
-      : { owned: null, cleanups: null, context: null, owner: detachedOwner || owner },
+      : {
+          owned: null,
+          cleanups: null,
+          context: null,
+          owner: detachedOwner === undefined ? owner : detachedOwner
+        },
     updateFn = unowned
       ? "_SOLID_DEV_"
         ? () =>
@@ -960,7 +965,7 @@ export function getOwner() {
   return Owner;
 }
 
-export function runWithOwner<T>(o: Owner, fn: () => T): T | undefined {
+export function runWithOwner<T>(o: typeof Owner, fn: () => T): T | undefined {
   const prev = Owner;
   const prevListener = Listener;
   Owner = o;

--- a/packages/solid/src/server/reactive.ts
+++ b/packages/solid/src/server/reactive.ts
@@ -34,8 +34,8 @@ interface Owner {
   context: any | null;
 }
 
-export function createRoot<T>(fn: (dispose: () => void) => T, detachedOwner?: Owner): T {
-  detachedOwner && (Owner = detachedOwner);
+export function createRoot<T>(fn: (dispose: () => void) => T, detachedOwner?: typeof Owner): T {
+  detachedOwner !== undefined && (Owner = detachedOwner);
   const owner = Owner,
     root: Owner = fn.length === 0 ? UNOWNED : { context: null, owner };
   Owner = root;
@@ -189,7 +189,7 @@ export function children(fn: () => any): ChildrenReturn {
   return memo as ChildrenReturn;
 }
 
-export function runWithOwner<T>(o: Owner, fn: () => T): T | undefined {
+export function runWithOwner<T>(o: typeof Owner, fn: () => T): T | undefined {
   const prev = Owner;
   Owner = o;
   try {

--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -687,6 +687,28 @@ describe("createRoot", () => {
       });
     });
   });
+  
+  test("Allows to define detachedOwner", () => {
+    let owner1: any;
+    let owner2: any;
+    let owner3: any;
+    let owner4: any;
+    let owner5: any;
+
+    createRoot(_ => (owner1 = getOwner()!));
+    createRoot(_ => (owner2 = getOwner()!), owner1);
+    createRoot(_ => {
+      owner3 = getOwner()!;
+      createRoot(_ => (owner4 = getOwner()!));
+      createRoot(_ => (owner5 = getOwner()!), null);
+    });
+
+    expect(owner1.owner).toBe(null);
+    expect(owner2.owner).toBe(owner1);
+    expect(owner3.owner).toBe(null);
+    expect(owner4.owner).toBe(owner3);
+    expect(owner5.owner).toBe(null);
+  });
 });
 
 describe("runWithOwner", () => {


### PR DESCRIPTION
## Summary

To create a fully detached root, we need to make sure the owner is not inherited. Currently `null` value was treated the same as `undefined` leading to use of current owner. To be able to control that behavior, now we can support `null` as detachedOwner which is a valid Owner type.

## How did you test this change?

Added unit test (pnpm test)