### PR TITLE
fix: createResource should not ignores empty string throw

### DIFF
--- a/.changeset/empty-melons-rule.md
+++ b/.changeset/empty-melons-rule.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+fix: createResource should not ignores empty string throw

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -609,8 +609,8 @@ export function createResource<T, S, R>(
   }
   function completeLoad(v: T | undefined, err: any) {
     runUpdates(() => {
-      if (!err) setValue(() => v);
-      setState(err ? "errored" : "ready");
+      if (err !== undefined) setValue(() => v);
+      setState(err !== undefined ? "errored" : "ready");
       setError(err);
       for (const c of contexts.keys()) c.decrement!();
       contexts.clear();
@@ -621,7 +621,7 @@ export function createResource<T, S, R>(
     const c = SuspenseContext && lookup(Owner, SuspenseContext.id),
       v = value(),
       err = error();
-    if (err && !pr) throw err;
+    if (err !== undefined && !pr) throw err;
     if (Listener && !Listener.user && c) {
       createComputed(() => {
         track();


### PR DESCRIPTION
`createResource` does not properly errors when an empty string is thrown in the fetcher.

it is expected that empty string like any other string will trigger the onError hook.

https://playground.solidjs.com/anonymous/12d55e94-dc30-4c04-93e9-77191a419bf5

## How did you test this change?

n/a