### PR TITLE
stores: array items tracking, removal, fixes #1695

### DIFF
--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -228,8 +228,10 @@ export function setProperty(
     node: DataNode | undefined;
   if ((node = getDataNode(nodes, property, prev))) node.$(() => value);
 
-  if (Array.isArray(state) && state.length !== len)
+  if (Array.isArray(state) && state.length !== len) {
+    for (let i = state.length; i < len; i++) (node = nodes[i]) && node.$();
     (node = getDataNode(nodes, "length", len)) && node.$(state.length);
+  }
   (node = nodes._) && node.$();
 }
 

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -292,6 +292,27 @@ describe("Tracking State changes", () => {
     setState("user", "firstName", "Jake");
   });
 
+  test("Track array item on removal", () => {
+    const [state, setState] = createStore([1]);
+    createRoot(() => {
+      let executionCount = 0;
+
+      expect.assertions(2);
+      createEffect(() => {
+        if (executionCount === 0) {
+          expect(state[0]).toBe(1);
+        } else if (executionCount === 1) {
+          expect(state[0]).toBe(undefined);
+        } else {
+          // should never get here
+          expect(executionCount).toBe(-1);
+        }
+        executionCount++;
+      });
+    });
+    setState([]);
+  });
+
   test("Tracking Top-Level Array iteration", () => {
     const [state, setState] = createStore(["hi"]);
     let executionCount = 0;


### PR DESCRIPTION
## Summary
Array items in stores are not removed when array `length` decreased which was initially reported in #1695 WRT `reconcile`. Actually this happens with anything that involves `length` only change. `setStore([])`, `setStore('length', v => v - 1)`, `setStore(produce(v => v.length--))`, `mutable.length = 0` etc. The test only uses the first one for `stores` but it should cover all of them hopefully.

## How did you test this change?
`pnpm test`
