### PR TITLE
Fix: swap KeyOf for MutableKeyOf in one of the SetStoreFunction overload

### DIFF
--- a/.changeset/large-gifts-swim.md
+++ b/.changeset/large-gifts-swim.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Fix: swap KeyOf for MutableKeyOf in one of the SetStoreFunction overload

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -383,7 +383,7 @@ type MutableKeyOf<T> = KeyOf<T> & keyof PickMutable<T>;
 type Rest<
   T,
   U extends PropertyKey[],
-  K extends KeyOf<T> = KeyOf<T> 
+  K extends KeyOf<T> = KeyOf<T>
 > = K extends keyof PickMutable<T>
   ? [Part<T, K>, ...RestSetterOrContinue<T[K], [K, ...U]>]
   : K extends KeyOf<K>
@@ -424,7 +424,7 @@ export interface SetStoreFunction<T> {
     K3 extends KeyOf<W<W<W<T>[K1]>[K2]>>,
     K4 extends KeyOf<W<W<W<W<T>[K1]>[K2]>[K3]>>,
     K5 extends KeyOf<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>>,
-    K6 extends KeyOf<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>>
+    K6 extends MutableKeyOf<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>>
   >(
     k1: Part<W<T>, K1>,
     k2: Part<W<W<T>[K1]>, K2>,

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -759,7 +759,7 @@ describe("Nested Classes", () => {
   // @ts-expect-error m is readonly
   setK5("i", "j", "k", "l", "m", 6);
   const [, setK6] = createStore({} as { i: { j: { k: { l: { m: { readonly n: number } } } } } });
-  // TODO @ts-expect-error n is readonly, nesting too deep?
+  // @ts-expect-error n is readonly, but has unreadable error due to method overloading
   setK6("i", "j", "k", "l", "m", "n", 7);
   const [, setK7] = createStore(
     {} as { i: { j: { k: { l: { m: { n: { readonly o: number } } } } } } }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->
tests!

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Hello, while diving into the `SetStoreFunction<T>` interface trying to understand this complex piece of typescript, one of the overload did look different as all the other one were following the pattern `KeyOf ... KeyOf, MutableKeyOf, setter`, except one of them that omit the MutableKeyOf (the one with 6keys). The consequences of this is that if you try to edit a 6th depth readonly store property, typescript doesn't complain whereas it does for the other cases. [Here is a playground](https://playground.solidjs.com/anonymous/d2d4c982-adb5-4c0d-abea-e8e036942240) for case 5, 6, 7 and 4:


## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
I only ran pnpm test, at first it was failing due to the TODO test in store spec. I edited this test and reran the test suit which now complete and expect an error for the case K6 [https://github.com/solidjs/solid/blob/3fd936c91da41452dc86eb0ec1d255738d59305d/packages/solid/store/test/store.spec.ts#L761-L763](https://github.com/solidjs/solid/blob/3fd936c91da41452dc86eb0ec1d255738d59305d/packages/solid/store/test/store.spec.ts#L761-L763)