### PR TITLE
Export `isDev` const from `solid-js/web`

### DIFF
--- a/.changeset/thick-goats-nail.md
+++ b/.changeset/thick-goats-nail.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Export `isDev` const from solid-js/web for differentiating between dev/prod env.

--- a/packages/solid/rollup.config.js
+++ b/packages/solid/rollup.config.js
@@ -30,6 +30,13 @@ const plugins = [
   })
 ];
 
+const replaceDev = isDev =>
+  replace({
+    '"_SOLID_DEV_"': isDev,
+    preventAssignment: true,
+    delimiters: ["", ""]
+  });
+
 export default [
   {
     input: "src/index.ts",
@@ -43,13 +50,7 @@ export default [
         format: "es"
       }
     ],
-    plugins: [
-      replace({
-        '"_SOLID_DEV_"': false,
-        preventAssignment: true,
-        delimiters: ["", ""]
-      })
-    ].concat(plugins)
+    plugins: [replaceDev(false)].concat(plugins)
   },
   {
     input: "src/server/index.ts",
@@ -78,7 +79,7 @@ export default [
         format: "es"
       }
     ],
-    plugins
+    plugins: [replaceDev(true)].concat(plugins)
   },
   {
     input: "store/src/index.ts",
@@ -93,13 +94,7 @@ export default [
       }
     ],
     external: ["solid-js"],
-    plugins: [
-      replace({
-        '"_SOLID_DEV_"': false,
-        preventAssignment: true,
-        delimiters: ["", ""]
-      })
-    ].concat(plugins)
+    plugins: [replaceDev(false)].concat(plugins)
   },
   {
     input: "store/src/server.ts",
@@ -129,7 +124,7 @@ export default [
       }
     ],
     external: ["solid-js"],
-    plugins
+    plugins: [replaceDev(true)].concat(plugins)
   },
   {
     input: "web/src/index.ts",
@@ -144,13 +139,7 @@ export default [
       }
     ],
     external: ["solid-js"],
-    plugins: [
-      replace({
-        '"_DX_DEV_"': false,
-        preventAssignment: true,
-        delimiters: ["", ""]
-      })
-    ].concat(plugins)
+    plugins: [replaceDev(false)].concat(plugins)
   },
   {
     input: "web/server/index.ts",
@@ -180,7 +169,7 @@ export default [
       }
     ],
     external: ["solid-js"],
-    plugins
+    plugins: [replaceDev(true)].concat(plugins)
   },
   {
     input: "universal/src/index.ts",
@@ -195,13 +184,7 @@ export default [
       }
     ],
     external: ["solid-js"],
-    plugins: [
-      replace({
-        '"_DX_DEV_"': false,
-        preventAssignment: true,
-        delimiters: ["", ""]
-      })
-    ].concat(plugins)
+    plugins: [replaceDev(false)].concat(plugins)
   },
   {
     input: "universal/src/index.ts",
@@ -216,7 +199,7 @@ export default [
       }
     ],
     external: ["solid-js"],
-    plugins
+    plugins: [replaceDev(true)].concat(plugins)
   },
   {
     input: "html/src/index.ts",

--- a/packages/solid/web/server/index.ts
+++ b/packages/solid/web/server/index.ts
@@ -15,7 +15,8 @@ export {
   mergeProps
 } from "solid-js";
 
-export const isServer = true;
+export const isServer: boolean = true;
+export const isDev: boolean = false;
 
 export function render() {}
 export function hydrate() {}

--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -32,6 +32,7 @@ export {
 export * from "./server-mock.js";
 
 export const isServer: boolean = false;
+export const isDev: boolean = "_SOLID_DEV_" as unknown as boolean;
 const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 
 function createElement(tagName: string, isSVG = false): HTMLElement | SVGElement {


### PR DESCRIPTION
Export `isDev` const from solid-js/web to make checking development/production envs clearer than using the `DEV` object with internal methods.

Since the `"_SOLID_DEV_"` string was replaced with `false` only in production entries, I've enabled replacing in dev entries as well.
Otherwise, it would have to be declared this way:
```ts
export const isDev: boolean = !!"_SOLID_DEV_";
```
Which is tree shakeable too