### PR TITLE
Fix owner leak in server's createRoot

### DIFF
--- a/packages/solid/src/server/reactive.ts
+++ b/packages/solid/src/server/reactive.ts
@@ -35,9 +35,14 @@ interface Owner {
 }
 
 export function createRoot<T>(fn: (dispose: () => void) => T, detachedOwner?: typeof Owner): T {
-  detachedOwner !== undefined && (Owner = detachedOwner);
   const owner = Owner,
-    root: Owner = fn.length === 0 ? UNOWNED : { context: null, owner };
+    root =
+      fn.length === 0
+        ? UNOWNED
+        : {
+            context: null,
+            owner: detachedOwner === undefined ? owner : detachedOwner
+          };
   Owner = root;
   let result: T;
   try {


### PR DESCRIPTION
## Summary

`createRoot` were leaking owner while running in server mode, as it was reverting back to `detachedOwner` instead of previous owner at the end of execution.

## How did you test this change?

I caught this error in one of my libs:
https://github.com/Exelord/solid-services/actions/runs/4156500282/jobs/7190330382

with the following fix, everything is working again.
