### PR TITLE
Feature: Add defaultProps helper function

### DIFF
--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -265,6 +265,14 @@ export function mergeProps<T extends unknown[]>(...sources: T): MergeProps<T> {
   return target as any;
 }
 
+export type DefaultProps<T, K extends keyof T> = MergeProps<[Required<Pick<T, K>>, T]>;
+export function defaultProps<T, K extends keyof T>(
+  defaults: Required<Pick<T, K>>,
+  props: T
+): DefaultProps<T, K> {
+  return mergeProps(defaults, props);
+}
+
 export type SplitProps<T, K extends (readonly (keyof T)[])[]> = [
   ...{
     [P in keyof K]: P extends `${number}`

--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -267,8 +267,8 @@ export function mergeProps<T extends unknown[]>(...sources: T): MergeProps<T> {
 
 export type DefaultProps<T, K extends keyof T> = MergeProps<[Required<Pick<T, K>>, T]>;
 export function defaultProps<T, K extends keyof T>(
-  defaults: Required<Pick<T, K>>,
-  props: T
+  props: T,
+  defaults: Required<Pick<T, K>>
 ): DefaultProps<T, K> {
   return mergeProps(defaults, props);
 }

--- a/packages/solid/test/component.spec.ts
+++ b/packages/solid/test/component.spec.ts
@@ -2,6 +2,7 @@ import {
   createRoot,
   createComponent,
   mergeProps,
+  defaultProps,
   splitProps,
   createUniqueId,
   createSignal,
@@ -225,21 +226,60 @@ describe("mergeProps", () => {
   });
 });
 
-describe("Set Default Props", () => {
-  test("simple set", () => {
+describe("defaultProps", () => {
+  test("empty defaults", () => {
     let props: SimplePropTypes = {
-        get a() {
-          return "ji";
-        },
-        b: null,
-        c: "j"
+      get a() {
+        return "beep";
       },
-      defaults: SimplePropTypes = { a: "yy", b: "ggg", d: "DD" };
-    props = mergeProps(defaults, props);
-    expect(props.a).toBe("ji");
+      b: null,
+      c: "boop"
+    };
+    props = defaultProps({}, props);
+    expect(props.a).toBe("beep");
     expect(props.b).toBe(null);
-    expect(props.c).toBe("j");
-    expect(props.d).toBe("DD");
+    expect(props.c).toBe("boop");
+    expect(props.d).toBe(undefined);
+  });
+  it("overwrites only undefined values", () => {
+    let props: SimplePropTypes = {
+      get a() {
+        return "beep";
+      },
+      b: null,
+      c: "boop"
+    };
+    props = defaultProps(
+      {
+        a: "xxx",
+        b: "xxx",
+        c: "xxx",
+        d: "xxx"
+      },
+      props
+    );
+    expect(props.a).toBe("beep");
+    expect(props.b).toBe(null);
+    expect(props.c).toBe("boop");
+    expect(props.d).toBe("xxx");
+  });
+  it("allows null as a default", () => {
+    let props: SimplePropTypes = {
+      a: "defined",
+      c: null
+    };
+    props = defaultProps(
+      {
+        a: null,
+        b: null,
+        c: null
+      },
+      props
+    );
+    expect(props.a).toBe("defined");
+    expect(props.b).toBe(null);
+    expect(props.c).toBe(null);
+    expect(props.d).toBe(undefined);
   });
 });
 

--- a/packages/solid/test/component.spec.ts
+++ b/packages/solid/test/component.spec.ts
@@ -235,7 +235,7 @@ describe("defaultProps", () => {
       b: null,
       c: "boop"
     };
-    props = defaultProps({}, props);
+    props = defaultProps(props, {});
     expect(props.a).toBe("beep");
     expect(props.b).toBe(null);
     expect(props.c).toBe("boop");
@@ -249,15 +249,12 @@ describe("defaultProps", () => {
       b: null,
       c: "boop"
     };
-    props = defaultProps(
-      {
-        a: "xxx",
-        b: "xxx",
-        c: "xxx",
-        d: "xxx"
-      },
-      props
-    );
+    props = defaultProps(props, {
+      a: "xxx",
+      b: "xxx",
+      c: "xxx",
+      d: "xxx"
+    });
     expect(props.a).toBe("beep");
     expect(props.b).toBe(null);
     expect(props.c).toBe("boop");
@@ -268,14 +265,11 @@ describe("defaultProps", () => {
       a: "defined",
       c: null
     };
-    props = defaultProps(
-      {
-        a: null,
-        b: null,
-        c: null
-      },
-      props
-    );
+    props = defaultProps(props, {
+      a: null,
+      b: null,
+      c: null
+    });
     expect(props.a).toBe("defined");
     expect(props.b).toBe(null);
     expect(props.c).toBe(null);

--- a/packages/solid/test/component.type-tests.ts
+++ b/packages/solid/test/component.type-tests.ts
@@ -1,4 +1,4 @@
-import { mergeProps, splitProps } from "../src";
+import { mergeProps, defaultProps, splitProps } from "../src";
 
 type Assert<T extends true> = never;
 // from: https://github.com/Microsoft/TypeScript/issues/27024#issuecomment-421529650
@@ -181,6 +181,54 @@ function M4<T extends keyof M4Type = "a">(
   type M9 = typeof m9;
   type TestM9 = Assert<IsExact<M9, { a?: number; b?: number; c?: number }>>;
 }
+
+// d1: defaultProps preserves prop types
+type D1Props = {
+  a?: string;
+  b: string;
+  c?: "one" | "two" | "three";
+  d: "one" | "two" | "three";
+  e?: [1, 2, 3];
+  f: [1, 2, 3];
+  g?: [string, number, "one" | "two", 3 | 4];
+  h: [string, number, "one" | "two", 3 | 4];
+  i?: null;
+  j: null;
+};
+const d1 = defaultProps({}, {} as D1Props);
+type D1 = typeof d1;
+type TestD1 = Assert<IsExact<D1, D1Props>>;
+
+// d2: defaultProps removes undefined on merged props
+const d2 = defaultProps(
+  {
+    a: "hello",
+    b: "two",
+    c: [1, 2, 3],
+    d: ["string", 99, "one", 4],
+    e: null
+  },
+  {} as {
+    a?: string;
+    b?: "one" | "two" | "three";
+    c?: [1, 2, 3];
+    d?: [string, number, "one" | "two", 3 | 4];
+    e?: null;
+  }
+);
+type D2 = typeof d2;
+type TestD2 = Assert<
+  IsExact<
+    D2,
+    {
+      a: string;
+      b: "one" | "two" | "three";
+      c: [1, 2, 3];
+      d: [string, number, "one" | "two", 3 | 4];
+      e: null;
+    }
+  >
+>;
 
 // s1-s3: splitProps return type is correct regardless of usage
 const s1 = splitProps({ a: 1, b: 2 }, ["a"]);

--- a/packages/solid/test/component.type-tests.ts
+++ b/packages/solid/test/component.type-tests.ts
@@ -195,25 +195,25 @@ type D1Props = {
   i?: null;
   j: null;
 };
-const d1 = defaultProps({}, {} as D1Props);
+const d1 = defaultProps({} as D1Props, {});
 type D1 = typeof d1;
 type TestD1 = Assert<IsExact<D1, D1Props>>;
 
 // d2: defaultProps removes undefined on merged props
 const d2 = defaultProps(
-  {
-    a: "hello",
-    b: "two",
-    c: [1, 2, 3],
-    d: ["string", 99, "one", 4],
-    e: null
-  },
   {} as {
     a?: string;
     b?: "one" | "two" | "three";
     c?: [1, 2, 3];
     d?: [string, number, "one" | "two", 3 | 4];
     e?: null;
+  },
+  {
+    a: "hello",
+    b: "two",
+    c: [1, 2, 3],
+    d: ["string", 99, "one", 4],
+    e: null
   }
 );
 type D2 = typeof d2;


### PR DESCRIPTION
## Summary

mergeProps provides the current standard way of adding default props to a component, but it has some weaknesses when it comes to typing (see #1526). defaultProps essentially adds a subset of mergeProps functionality but with more restricted typing for the specific case of providing default props to a component. It has two main advantages:
- Exact typings are preserved (e.g. `"start" | "center" | "end"` does not get transformed into `string`)
- The default props are restricted to providing keys that are already defined as Component props. This provides safety against accidentally providing defaults for props that are no longer valid.

Even though technically the functionality of defaultProps can be achieved with mergeProps, defaultProps provides a much nicer typescript experience for an extremely common use case.

## How did you test this change?

- Added tests to `packages/solid/test/component.spec.ts`
- Added type tests to `packages/solid/test/component.type-tests.ts`
- Ran the full test suite with `pnpm test`