### PR TITLE
Improve type inference of `createSelector`.

### DIFF
--- a/.changeset/five-cats-compare.md
+++ b/.changeset/five-cats-compare.md
@@ -2,4 +2,4 @@
 "solid-js": patch
 ---
 
-Add function overloads to `createSelector` to improve type inference.
+Improve type inference of `createSelector`.

--- a/.changeset/five-cats-compare.md
+++ b/.changeset/five-cats-compare.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Add function overloads to `createSelector` to improve type inference.

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -784,13 +784,7 @@ export type EqualityCheckerFunction<T, U> = (a: U, b: T) => boolean;
  *
  * @description https://www.solidjs.com/docs/latest/api#createselector
  */
-export function createSelector<T, U = T>(source: Accessor<T>): (key: U) => boolean;
 export function createSelector<T, U = T>(
-  source: Accessor<T>,
-  fn: EqualityCheckerFunction<T, U>,
-  options?: BaseOptions
-): (key: U) => boolean;
-export function createSelector<T, U>(
   source: Accessor<T>,
   fn: EqualityCheckerFunction<T, U> = equalFn as TODO,
   options?: BaseOptions

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -784,18 +784,8 @@ export type EqualityCheckerFunction<T, U> = (a: U, b: T) => boolean;
  *
  * @description https://www.solidjs.com/docs/latest/api#createselector
  */
-// default equality checke
-export function createSelector<T, U /* U left for backwards compatibility */>(
-  source: Accessor<T>
-): (key: T) => boolean;
-// custom equality checker
-export function createSelector<T, U /* U left for backwards compatibility */>(
-  source: Accessor<T>,
-  fn: EqualityCheckerFunction<T, T>,
-  options?: BaseOptions
-): (key: T) => boolean;
-// custom equality checker and key type
-export function createSelector<T, U>(
+export function createSelector<T, U = T>(source: Accessor<T>): (key: U) => boolean;
+export function createSelector<T, U = T>(
   source: Accessor<T>,
   fn: EqualityCheckerFunction<T, U>,
   options?: BaseOptions

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -784,6 +784,22 @@ export type EqualityCheckerFunction<T, U> = (a: U, b: T) => boolean;
  *
  * @description https://www.solidjs.com/docs/latest/api#createselector
  */
+// default equality checke
+export function createSelector<T, U /* U left for backwards compatibility */>(
+  source: Accessor<T>
+): (key: T) => boolean;
+// custom equality checker
+export function createSelector<T, U /* U left for backwards compatibility */>(
+  source: Accessor<T>,
+  fn: EqualityCheckerFunction<T, T>,
+  options?: BaseOptions
+): (key: T) => boolean;
+// custom equality checker and key type
+export function createSelector<T, U>(
+  source: Accessor<T>,
+  fn: EqualityCheckerFunction<T, U>,
+  options?: BaseOptions
+): (key: U) => boolean;
 export function createSelector<T, U>(
   source: Accessor<T>,
   fn: EqualityCheckerFunction<T, U> = equalFn as TODO,

--- a/packages/solid/test/signals.type-tests.ts
+++ b/packages/solid/test/signals.type-tests.ts
@@ -722,6 +722,12 @@ const onMemo4: Accessor<number> = onMemo3;
   const bool2: boolean = selector("123");
 }
 {
+  const selector = createSelector(() => 123, undefined, { name: "test" });
+  const bool: boolean = selector(123);
+  // @ts-expect-error Argument of type 'string' is not assignable to parameter of type 'number'. ts(2345)
+  const bool2: boolean = selector("123");
+}
+{
   const selector = createSelector<number | string>(() => 123);
   const bool: boolean = selector(123);
   const bool2: boolean = selector("123");
@@ -744,6 +750,16 @@ const onMemo4: Accessor<number> = onMemo3;
   );
   // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'string'. ts(2345)
   const bool: boolean = selector(123);
+  const bool2: boolean = selector("123");
+}
+{
+  const selector = createSelector(
+    () => 123,
+    (key, source) => key === source,
+    { name: "test" }
+  );
+  const bool: boolean = selector(123);
+  // @ts-expect-error Argument of type 'string' is not assignable to parameter of type 'number'. ts(2345)
   const bool2: boolean = selector("123");
 }
 

--- a/packages/solid/test/signals.type-tests.ts
+++ b/packages/solid/test/signals.type-tests.ts
@@ -716,22 +716,32 @@ const onMemo4: Accessor<number> = onMemo3;
 //////////////////////////////////////////////////////////////////////////
 
 {
-  const source = (): number => 123;
-  const selector = createSelector(source);
+  const selector = createSelector(() => 123);
   const bool: boolean = selector(123);
   // @ts-expect-error Argument of type 'string' is not assignable to parameter of type 'number'. ts(2345)
   const bool2: boolean = selector("123");
 }
 {
-  const source = (): number => 123;
-  const selector = createSelector(source, (key, source) => key === source);
+  const selector = createSelector<number | string>(() => 123);
+  const bool: boolean = selector(123);
+  const bool2: boolean = selector("123");
+  // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'string | number'. ts(2345)
+  const bool3: boolean = selector(null);
+}
+{
+  const selector = createSelector(
+    () => 123,
+    (key, source) => key === source
+  );
   const bool: boolean = selector(123);
   // @ts-expect-error Argument of type 'string' is not assignable to parameter of type 'number'. ts(2345)
   const bool2: boolean = selector("123");
 }
 {
-  const source = (): number => 123;
-  const selector = createSelector(source, (key: string, source) => Number(key) === source);
+  const selector = createSelector(
+    () => 123,
+    (key: string, source) => Number(key) === source
+  );
   // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'string'. ts(2345)
   const bool: boolean = selector(123);
   const bool2: boolean = selector("123");

--- a/packages/solid/test/signals.type-tests.ts
+++ b/packages/solid/test/signals.type-tests.ts
@@ -6,6 +6,7 @@ import {
   Accessor,
   on,
   createSignal,
+  createSelector,
   Signal,
   Setter
   // } from "../types/index";
@@ -709,6 +710,32 @@ const onMemo3 = createMemo(
 );
 // @ts-expect-error when deferred the type includes undefined
 const onMemo4: Accessor<number> = onMemo3;
+
+//////////////////////////////////////////////////////////////////////////
+// createSelector ////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+{
+  const source = (): number => 123;
+  const selector = createSelector(source);
+  const bool: boolean = selector(123);
+  // @ts-expect-error Argument of type 'string' is not assignable to parameter of type 'number'. ts(2345)
+  const bool2: boolean = selector("123");
+}
+{
+  const source = (): number => 123;
+  const selector = createSelector(source, (key, source) => key === source);
+  const bool: boolean = selector(123);
+  // @ts-expect-error Argument of type 'string' is not assignable to parameter of type 'number'. ts(2345)
+  const bool2: boolean = selector("123");
+}
+{
+  const source = (): number => 123;
+  const selector = createSelector(source, (key: string, source) => Number(key) === source);
+  // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'string'. ts(2345)
+  const bool: boolean = selector(123);
+  const bool2: boolean = selector("123");
+}
 
 //////////////////////////////////////////////////////////////////////////
 // variations of signal types ////////////////////////////////////////////

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 overrides:
   babel-preset-solid: workspace:*


### PR DESCRIPTION
The types for `createSelector` are making this primitive annoying to use if we want to use the default equality checker - omit the second param - we have to pass an explicit `<number, number>` generic to get the right `key` type. Otherwise the selector function will be `(key: unknown) => boolean`.

![image](https://github.com/solidjs/solid/assets/24491503/98b66abb-13df-47ca-a652-2ab1ef905c46)

This adds overloads to the function to infer the type of the `key` from `source`. It still can be overwritten and should be comparable with current uses of the primitive.

Added some basic type tests to cover the types.