### PR TITLE
Fix order of onError callbacks execution

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -956,7 +956,7 @@ export function onError(fn: (err: any) => void): void {
       console.warn("error handlers created outside a `createRoot` or `render` will never be run");
   else if (Owner.context === null) Owner.context = { [ERROR]: [fn] };
   else if (!Owner.context[ERROR]) Owner.context[ERROR] = [fn];
-  else Owner.context[ERROR].push(fn);
+  else Owner.context[ERROR].unshift(fn);
 }
 
 export function getListener() {

--- a/packages/solid/src/server/reactive.ts
+++ b/packages/solid/src/server/reactive.ts
@@ -150,7 +150,7 @@ export function onError(fn: (err: any) => void): void {
   if (Owner) {
     if (Owner.context === null) Owner.context = { [ERROR]: [fn] };
     else if (!Owner.context[ERROR]) Owner.context[ERROR] = [fn];
-    else Owner.context[ERROR].push(fn);
+    else Owner.context[ERROR].unshift(fn);
   }
 }
 

--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -453,19 +453,17 @@ describe("onError", () => {
   });
 
   test("With multiple error handlers", () => {
-    let errored = false;
-    let errored2 = false;
+    const errors: string[] = [];
     expect(() =>
       createRoot(() => {
         createEffect(() => {
-          onError(() => (errored = true));
-          onError(() => (errored2 = true));
+          onError(() => errors.push("first"));
+          onError(() => errors.push("second"));
           throw "fail";
         });
       })
     ).not.toThrow("fail");
-    expect(errored).toBe(true);
-    expect(errored2).toBe(true);
+    expect(errors).toEqual(["second", "first"]);
   });
 
   test("In update effect", () => {


### PR DESCRIPTION
## Summary

I would expect that errors callbacks will be executed in reversed order ie. From latest to last defined.

```ts
function doSth() {
  onError(() => console.log("child"))
  throw new Error("error")
}

onError(() => console.log("parent"))
doSth(); // logs: "child", "parent"
```

## Why is it important?

We should be able to handle error as close to the error itself as possible. In the above example I would expect the child to have a chance to catch the error first before raising it to parent.

Similar like with `<ErrorBoundry />` the errors are handled in reversed order:
```tsx
<ErrorBoundary fallback={err => { console.log('parent'); throw err}}>
  <ErrorBoundary fallback={err => { console.log('child'); throw err}}>
    <Broken />
  </ErrorBoundary>
</ErrorBoundary>
```

## How did you test this change?
`pnpm test` & `pnpm build`