### PR TITLE
feature: Add document property to owner

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -82,6 +82,7 @@ export interface SignalState<T> extends SourceMapValue {
 }
 
 export interface Owner {
+  root?: Owner;
   owned: Computation<any>[] | null;
   cleanups: (() => void)[] | null;
   owner: Owner | null;
@@ -145,6 +146,7 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: typeof Owner)
         ? { owned: null, cleanups: null, context: null, owner: null }
         : UNOWNED
       : {
+          root: detachedOwner?.root ?? owner?.root,
           owned: null,
           cleanups: null,
           context: null,
@@ -1396,6 +1398,7 @@ function createComputation<Next, Init = unknown>(
     sourceSlots: null,
     cleanups: null,
     value: init,
+    root: Owner?.root,
     owner: Owner,
     context: null,
     pure


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

I currently work on an application based on microfrontends (MFEs) architecture. We have several teams working on different parts of the application and we currently use React.
Our setup consists on having each MFE contained in its own shadow root, having its own style and dependencices.

All the MFEs also use a component library that is based on webcomponents. Since different versions of the library are going to be used by different teams, we can't use the default `window.customElements` registry to store webcomponents.
We current use this [polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/scoped-custom-element-registry) that allows us to attach custom element registries to the MFEs shadow roots. The polyfill also attaches other functions to the shadow root e.g. `createElement`, `importNode`, etc... so it can be used as if it as a `Document` instance.

We also use React to render custom elements from the shadowRoot rather than window.
This is possible because when rendering elements, react will use the `ownerDocument` of the element passed to `createRoot`, so we can easily set the element's `ownerDocument` to be the shadowRoot itself and the render phase will use the custom functions attached to the shadow root. [(this is where react gets the ownerDocument, search for getOwnerDocumentFromRootContainer) ](https://github.com/facebook/react/blob/6fc3333b685657c8e6425df9fcb4fe1ce7374d40/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js#L196)

I have been trying to use Solid as an alternative to react in our application.
One thing that is preventing me from that is the fact that when rendering templates with custom elements, solid always uses `document.importNode`, there is no way to change it to use documents other than `window.document`.

So my idea was to make it possible to change the document that is used for rendering.
The idea consists on two small changes on this project (this PR), and on dom-expressions.

In this PR I added a new `document` property to owners when solid's `createRoot` and `createComputation` are called (not sure if it is needed on computations).
When child owners are created, I copy the document ref to make access easier.
One thing that concerns me is that the signal.js file there are no mentions to any DOM apis/types. So maybe that could be done in another way. In any way, the owner.document property is never used, just set.

In the [dom-expressions PR](https://github.com/ryansolid/dom-expressions/pull/253) I make two changes to the client.js file, one in the `render` function, it now always pass a owner to `createRoot`, that owner contains the document property set to the root element's `ownerDocument`.
And in the `template` function, instead of just calling `document.importNode`, it uses `(getOwner().document || document).importNode`.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

This is my first PR in solid, I did not find much information on how to create a test build for both projects at once.
Since the amount of changes is very small, made the proposed changes directly to the solid dist files in my node_modules directory to verify that it works.

All existing tests on both projects also passed, I'm not sure if a test is necessary on this PR, it is just a new optional property on Owner. Maybe on the dom-extensions PR, but again, minor changes to render and template function, which I think are being tested already.

