### PR TITLE
Fix infinite loop in Suspense error handling on the server

### DIFF
--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -552,7 +552,6 @@ export function SuspenseList(props: {
 
 export function Suspense(props: { fallback?: string; children: string }) {
   let done: undefined | ((html?: string, error?: any) => boolean);
-  let clean: any;
   const ctx = sharedConfig.context!;
   const id = ctx.id + ctx.count;
   const o = createOwner();
@@ -569,8 +568,8 @@ export function Suspense(props: { fallback?: string; children: string }) {
     });
   function runSuspense() {
     setHydrateContext({ ...ctx, count: 0 });
-    o && cleanNode(o);
-    return runWithOwner(o!, () => {
+    cleanNode(o);
+    return runWithOwner(o, () => {
       return createComponent(SuspenseContext.Provider, {
         value,
         get children() {
@@ -584,14 +583,14 @@ export function Suspense(props: { fallback?: string; children: string }) {
   // never suspended
   if (suspenseComplete(value)) return res;
 
-  onError(err => {
-    if (!done || !done(undefined, err)) {
-      if (o)
-        runWithOwner(o.owner!, () => {
+  runWithOwner(o, () => {
+    onError(err => {
+      if (!done || !done(undefined, err)) {
+        runWithOwner(o.owner, () => {
           throw err;
         });
-      else throw err;
-    }
+      }
+    });
   });
   done = ctx.async ? ctx.registerFragment(id) : undefined;
   if (ctx.async) {


### PR DESCRIPTION
## Summary

Fixes #1648 

Suspense was attaching it's `onError` not to the `o` new owner it created, but to the current `Owner`, which ends up being the parent of `o`. So when it tries to pass the error to the parent with `runWithOwner`, it's actually passing it to itself creating an infinite loop.

## How did you test this change?

I see there are no server tests for solid-js at the moment. But patching solid-js locally has solved this issue for me.
I'm not sure if I should maybe try adding one using `// @jest-environment node` comment to force node env with jest?
Maybe after #1609 gets merged this could be improved.