### PR TITLE
Fix `isServer` const type

### DIFF
--- a/.changeset/brown-tips-remain.md
+++ b/.changeset/brown-tips-remain.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Correct the type of `isServer` const to `boolean` from `false`.

--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -30,7 +30,8 @@ export {
 } from "solid-js";
 
 export * from "./server-mock.js";
-export const isServer = false;
+
+export const isServer: boolean = false;
 const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 
 function createElement(tagName: string, isSVG = false): HTMLElement | SVGElement {


### PR DESCRIPTION
Because the type for the const `isServer` is taken from the client runtime version where it was just assigned `false`, it's type was inferred as `false` as well. This lead to some warnings when using stricter eslint rules:

![image](https://user-images.githubusercontent.com/24491503/220710627-1721521c-6c5f-4ddd-a7cb-8c7cabf4339c.png)

This will make it into `boolean`