### PR TITLE
Optimize `mergeProps` and `splitProps`

### DIFF
--- a/.changeset/tender-grapes-exercise.md
+++ b/.changeset/tender-grapes-exercise.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Improve performance in `splitProps` and `mergeProps`

--- a/packages/solid/test/component.bench.ts
+++ b/packages/solid/test/component.bench.ts
@@ -1,0 +1,151 @@
+import { mergeProps, splitProps } from "../src";
+import { bench } from "vitest";
+
+const staticDesc = {
+  value: 1,
+  writable: true,
+  configurable: true,
+  enumerable: true,
+};
+
+const signalDesc = {
+  get() {
+    return 1;
+  },
+  configurable: true,
+  enumerable: true,
+};
+
+const cache = new Map<string, any>()
+
+const createObject = (
+  name: string,
+  amount: number,
+  desc: (index: number) => PropertyDescriptor
+) => {
+  const key = `${name}-${amount}`
+  const cached = cache.get(key)
+  if (cached) return cached
+  const proto: Record<string, any> = {};
+  for (let index = 0; index < amount; ++index)
+    proto[`${name}${index}`] = desc(index);
+  const result = Object.defineProperties({}, proto) as Record<string, any>;
+  cache.set(key, result)
+  return result
+};
+
+const keys = (o: Record<string, any>) => Object.keys(o);
+
+type Test = {
+  title: string;
+  benchs: { title: string; func: any }[];
+};
+
+function createTest<
+  T extends (...args: any[]) => any,
+  G extends (...args: any[]) => any
+>(options: {
+  name: string;
+  /**
+   * `vitest bench -t "FILTER"` does not work
+   */
+  filter?: RegExp;
+  subjects: {
+    name: string;
+    func: T;
+  }[];
+  generator: Record<string, G>;
+  inputs: (generator: G) => Record<string, Parameters<T>>;
+}) {
+  const tests: Test[] = [];
+  for (const generatorName in options.generator) {
+    const generator = options.generator[generatorName];
+    const inputs = options.inputs(generator);
+    for (const inputName in inputs) {
+      const args = inputs[inputName];
+      const test: Test = {
+        title: `${options.name}-${generatorName}${inputName}`,
+        benchs: [],
+      };
+      if (options.filter && !options.filter.exec(test.title)) continue;
+      for (const subject of options.subjects) {
+        test.benchs.push({
+          title: subject.name,
+          func: () => subject.func(...args),
+        });
+      }
+      tests.push(test);
+    }
+  }
+  return tests;
+}
+
+type SplitProps = (...args: any[]) => Record<string, any>[];
+
+const generator = {
+  static: (amount: number) => createObject("static", amount, () => staticDesc),
+  signal: (amount: number) => createObject("signal", amount, () => signalDesc),
+  mixed: (amount: number) =>
+    createObject("mixed", amount, (v) => (v % 2 ? staticDesc : signalDesc)),
+} as const;
+
+const filter = new RegExp(process.env.FILTER || ".+");
+
+const splitPropsTests = createTest({
+  filter,
+  name: "splitProps",
+  subjects: [
+    {
+      name: "splitProps",
+      func: splitProps as SplitProps,
+    },
+  ],
+  generator,
+  inputs: (g) => ({
+    "(5, 1)": [g(5), keys(g(1))],
+    "(5, 1, 2)": [g(5), keys(g(1)), keys(g(2))],
+    "(0, 15)": [g(0), keys(g(15))],
+    "(0, 3, 2)": [g(0), keys(g(3)), keys(g(2))],
+    "(0, 100)": [g(0), keys(g(100))],
+    "(0, 100, 3, 2)": [g(0), keys(g(100)), keys(g(3)), keys(g(2))],
+    "(25, 100)": [g(25), keys(g(100))],
+    "(50, 100)": [g(50), keys(g(100))],
+    "(100, 25)": [g(100), keys(g(25))],
+  }),
+});
+
+const mergePropsTest = createTest({
+  name: "mergeProps",
+  filter,
+  subjects: [
+    {
+      name: "mergeProps",
+      func: mergeProps,
+    },
+  ],
+  generator,
+  inputs: (g) => ({
+    "(5, 1)": [g(5), g(1)],
+    "(5, 1, 2)": [g(5), g(1), g(2)],
+    "(0, 15)": [g(0), g(15)],
+    "(0, 3, 2)": [g(0), g(3), g(2)],
+    "(0, 100)": [g(0), g(100)],
+    "(0, 100, 3, 2)": [g(0), g(100), g(3), g(2)],
+    "(25, 100)": [g(25), g(100)],
+    "(50, 100)": [g(50), g(100)],
+    "(100, 25)": [g(100), g(25)],
+  }),
+});
+
+for (const test of splitPropsTests) {
+  describe(test.title, () => {
+    for (const { title, func } of test.benchs) bench(title, func);
+  });
+}
+
+for (const test of mergePropsTest) {
+  describe(test.title, () => {
+    for (const { title, func } of test.benchs) bench(title, func);
+  });
+}
+


