### PR TITLE
Propagate errors to parents when throwing errors in nested catchError

### DIFF
--- a/.changeset/cyan-moons-wink.md
+++ b/.changeset/cyan-moons-wink.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Propagate errors to parents when throwing errors in nested catchError

--- a/packages/solid/src/server/reactive.ts
+++ b/packages/solid/src/server/reactive.ts
@@ -18,11 +18,16 @@ export function castError(err: unknown): Error {
   return new Error(typeof err === "string" ? err : "Unknown error", { cause: err });
 }
 
-function handleError(err: unknown): void {
+function handleError(err: unknown, owner = Owner): void {
+  const fns = lookup(owner, ERROR);
   const error = castError(err);
-  const fns = lookup(Owner, ERROR);
   if (!fns) throw error;
-  for (const f of fns) f(error);
+
+  try {
+    for (const f of fns) f(error);
+  } catch (e) {
+    handleError(e, owner?.owner || null);
+  }
 }
 
 const UNOWNED: Owner = { context: null, owner: null, owned: null, cleanups: null };

--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -456,6 +456,28 @@ describe("catchError", () => {
     expect(errored).toBe(true);
   });
 
+  test("Nested in catchError", () => {
+    let errored = false;
+    expect(() =>
+      createRoot(() => {
+        catchError(
+          () => {
+            catchError(
+              () => {
+                throw "fail";
+              },
+              error => {
+                throw error;
+              }
+            );
+          },
+          () => (errored = true)
+        );
+      })
+    ).not.toThrow("fail");
+    expect(errored).toBe(true);
+  });
+
   test("In initial effect", () => {
     let errored = false;
     expect(() =>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

While Im not sure yet if this is really the expected behaviour (at lest that's what doc says), it was quite easy to make catchError errors bubbling through parents.

Fixes: #1773 

## How did you test this change?

`pnpm test`