### PR TITLE
Solid-Element: Add clarification on 'props' parameter in customElement function

### DIFF
--- a/.changeset/gorgeous-parents-greet.md
+++ b/.changeset/gorgeous-parents-greet.md
@@ -1,0 +1,6 @@
+---
+"solid-element": patch
+"solid-js": patch
+---
+
+Solid-Element: Add clarification on 'props' parameter in customElement function

--- a/packages/solid-element/README.md
+++ b/packages/solid-element/README.md
@@ -22,7 +22,7 @@ The simplest way to create a Web Component is to use the `customElement` method.
 
 The arguments of `customElement` are:
 1) custom element tag (e.g. `'my-component'`)
-2) (optional) props (e.g. `{someProp: 'one', otherProp: 'two'}`)
+2) (optional) Default prop values (e.g. `{someProp: 'one', otherProp: 'two'}`). Props without default values will be ignored by the customElement.
 3) the Solid template function. The arguments of this function are state wrapped props as the first argument, and the underlying element as the 2nd (e.g. `(props, { element }) => {  solid code here
  }`)
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
When defining a customElement, you have to provide default prop values or the CE won't respond to changes to
the props. Currently it looks like it's only for providing default values, but it's in fact a prop definition that is used by the underlying component-register lib.
 See https://github.com/ryansolid/component-register/blob/aef1a09a435043cb10692c7ab7b0667bda6cdbe8/src/element.ts#LL95C36-L95C36
-->

## How did you test this change?

N/A
