### PR TITLE
Feat: add some overloads for StoreSetter

### DIFF
--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -495,6 +495,68 @@ export interface SetStoreFunction<T> {
     k7: Part<W<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>[K6]>, K7>,
     ...rest: Rest<W<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>[K6]>[K7], [K7, K6, K5, K4, K3, K2, K1]>
   ): void;
+
+  <
+    K1 extends KeyOf<W<T>>,
+    K2 extends KeyOf<W<W<T>[K1]>>,
+    K3 extends KeyOf<W<W<W<T>[K1]>[K2]>>,
+    K4 extends KeyOf<W<W<W<W<T>[K1]>[K2]>[K3]>>,
+    K5 extends KeyOf<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>>,
+    K6 extends KeyOf<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>>
+  >(
+    k1: Part<W<T>, K1>,
+    k2: Part<W<W<T>[K1]>, K2>,
+    k3: Part<W<W<W<T>[K1]>[K2]>, K3>,
+    k4: Part<W<W<W<W<T>[K1]>[K2]>[K3]>, K4>,
+    k5: Part<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>, K5>,
+    k6: Part<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>, K6>,
+    ...rest: Rest<W<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5]>[K6], [K6, K5, K4, K3, K2, K1]>
+  ): void;
+
+  <
+    K1 extends KeyOf<W<T>>,
+    K2 extends KeyOf<W<W<T>[K1]>>,
+    K3 extends KeyOf<W<W<W<T>[K1]>[K2]>>,
+    K4 extends KeyOf<W<W<W<W<T>[K1]>[K2]>[K3]>>,
+    K5 extends KeyOf<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>>
+  >(
+    k1: Part<W<T>, K1>,
+    k2: Part<W<W<T>[K1]>, K2>,
+    k3: Part<W<W<W<T>[K1]>[K2]>, K3>,
+    k4: Part<W<W<W<W<T>[K1]>[K2]>[K3]>, K4>,
+    k5: Part<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>, K5>,
+    ...rest: Rest<W<W<W<W<W<T>[K1]>[K2]>[K3]>[K4]>[K5], [K5, K4, K3, K2, K1]>
+  ): void;
+
+  <
+    K1 extends KeyOf<W<T>>,
+    K2 extends KeyOf<W<W<T>[K1]>>,
+    K3 extends KeyOf<W<W<W<T>[K1]>[K2]>>,
+    K4 extends KeyOf<W<W<W<W<T>[K1]>[K2]>[K3]>>
+  >(
+    k1: Part<W<T>, K1>,
+    k2: Part<W<W<T>[K1]>, K2>,
+    k3: Part<W<W<W<T>[K1]>[K2]>, K3>,
+    k4: Part<W<W<W<W<T>[K1]>[K2]>[K3]>, K4>,
+    ...rest: Rest<W<W<W<W<T>[K1]>[K2]>[K3]>[K4], [K4, K3, K2, K1]>
+  ): void;
+
+  <K1 extends KeyOf<W<T>>, K2 extends KeyOf<W<W<T>[K1]>>, K3 extends KeyOf<W<W<W<T>[K1]>[K2]>>>(
+    k1: Part<W<T>, K1>,
+    k2: Part<W<W<T>[K1]>, K2>,
+    k3: Part<W<W<W<T>[K1]>[K2]>, K3>,
+    ...rest: Rest<W<W<W<T>[K1]>[K2]>[K3], [K3, K2, K1]>
+  ): void;
+
+  <K1 extends KeyOf<W<T>>, K2 extends KeyOf<W<W<T>[K1]>>>(
+    k1: Part<W<T>, K1>,
+    k2: Part<W<W<T>[K1]>, K2>,
+    ...rest: Rest<W<W<T>[K1]>[K2], [K2, K1]>
+  ): void;
+
+  <K1 extends KeyOf<W<T>>>(k1: Part<W<T>, K1>, ...rest: Rest<W<T>[K1], [K1]>): void;
+
+  (...rest: Rest<T, []>): void;
 }
 
 /**

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -827,10 +827,64 @@ describe("Nested Classes", () => {
   const [, setStore] = createStore({ data: ["a", 1] as [string, number] });
   setStore("data", 0, "hello");
   setStore("data", 1, 2);
-  // @ts-expect-error number not assignable to string
+  // Not working anymore @ts-expect-error number not assignable to string
   setStore("data", 0, 3);
-  // @ts-expect-error string not assignable to number
+  // Not working anymore @ts-expect-error string not assignable to number
   setStore("data", 1, "world");
+};
+
+// can use a rest parameter as input of a setStore function in depth lower than 7
+() => {
+  const [, setStore0] = createStore(
+    [] as { id: number; firstName: string; lastName: Date; nickName: string; adress: string }[]
+  );
+  const doSomethingThenSet = (...rest: any) => {
+    console.log(rest);
+    setStore0(...rest);
+  };
+
+  const [, setUsers1] = createStore(
+    [] as { id: number; firstName: string; lastName: Date; nickName: string; adress: string }[]
+  );
+  const setUser1 = (id: number, ...rest: any) => setUsers1(user => user.id === id, ...rest);
+
+  const [, setUsers2] = createStore({ a: { b: [] } } as {
+    a: { b: { id: number; data: string }[] };
+  });
+  const setUser2 = (id: number, ...rest: any) =>
+    setUsers2("a", "b", user => user.id === id, ...rest);
+
+  const [, setUsers3] = createStore({ a: { b: { c: [] } } } as {
+    a: { b: { c: { id: number; data: string }[] } };
+  });
+  const setUser3 = (id: number, ...rest: any) =>
+    setUsers3("a", "b", "c", user => user.id === id, ...rest);
+
+  const [, setUsers4] = createStore({ a: { b: { c: { d: [] } } } } as {
+    a: { b: { c: { d: { id: number; data: string }[] } } };
+  });
+  const setUser4 = (id: number, ...rest: any) =>
+    setUsers4("a", "b", "c", "d", user => user.id === id, ...rest);
+
+  const [, setUsers5] = createStore({ a: { b: { c: { d: { e: [] } } } } } as {
+    a: { b: { c: { d: { e: { id: number; data: string }[] } } } };
+  });
+  const setUser5 = (id: number, ...rest: any) =>
+    setUsers5("a", "b", "c", "d", "e", user => user.id === id, ...rest);
+
+  const [, setUsers6] = createStore({ a: { b: { c: { d: { e: { f: [] } } } } } } as {
+    a: { b: { c: { d: { e: { f: { id: number; data: string }[] } } } } };
+  });
+  const setUser6 = (id: number, ...rest: any) =>
+    setUsers6("a", "b", "c", "d", "e", "f", user => user.id === id, ...rest);
+
+  const [, setUsers7] = createStore({ a: { b: { c: { d: { e: { f: { g: [] } } } } } } } as {
+    a: { b: { c: { d: { e: { f: { g: { id: number; data: string }[] } } } } } };
+  });
+
+  const setUser7 = (id: number, ...rest: any) =>
+    // @ts-expect-error TODO ? 8 args + a rest parameter does not match anything
+    setUsers7("a", "b", "c", "d", "e", "f", "g", "h", user => user.id === id, ...rest);
 };
 
 // // cannot mutate a store directly


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

At the moment typescript only allow the following signatures for SetStoreFunction interface;

```js
(setter): void;
(k1, setter): void;
(k1, k2, setter): void;
(k1, k2, k3, setter): void;
(k1, k2, k3, k4, setter): void;
(k1, k2, k3, k4, k5, setter): void;
(k1, k2, k3, k4, k5, k6, setter): void;
(k1, k2, k3, k4, k5, k6, k7, setter): void;
(k1, k2, k3, k4, k5, k6, k7, ...rest): void;
```

I'm hidding the type because it's not relevant for the discussion. Said another way, at the moment, the interface only allow for:
- exactly 1 arg
- exactly 2 args
- exactly 3 args
- exactly 4 args
- exactly 5 args
- exactly 6 args
- exactly 7 args
- exactly 8 args
- 8 or more args.

My proposition is to add overload for the cases:
- 1 or more args
- 2 or more args
- 3 or more args
- ...
- 7 or more args

So that it would be legal to write :

```ts
const [, setUsers1] = createStore(
    [] as { id: number; firstName: string; lastName: Date; nickName: string; adresse: string }[]
  );
  const setUser1 = (id: number, ...rest: any) => setUsers1(user => user.id === id, ...rest);
```

### Breaking change:

To add support for those case mean that this does not error anymore
```ts
  const [, setStore] = createStore({ data: ["a", 1] as [string, number] });
  // Does Not Error anymore
  setStore("data", 0, 3);
  // Does Not Error anymore
  setStore("data", 1, "world");
```

The reason for that is that the rest of the overload 1+ typing is not smart enough to inspect the second argument so it think that he is looking at a `(string | number)[]`. I say it is not a big deal to lose this safety and it was a safety we didn't provide for case 8+ before my change anyway.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

Commented the 2 failing tests
Added some test for the new signatures
pnpm test