### PR TITLE
feat(store): deep watch on dependencies

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -951,8 +951,7 @@ export function on<S, Next extends Prev, Prev = Next>(
 /**
  * deepTraverse - traverse an object
  * @param obj an object to traverse
- * @returns a new object with all functions called
- * @description https://www.solidjs.com/docs/latest/api#deeptraverse
+ * @returns an object with all values traversed
  * @private
  * */
 function deepTraverse<S>(obj: S): S {

--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -97,6 +97,21 @@ describe("Create signals", () => {
     set("a", "b", "minds");
     expect(temp!).toBe('impure {"a":{"b":"minds"}}');
   });
+  test("Create a Effect with explicit deps and no deep evaluation", () => {
+    let temp: string;
+    const [sign, set] = createStore({ a: { b: "thoughts" } });
+    createRoot(() => {
+      const fn = on(
+        () => sign,
+        v => (temp = `impure ${JSON.stringify(v)}`)
+        // { deep: false } by default
+      );
+      createEffect(fn);
+    });
+    expect(temp!).toBe('impure {"a":{"b":"thoughts"}}');
+    set("a", "b", "minds");
+    expect(temp!).toBe('impure {"a":{"b":"thoughts"}}');
+  });
 });
 
 describe("Update signals", () => {

--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -19,6 +19,7 @@ import {
   getOwner,
   runWithOwner
 } from "../src";
+import { createStore } from "../store/src";
 
 import "./MessageChannel";
 
@@ -80,6 +81,21 @@ describe("Create signals", () => {
     expect(temp!).toBeUndefined();
     set("minds");
     expect(temp!).toBe("impure minds");
+  });
+  test("Create a Effect with explicit deps and deep evaluation", () => {
+    let temp: string;
+    const [sign, set] = createStore({ a: { b: "thoughts" } });
+    createRoot(() => {
+      const fn = on(
+        () => sign,
+        v => (temp = `impure ${JSON.stringify(v)}`),
+        { deep: true }
+      );
+      createEffect(fn);
+    });
+    expect(temp!).toBe('impure {"a":{"b":"thoughts"}}');
+    set("a", "b", "minds");
+    expect(temp!).toBe('impure {"a":{"b":"minds"}}');
   });
 });
 
@@ -687,7 +703,7 @@ describe("createRoot", () => {
       });
     });
   });
-  
+
   test("Allows to define detachedOwner", () => {
     let owner1: any;
     let owner2: any;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

I come from a Vue Background and I have used a lot the [`deep` watcher](https://vuejs.org/guide/essentials/watchers.html#deep-watchers) into reactive objects to make sync-like operations, e.g save to localStorage, send information to APIs, etc. So I would love to have something similar here.

I used a similar algorithm as Vue, as the reactive systems are similar, we just need to deepTraverse through the dependency and call any value in the Proxy object so that it triggers the effect once anything changes.

## How did you test this change?

- I created a UnitTest show-casing the behaviour of a deep traversed dependency object.
- Added the failing case when `deep` is off.
