### PR TITLE
Add fast track for `untrack` in case of `null` listener

### DIFF
--- a/.changeset/shaggy-pears-think.md
+++ b/.changeset/shaggy-pears-think.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Add fast track for `untrack` in case of `null` listener

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -822,6 +822,8 @@ export function batch<T>(fn: Accessor<T>): T {
  * @description https://www.solidjs.com/docs/latest/api#untrack
  */
 export function untrack<T>(fn: Accessor<T>): T {
+  if (Listener === null) return fn();
+
   const listener = Listener;
   Listener = null;
   try {


### PR DESCRIPTION
## Summary

Now, we will check the Listener before untracking optimising execution in case of nested untrack usage.

```ts
const api = {
  run() {
     untrack(() => setName("fast"))
  }
}

untrack(() => api.run(())
```

## How did you test this change?

`pnpm test`