### PR DESCRIPTION
## Summary

1. `Object.defineProperties` is slower than `Object.defineProperty`.
2. `Object.getOwnPropertyDescriptors` is slower than `Object.getOwnPropertyDescriptor`.
3. `Object.defineProperty` is slower than to assign a value.
4. Obviously, getter is slower than value access.

## How did you test this change?

```sh
cd packages/solid
npm t
```

```sh
FILTER=mergeProps npx vitest bench --run
```
<details>
<summary>report</summary>

```
 RUN  v0.29.3

 ✓ test/component.bench.ts  (54 tests) 31401ms


 BENCH  Summary

  mergeProps - test/component.bench.ts > mergeProps-static(5, 1)
    1.85x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-static(5, 1, 2)
    1.96x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-static(0, 15)
    1.58x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-static(0, 3, 2)
    1.86x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-static(0, 100)
    1.67x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-static(0, 100, 3, 2)
    2.03x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-static(25, 100)
    1.78x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-static(50, 100)
    1.86x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-static(100, 25)
    1.85x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-signal(5, 1)
    1.52x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-signal(5, 1, 2)
    1.65x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-signal(0, 15)
    1.51x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-signal(0, 3, 2)
    1.77x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-signal(0, 100)
    1.61x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-signal(0, 100, 3, 2)
    1.65x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-signal(25, 100)
    1.56x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-signal(50, 100)
    1.55x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-signal(100, 25)
    1.70x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-mixed(5, 1)
    1.61x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-mixed(5, 1, 2)
    1.69x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-mixed(0, 15)
    1.60x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-mixed(0, 3, 2)
    1.59x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-mixed(0, 100)
    1.55x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-mixed(0, 100, 3, 2)
    1.58x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-mixed(25, 100)
    1.62x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-mixed(50, 100)
    1.62x faster than oldMergeProps

  mergeProps - test/component.bench.ts > mergeProps-mixed(100, 25)
    1.63x faster than oldMergeProps

```
</details>

```sh
FILTER=splitProps-mixed npx vitest bench --run
```
<details>
<summary>report</summary>

```
 RUN  v0.29.3

 ✓ test/component.bench.ts  (18 tests) 13908ms


 BENCH  Summary

  splitProps - test/component.bench.ts > splitProps-mixed(5, 1)
    2.19x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-mixed(5, 1, 2)
    2.19x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-mixed(0, 15)
    4.71x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-mixed(0, 3, 2)
    6.65x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-mixed(0, 100)
    24.16x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-mixed(0, 100, 3, 2)
    77.38x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-mixed(25, 100)
    2.98x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-mixed(50, 100)
    2.84x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-mixed(100, 25)
    2.92x faster than oldSplitProps
```
</details>

```sh
FILTER=splitProps-signal npx vitest bench --run
```
<details>
<summary>report</summary>

```

 RUN  v0.29.3

 ✓ test/component.bench.ts  (18 tests) 13717ms


 BENCH  Summary

  splitProps - test/component.bench.ts > splitProps-signal(5, 1)
    1.70x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-signal(5, 1, 2)
    1.87x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-signal(0, 15)
    4.83x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-signal(0, 3, 2)
    6.20x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-signal(0, 100)
    24.08x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-signal(0, 100, 3, 2)
    72.55x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-signal(25, 100)
    2.18x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-signal(50, 100)
    2.04x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-signal(100, 25)
    2.37x faster than oldSplitProps
```
</details>

```sh
FILTER=splitProps-static npx vitest bench --run
```
<details>
<summary>report</summary>

```

 RUN  v0.29.3

 ✓ test/component.bench.ts  (18 tests) 14521ms


 BENCH  Summary

  splitProps - test/component.bench.ts > splitProps-static(5, 1)
    6.35x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-static(5, 1, 2)
    7.86x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-static(0, 15)
    4.96x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-static(0, 3, 2)
    6.82x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-static(0, 100)
    25.39x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-static(0, 100, 3, 2)
    77.97x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-static(25, 100)
    10.81x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-static(50, 100)
    8.31x faster than oldSplitProps

  splitProps - test/component.bench.ts > splitProps-static(100, 25)
    7.25x faster than oldSplitProps
```
</details>