### PR TITLE
Fix external source tests

### DIFF
--- a/.changeset/tender-sheep-eat.md
+++ b/.changeset/tender-sheep-eat.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Fix external source tests

--- a/package.json
+++ b/package.json
@@ -53,5 +53,10 @@
     "typescript": "^4.9.5",
     "vite-plugin-solid": "^2.7.0-beta.0",
     "vitest": "^0.29.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "babel-preset-solid": "workspace:*"
+    }
   }
 }

--- a/packages/solid/test/external-source.spec.ts
+++ b/packages/solid/test/external-source.spec.ts
@@ -1,5 +1,3 @@
-// Disabled until I can figure out why it is broken
-
 import { createRoot, createMemo, enableExternalSource } from "../src";
 
 import "./MessageChannel";
@@ -31,34 +29,35 @@ let listener: (() => void) | null = null;
 
 let sources: Map<() => void, Set<ExternalSource>> = new Map();
 
-enableExternalSource((fn, trigger) => {
-  sources.set(trigger, new Set());
-  return {
-    track: x => {
-      const tmp = listener;
-      // trigger could play the role of listener，as it has stable reference
-      listener = trigger;
-      try {
-        return fn(x);
-      } finally {
-        listener = tmp;
-      }
-    },
-    dispose: () => {
-      sources.get(trigger)!.forEach(x => x.removeListener(trigger));
-      sources.delete(trigger);
-    }
-  };
-});
-
-enableExternalSource(fn => {
-  return {
-    track: fn,
-    dispose: () => {}
-  };
-}); // do nothing, make sure multiple factories be piped.
-
 describe("external source", () => {
+  beforeEach(() => {
+    enableExternalSource((fn, trigger) => {
+      sources.set(trigger, new Set());
+      return {
+        track: x => {
+          const tmp = listener;
+          // trigger could play the role of listener，as it has stable reference
+          listener = trigger;
+          try {
+            return fn(x);
+          } finally {
+            listener = tmp;
+          }
+        },
+        dispose: () => {
+          sources.get(trigger)!.forEach(x => x.removeListener(trigger));
+          sources.delete(trigger);
+        }
+      };
+    });
+
+    enableExternalSource(fn => {
+      return {
+        track: fn,
+        dispose: () => {}
+      };
+    }); // do nothing, make sure multiple factories be piped.
+  });
   it("should trigger solid primitive update", () => {
     createRoot(fn => {
       const e = new ExternalSource(0);
@@ -70,5 +69,9 @@ describe("external source", () => {
       expect(memo()).toBe(1);
       fn();
     });
+  });
+
+  afterEach(() => {
+    vi.resetModules();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,8 @@
 lockfileVersion: 5.4
 
+overrides:
+  babel-preset-solid: workspace:*
+
 importers:
 
   .:
@@ -893,16 +896,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.18.9
-    dev: true
-
-  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.21.3:
-    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
@@ -2584,19 +2577,6 @@ packages:
       validate-html-nesting: 1.2.1
     dev: true
 
-  /babel-plugin-jsx-dom-expressions/0.36.0-beta.9_@babel+core@7.21.3:
-    resolution: {integrity: sha512-NPWuCbKk1IBXNs9waXemn48MazaEBFBzy0qTfbnuvyuf+YtkyDzQFvoX1kfObpnmRxqq13xb5SS0k1hGlsgCQQ==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-    dependencies:
-      '@babel/core': 7.21.3
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.21.3
-      '@babel/types': 7.21.3
-      html-entities: 2.3.3
-      validate-html-nesting: 1.2.1
-    dev: true
-
   /babel-plugin-polyfill-corejs2/0.3.1_@babel+core@7.20.12:
     resolution: {integrity: sha512-v7/T6EQcNfVLfcN2X8Lulb7DjprieyLWJK/zOWH5DUYcAgex9sP3h25Q+DLsX9TloXe3y1O8l2q2Jv9q8UVB9w==}
     peerDependencies:
@@ -2635,15 +2615,6 @@ packages:
 
   /babel-plugin-transform-rename-import/2.3.0:
     resolution: {integrity: sha512-dPgJoT57XC0PqSnLgl2FwNvxFrWlspatX2dkk7yjKQj5HHGw071vAcOf+hqW8ClqcBDMvEbm6mevn5yHAD8mlQ==}
-    dev: true
-
-  /babel-preset-solid/1.7.0-beta.4_@babel+core@7.21.3:
-    resolution: {integrity: sha512-HqVkf4g5H+0eGd41/O5kqFXD5+Z32uUhqgMSWYCOsaOUVBzvQBk6LkCbLEjltORK4MGSOl0EDmUg2ShngNUH1g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.21.3
-      babel-plugin-jsx-dom-expressions: 0.36.0-beta.9_@babel+core@7.21.3
     dev: true
 
   /balanced-match/1.0.2:
@@ -6091,7 +6062,7 @@ packages:
       '@babel/core': 7.21.3
       '@babel/preset-typescript': 7.18.6_@babel+core@7.21.3
       '@types/babel__core': 7.20.0
-      babel-preset-solid: 1.7.0-beta.4_@babel+core@7.21.3
+      babel-preset-solid: link:packages/babel-preset-solid
       merge-anything: 5.1.4
       solid-refresh: 0.5.2
       vitefu: 0.2.4


### PR DESCRIPTION
## Summary
This PR fixes the external source tests @ryansolid disabled in the next branch. This is done by only enabling external sources before the test runs, and then resetting imported modules after, bringing things back to a clean slate for the remaining tests. Also included is an override for babel-preset-solid to ensure it comes from the workspace instead of from vite-plugin-solid's dependency. I don't think this does anything specifically to fix the issue but is a good thing to have I would think, since we probably shouldn't be pulling it from npm normally?

## How did you test this change?
I ran brought back the external store test file and ran ```pnpm turbo run test test-types --force``` and everything passed!