### PR TITLE
fix: KeyOf<T> allowing number to index never

### DIFF
--- a/.changeset/selfish-dots-marry.md
+++ b/.changeset/selfish-dots-marry.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Fixed test case for setStore 7 parameter overload by fixing KeyOf giving number for KeyOf<never>

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -370,10 +370,11 @@ type W<T> = Exclude<T, NotWrappable>;
 type KeyOf<T> = number extends keyof T // have to check this otherwise ts won't allow KeyOf<T> to index T
   ? 0 extends 1 & T // if it's any just return keyof T
     ? keyof T
-    : [T] extends [readonly unknown[]]
-    ? number // it's an array or tuple; exclude the non-number properties
     : [T] extends [never]
-    ? never // keyof never is PropertyKey which number extends; return never
+    ? never // keyof never is PropertyKey, which number extends. this must go before
+    : // checking [T] extends [readonly unknown[]] because never extends everything
+    [T] extends [readonly unknown[]]
+    ? number // it's an array or tuple; exclude the non-number properties
     : keyof T // it's something which contains an index signature for strings or numbers
   : keyof T;
 

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -759,7 +759,7 @@ describe("Nested Classes", () => {
   // @ts-expect-error m is readonly
   setK5("i", "j", "k", "l", "m", 6);
   const [, setK6] = createStore({} as { i: { j: { k: { l: { m: { readonly n: number } } } } } });
-  // TODO @ts-expect-error n is readonly, but has unreadable error due to method overloading
+  // @ts-expect-error n is readonly, but has unreadable error due to method overloading
   setK6("i", "j", "k", "l", "m", "n", 7);
   const [, setK7] = createStore(
     {} as { i: { j: { k: { l: { m: { n: { readonly o: number } } } } } } }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary


Do the `never` check before and not after the `readonly unknown[]` check.
This prevents `KeyOf<never>` from giving `number` (since `never` extends everything).
This correctly errors when the setStore overload with 7 parameters tries to set a readonly property.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
`pnpm test`

Edit: latest version places it before `readonly unknown[]` instead of at the start, which should make the common cases faster (though I don't know how TS actually handles it). Changed it since the type is slow to begin with. 