### PR TITLE
Change onError mechanism to bubbling

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1681,11 +1681,19 @@ function castError(err: any) {
   return new Error("Unknown error");
 }
 
-function handleError(err: any) {
+function handleError(err: unknown): void {
   err = castError(err);
   const fns = ERROR && lookup(Owner, ERROR);
   if (!fns) throw err;
-  for (const f of fns) f(err);
+  for (const f of fns) {
+    try {
+      f(err);
+      return;
+    } catch (e) {
+      err = e;
+    }
+  }
+  throw err;
 }
 
 function lookup(owner: Owner | null, key: symbol | string): any {

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -956,7 +956,7 @@ export function onError(fn: (err: any) => void): void {
       console.warn("error handlers created outside a `createRoot` or `render` will never be run");
   else if (Owner.context === null) Owner.context = { [ERROR]: [fn] };
   else if (!Owner.context[ERROR]) Owner.context[ERROR] = [fn];
-  else Owner.context[ERROR].push(fn);
+  else Owner.context[ERROR].unshift(fn);
 }
 
 export function getListener() {

--- a/packages/solid/src/server/reactive.ts
+++ b/packages/solid/src/server/reactive.ts
@@ -19,11 +19,19 @@ export function castError(err: any) {
   return new Error("Unknown error");
 }
 
-function handleError(err: any) {
+function handleError(err: unknown): void {
   err = castError(err);
   const fns = lookup(Owner, ERROR);
   if (!fns) throw err;
-  for (const f of fns) f(err);
+  for (const f of fns) {
+    try {
+      f(err);
+      return;
+    } catch (e) {
+      err = e;
+    }
+  }
+  throw err;
 }
 
 const UNOWNED: Owner = { context: null, owner: null };

--- a/packages/solid/src/server/reactive.ts
+++ b/packages/solid/src/server/reactive.ts
@@ -150,7 +150,7 @@ export function onError(fn: (err: any) => void): void {
   if (Owner) {
     if (Owner.context === null) Owner.context = { [ERROR]: [fn] };
     else if (!Owner.context[ERROR]) Owner.context[ERROR] = [fn];
-    else Owner.context[ERROR].push(fn);
+    else Owner.context[ERROR].unshift(fn);
   }
 }
 

--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -453,19 +453,17 @@ describe("onError", () => {
   });
 
   test("With multiple error handlers", () => {
-    let errored = false;
-    let errored2 = false;
+    const errors: string[] = [];
     expect(() =>
       createRoot(() => {
         createEffect(() => {
-          onError(() => (errored = true));
-          onError(() => (errored2 = true));
+          onError(() => errors.push("first"));
+          onError(() => errors.push("second"));
           throw "fail";
         });
       })
     ).not.toThrow("fail");
-    expect(errored).toBe(true);
-    expect(errored2).toBe(true);
+    expect(errors).toEqual(["second", "first"]);
   });
 
   test("In update effect", () => {

--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -458,7 +458,10 @@ describe("onError", () => {
       createRoot(() => {
         createEffect(() => {
           onError(() => errors.push("first"));
-          onError(() => errors.push("second"));
+          onError(e => {
+            errors.push("second");
+            throw e;
+          });
           throw "fail";
         });
       })


### PR DESCRIPTION
## Summary

I would like to propose changing the current way of `onError` handling:

![current](https://user-images.githubusercontent.com/1469375/218454101-97e37b27-dfe5-49a8-b0d1-d8f983ba5b76.png)

into bubbling mechanism:

![bubbling](https://user-images.githubusercontent.com/1469375/218454110-3b47e576-74a6-476a-af72-67a9af225571.png)

## Motivation

Current we are not able to handle an error without making sure that none of `onError` hooks won't throw an error. However this seams to be impossible as in a context of specific function we cannot be sure if any of the parents are doing that or not. With bubbling mechanism, the error will be first handled as close to the origin as possible, and the handler will be able to decide whether to rethrow it or not. In the first case the error will be propagated further to the next nearest handler, in the second case, it will be treated as handled error, and no other `onError` hooks will be triggered. 

This is the same way how try/catch is working, so it is more intuitive, and delivers more familiar DX 

## How did you test this change?

`pnpm test && pnpm build`