### PR TITLE
fix: set store not working when too deep

### DIFF
--- a/.changeset/clean-months-scream.md
+++ b/.changeset/clean-months-scream.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Fixed the store setter's recursive fallback overload not terminating with non-numbers

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -380,19 +380,17 @@ type KeyOf<T> = number extends keyof T // have to check this otherwise ts won't 
 type MutableKeyOf<T> = KeyOf<T> & keyof PickMutable<T>;
 
 // rest must specify at least one (additional) key, followed by a StoreSetter if the key is mutable.
-type Rest<
-  T,
-  U extends PropertyKey[],
-  K extends KeyOf<T> = KeyOf<T> 
-> = K extends keyof PickMutable<T>
+type Rest<T, U extends PropertyKey[], K extends KeyOf<T> = KeyOf<T>> = [T] extends [never]
+  ? never
+  : K extends MutableKeyOf<T>
   ? [Part<T, K>, ...RestSetterOrContinue<T[K], [K, ...U]>]
-  : K extends KeyOf<K>
+  : K extends KeyOf<T>
   ? [Part<T, K>, ...RestContinue<T[K], [K, ...U]>]
   : never;
 
 type RestContinue<T, U extends PropertyKey[]> = 0 extends 1 & T
   ? [...Part<any>[], StoreSetter<any, PropertyKey[]>]
-  : Rest<T, U>;
+  : Rest<W<T>, U>;
 
 type RestSetterOrContinue<T, U extends PropertyKey[]> = [StoreSetter<T, U>] | RestContinue<T, U>;
 

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -808,6 +808,18 @@ describe("Nested Classes", () => {
   setStore("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", (v, t) => ({
     k: 2
   }));
+  setStore("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", 2);
+};
+
+// same as the above but with strings which have more types of keys
+() => {
+  const [, setStore] = createStore({
+    a: { b: { c: { d: { e: { f: { g: { h: { i: { j: { k: "l" } } } } } } } } } }
+  });
+  setStore("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "m");
+  setStore("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", (v, t) => ({
+    k: "m"
+  }));
 };
 
 // tuples are correctly typed


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

Fixes https://playground.solidjs.com/anonymous/f595df62-5514-4986-b012-4894b8b02e92. I think it's broken because strings have a key (`number`) which has a type of `string` again, causing infinite recursion. Preventing non-wrappable types from being recursed into fixes that. Checking `[T] extends [never]` fixes infinite recursion in the case where `T` becomes `never`.

## How did you test this change?

`pnpm test`.

~~I can't run the tests for `solid-js` on windows, did this break recently?~~

Nevermind, nuking `node_modules` fixed it.