### PR TITLE
make it harder for the optimizer to incorrectly export DEV twice

### DIFF
--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -69,19 +69,14 @@ type JSXElement = JSX.Element;
 export type { JSXElement, JSX };
 
 // dev
-import {
-  registerGraph,
-  writeSignal,
-  DevHooks
-} from "./reactive/signal.js";
-let DEV:
-  | {
+import { registerGraph, writeSignal, DevHooks } from "./reactive/signal.js";
+const DEV = "_SOLID_DEV_"
+  ? ({ hooks: DevHooks, writeSignal, registerGraph } as {
       readonly hooks: typeof DevHooks;
       readonly writeSignal: typeof writeSignal;
       readonly registerGraph: typeof registerGraph;
-    }
-  | undefined;
-if ("_SOLID_DEV_") DEV = { hooks: DevHooks, writeSignal, registerGraph };
+    })
+  : undefined;
 export { DEV };
 
 // handle multiple instance check


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

Try to fix https://github.com/solidjs/solid/issues/1660. I think `skypack` is complaining because `dev.cjs` after being optimized has 

```js
exports.DEV = void 0;
exports.DEV = {
  hooks: DevHooks,
  writeSignal,
  registerGraph
};
```
This change make it harder for the optimizer to export `DEV` twice.

```js
const DEV = "_SOLID_DEV_"
  ? ({ hooks: DevHooks, writeSignal, registerGraph } as {
      readonly hooks: typeof DevHooks;
      readonly writeSignal: typeof writeSignal;
      readonly registerGraph: typeof registerGraph;
    })
  : undefined;
export { DEV };
```

## How did you test this change?

I can´t test if this will fix `skypack` build.
