### PR TITLE
feature: allow configuring the initial value of from

### DIFF
--- a/packages/solid/src/reactive/observable.ts
+++ b/packages/solid/src/reactive/observable.ts
@@ -87,9 +87,21 @@ export function observable<T>(input: Accessor<T>): Observable<T> {
 export function from<T>(
   producer:
     | ((setter: Setter<T | undefined>) => () => void)
-    | { subscribe: (fn: (v: T) => void) => (() => void) | { unsubscribe: () => void } }
+    | { subscribe: (fn: (v: T) => void) => (() => void) | { unsubscribe: () => void }}
+): Accessor<T | undefined>;
+export function from<T>(
+  producer:
+    | ((setter: Setter<T | undefined>) => () => void)
+    | { subscribe: (fn: (v: T) => void) => (() => void) | { unsubscribe: () => void }, initialValue: T}
+): Accessor<T>;
+
+export function from<T>(
+  producer:
+    | ((setter: Setter<T | undefined>) => () => void)
+    | { subscribe: (fn: (v: T) => void) => (() => void) | { unsubscribe: () => void }, initialValue?: T }
 ): Accessor<T | undefined> {
-  const [s, set] = createSignal<T | undefined>(undefined, { equals: false });
+  const initialValue = "initialValue" in producer ? producer.initialValue : undefined;
+  const [s, set] = createSignal<T | undefined>(initialValue, { equals: false });
   if ("subscribe" in producer) {
     const unsub = producer.subscribe(v => set(() => v));
     onCleanup(() => ("unsubscribe" in unsub ? unsub.unsubscribe() : unsub()));

--- a/packages/solid/test/observable.spec.ts
+++ b/packages/solid/test/observable.spec.ts
@@ -64,7 +64,7 @@ describe("from transform", () => {
     vi.useRealTimers();
   });
 
-  test("without initialValue but setting a value in the setup", async () => {
+  test("manual set without initialValue", async () => {
    let out: () => undefined | number;
 
     createRoot(() => {
@@ -88,7 +88,7 @@ describe("from transform", () => {
     expect(out!()).toBe(1);
   });
 
-  test("without initialValue but setting a value in the setup", async () => {
+  test("manual set without initialValue but setting a value in the setup", async () => {
     let out: () => undefined | number;
 
     createRoot(() => {
@@ -113,7 +113,7 @@ describe("from transform", () => {
     expect(out!()).toBe(2);
   });
 
-  test("with initialValue", async () => {
+  test("manual set with initialValue", async () => {
     let out: () => number; // froms with initalValue can be strongly typed
 
     createRoot(() => {
@@ -153,7 +153,6 @@ describe("from transform", () => {
     expect(out!()).toBe("John");
   });
 
- 
   test("from producer", async () => {
     let out: () => string | undefined;
     let set: (v: string) => void;

--- a/packages/solid/test/observable.spec.ts
+++ b/packages/solid/test/observable.spec.ts
@@ -57,6 +57,87 @@ describe("Observable operator", () => {
 });
 
 describe("from transform", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("without initialValue but setting a value in the setup", async () => {
+   let out: () => undefined | number;
+
+    createRoot(() => {
+      out = from({
+        subscribe: (set) => {
+          let counter = 0;
+          const interval = setInterval(() => {
+            set(counter++);
+          }, 100);
+          return () => { 
+            clearInterval(interval) 
+          };
+        },
+      });
+    });
+
+    expect(out!()).toBe(undefined);
+    vi.advanceTimersByTime(100);
+    expect(out!()).toBe(0);
+    vi.advanceTimersByTime(100);
+    expect(out!()).toBe(1);
+  });
+
+  test("without initialValue but setting a value in the setup", async () => {
+    let out: () => undefined | number;
+
+    createRoot(() => {
+      out = from({
+        subscribe: (set) => {
+          let counter = 0;
+          set(0);
+          const interval = setInterval(() => {
+            set(++counter);
+          }, 100);
+          return () => { 
+            clearInterval(interval) 
+          };
+        },
+      });
+    });
+
+    expect(out!()).toBe(0);
+    vi.advanceTimersByTime(100);
+    expect(out!()).toBe(1);
+    vi.advanceTimersByTime(100);
+    expect(out!()).toBe(2);
+  });
+
+  test("with initialValue", async () => {
+    let out: () => number; // froms with initalValue can be strongly typed
+
+    createRoot(() => {
+      let counter = 0;
+      out = from({
+        subscribe: (set) => {
+          const interval = setInterval(() => {
+            set(++counter);
+          }, 100);
+          return () => { 
+            clearInterval(interval) 
+          };
+        },
+        initialValue: counter,
+      });
+    });
+
+    expect(out!()).toBe(0);
+    vi.advanceTimersByTime(100);
+    expect(out!()).toBe(1);
+    vi.advanceTimersByTime(100);
+    expect(out!()).toBe(2);
+  });
+
   test("from subscribable", async () => {
     let out: () => string | undefined;
     let set: (v: string) => void;
@@ -72,6 +153,7 @@ describe("from transform", () => {
     expect(out!()).toBe("John");
   });
 
+ 
   test("from producer", async () => {
     let out: () => string | undefined;
     let set: (v: string) => void;


### PR DESCRIPTION
## Summary

I added an option to pass an initial value to `from`. This allows for easier integration with 3th party observables. For example, OpenLayers has their own kind of observables where they emit an event if something changed.
```typescript
const view = fromSomewhere();
const viewProperties = from<Properties>((set) => {
    const syncProperties = () => {
      const olProps = view.getProperties();
      set(olProps);
    };
    syncProperties();
    props.view.on("propertychange", syncProperties);
    return () => props.view.un("propertychange", syncProperties);
 }) as Accessor<Properties>;
```

This code has multiple problems:
1. You need to call set directly in the setup, otherwise the signal will be undefined until the first event is emitted.
2. Typescript can't possibly know that the signal will never be undefined since it does not know what happens in the setup, so you have to do a manual cast to `Accessor<Properties>`. This makes the code more brittle, considering that you might forget to call the `set()` in the setup

As such, I changed the api of from that you can define an inital value. The previous code can then be rewritten to: 
```typescript
// this will now be inferred to Accessor<Properties>
const viewProperties = from<Properties>({
  subscribe: (set) => {
    const syncProperties = () => {
      const olProps = view.getProperties();
      set(olProps);
    };
    view.on("propertychange", syncProperties);
    return () => view.un("propertychange", syncProperties);
   },
   initialValue: view.getProperties(),
});
```

We can possibly also implement this for the function syntax (the one in use on the original example). I've not done it in this PR, but if there is interest in it, I will do so.

## How did you test this change?

I added some test cases
