### PR TITLE
DEV: Add component function to component owner

### DIFF
--- a/.changeset/nice-dogs-draw.md
+++ b/.changeset/nice-dogs-draw.md
@@ -1,0 +1,6 @@
+---
+"solid-js": patch
+---
+
+Add a reference to the component funciton to DevComponent owner.
+Rename DevComponent's property from `componentName` to `name`.

--- a/packages/solid/test/dev.spec.ts
+++ b/packages/solid/test/dev.spec.ts
@@ -5,8 +5,10 @@ import {
   createEffect,
   createComputed,
   DEV,
-  createContext
+  createContext,
+  createComponent
 } from "../src";
+import type { DevComponent } from "../src/reactive/signal";
 import { createStore, unwrap, DEV as STORE_DEV } from "../store/src";
 
 describe("Dev features", () => {
@@ -138,5 +140,18 @@ describe("Dev features", () => {
     set("inner", "foo", 2);
     expect(cb).toHaveBeenCalledTimes(2);
     expect(cb).toHaveBeenCalledWith(unwrap(s.inner), "foo", 2, 1);
+  });
+
+  test("createComponent should create a component owner in DEV", () => {
+    createRoot(() => {
+      const props = {};
+      createComponent(function MyComponent() {
+        const owner = getOwner() as DevComponent<{}>;
+        expect(owner.name).toBe("MyComponent");
+        expect(owner.props).toBe(props);
+        expect(owner.component).toBe(MyComponent);
+        return null;
+      }, props);
+    });
   });
 });


### PR DESCRIPTION
The function passed to `fn` property of dev component owners is not the original component function.

![image](https://user-images.githubusercontent.com/24491503/219967843-8d46900c-a1fa-43f5-9bf4-9571ad951141.png)

A reference to the original component function will be handy for leveraging chrome's `inspect()` API for viewing the component in the chrome Sources tab.
Also, the [new PR to solid-refresh](https://github.com/solidjs/solid-refresh/pull/34) is passing component location by [adding it as a property of the original function](https://github.com/solidjs/solid-refresh/blob/c98cb9ad830dab8621d7cac1e61f3ef9d3f3ab59/src/runtime/index.ts#L58). Which can be used in devtools to open the component source in user's IDE.

Additionally, I've renamed the `componentName` property to `name` - no idea why I haven't done that in https://github.com/solidjs/solid/pull/1460
Since the name generation has been deleted, the `name` property will be empty.