### PR TITLE
fix(typescript): `Setter<T>` being assignable to any `Setter`

### DIFF
--- a/.changeset/brown-queens-bake.md
+++ b/.changeset/brown-queens-bake.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Changes how the Setter type was declared without actually functionally changing it, fixing the Setter type being assignable to any other Setter type; fixes #1818.

--- a/.changeset/brown-queens-bake.md
+++ b/.changeset/brown-queens-bake.md
@@ -3,3 +3,17 @@
 ---
 
 Changes how the Setter type was declared without actually functionally changing it, fixing the Setter type being assignable to any other Setter type; fixes #1818.
+
+Generically typed Setters must now non-null assert their parameter, i.e.
+
+```diff
+function myCustomSignal<T>(v: T) {
+  const [get, set] = createSignal<T>();
+-   const mySetter: Setter<T | undefined> = (v?) => set(v);
++   const mySetter: Setter<T | undefined> = (v?) => set(v!);
+
+  const [get, set] = createSignal<T>(v);
+-   const mySetter: Setter<T> = (v?) => set(v);
++   const mySetter: Setter<T> = (v?) => set(v!);
+}
+```

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -174,10 +174,11 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: typeof Owner)
 
 export type Accessor<T> = () => T;
 
-export type Setter<T> = (undefined extends T ? () => undefined : {}) &
-  (<U extends T>(value: (prev: T) => U) => U) &
-  (<U extends T>(value: Exclude<U, Function>) => U) &
-  (<U extends T>(value: Exclude<U, Function> | ((prev: T) => U)) => U);
+export type Setter<T> = (undefined extends T ? () => undefined : {}) & {
+  <U extends T>(value: (prev: T) => U): U;
+  <U extends T>(value: Exclude<U, Function>): U;
+  <U extends T>(value: Exclude<U, Function> | ((prev: T) => U)): U;
+};
 
 export type Signal<T> = [get: Accessor<T>, set: Setter<T>];
 

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -174,11 +174,18 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: typeof Owner)
 
 export type Accessor<T> = () => T;
 
-export type Setter<T> = (undefined extends T ? () => undefined : {}) & {
-  <U extends T>(value: (prev: T) => U): U;
-  <U extends T>(value: Exclude<U, Function>): U;
-  <U extends T>(value: Exclude<U, Function> | ((prev: T) => U)): U;
-};
+export type Setter<T> = undefined extends T
+  ? {
+      (): undefined;
+      <U extends T>(value: (prev: T) => U): U;
+      <U extends T>(value: Exclude<U, Function>): U;
+      <U extends T>(value: Exclude<U, Function> | ((prev: T) => U)): U;
+    }
+  : {
+      <U extends T>(value: (prev: T) => U): U;
+      <U extends T>(value: Exclude<U, Function>): U;
+      <U extends T>(value: Exclude<U, Function> | ((prev: T) => U)): U;
+    };
 
 export type Signal<T> = [get: Accessor<T>, set: Setter<T>];
 

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -174,18 +174,14 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: typeof Owner)
 
 export type Accessor<T> = () => T;
 
-export type Setter<T> = undefined extends T
-  ? {
-      (): undefined;
-      <U extends T>(value: (prev: T) => U): U;
-      <U extends T>(value: Exclude<U, Function>): U;
-      <U extends T>(value: Exclude<U, Function> | ((prev: T) => U)): U;
-    }
-  : {
-      <U extends T>(value: (prev: T) => U): U;
-      <U extends T>(value: Exclude<U, Function>): U;
-      <U extends T>(value: Exclude<U, Function> | ((prev: T) => U)): U;
-    };
+export type Setter<in out T> = {
+  <U extends T>(...args: undefined extends T ? [] : [value: (prev: T) => U]): undefined extends T
+    ? undefined
+    : U;
+  <U extends T>(value: (prev: T) => U): U;
+  <U extends T>(value: Exclude<U, Function>): U;
+  <U extends T>(value: Exclude<U, Function> | ((prev: T) => U)): U;
+};
 
 export type Signal<T> = [get: Accessor<T>, set: Setter<T>];
 

--- a/packages/solid/test/signals.type-tests.ts
+++ b/packages/solid/test/signals.type-tests.ts
@@ -1052,10 +1052,25 @@ createComputed<number>((v: number | string) => 123, "asd");
 // @ts-expect-error second generic is not inferred and remains as number
 createRenderEffect<number>((v: number | string) => 123, "asd");
 
-
 //////////////////////////////////////////////////////////////////////////
 // test setter invariance ////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
-declare const s1: Setter<number>;
-// @ts-expect-error should be invariant
-const s2: Setter<bigint> = s1;
+declare const setNumber: Setter<number>;
+declare const setNumberOrUndefined: Setter<number | undefined>;
+declare const setUndefined: Setter<undefined>;
+// @ts-expect-error can't set string to number, function form receives number
+const s1: Setter<string> = setNumber;
+// @ts-expect-error can't set string | undefined to number, function form receives number
+const s2: Setter<string | undefined> = setNumber;
+// @ts-expect-error can't set undefined to number, function form receives number
+const s3: Setter<undefined> = setNumber;
+// @ts-expect-error can't set string to number | undefined, function form receives number | undefined
+const s4: Setter<string> = setNumberOrUndefined;
+// @ts-expect-error can't set string to number, function form receives number
+const s5: Setter<string | undefined> = setNumberOrUndefined;
+// @ts-expect-error function form receives number
+const s6: Setter<undefined> = setNumberOrUndefined;
+// @ts-expect-error can't set string to undefined, function form receives undefined
+const s7: Setter<string> = setUndefined;
+// @ts-expect-error can't set string to undefined
+const s8: Setter<string | undefined> = setUndefined;

--- a/packages/solid/test/signals.type-tests.ts
+++ b/packages/solid/test/signals.type-tests.ts
@@ -1051,3 +1051,11 @@ createEffect<number>((v: number | string) => 123, "asd");
 createComputed<number>((v: number | string) => 123, "asd");
 // @ts-expect-error second generic is not inferred and remains as number
 createRenderEffect<number>((v: number | string) => 123, "asd");
+
+
+//////////////////////////////////////////////////////////////////////////
+// test setter invariance ////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+declare const s1: Setter<number>;
+// @ts-expect-error should be invariant
+const s2: Setter<bigint> = s1;

--- a/packages/solid/test/signals.type-tests.ts
+++ b/packages/solid/test/signals.type-tests.ts
@@ -852,14 +852,14 @@ setStringOrNumber("");
 
 function createGenericSignal<T>(): Signal<T | undefined> {
   const [generic, setGeneric] = createSignal<T>();
-  const customSet: Setter<T | undefined> = (v?) => setGeneric(v);
-  return [generic, (v?) => setGeneric(v)];
+  const customSet: Setter<T | undefined> = (v?) => setGeneric(v!);
+  return [generic, (v?) => setGeneric(v!)];
 }
 
 function createInitializedSignal<T>(init: T): Signal<T> {
   const [generic, setGeneric] = createSignal<T>(init);
-  const customSet: Setter<T> = (v?) => setGeneric(v);
-  return [generic, (v?) => setGeneric(v)];
+  const customSet: Setter<T> = (v?) => setGeneric(v!);
+  return [generic, (v?) => setGeneric(v!)];
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

For some reason this fixes #1818. I assume it's because internally typescript does something slightly different but honestly have no clue why this works.

### Further Changes

Switched to using variance annotations, and to have that work changed the type to be a single overloaded function. With variance annotations different `Setter`s will not be mutually assignable; some of the edge cases seem to only be solved by it. The parameterless case is handled somewhat awkwardly, however. As a result, generically typed Setters must now non-null assert their parameter, i.e.

```diff
function myCustomSignal<T>(v: T) {
  const [get, set] = createSignal<T>();
-   const mySetter: Setter<T | undefined> = (v?) => set(v);
+   const mySetter: Setter<T | undefined> = (v?) => set(v!);

  const [get, set] = createSignal<T>(v);
-   const mySetter: Setter<T> = (v?) => set(v);
+   const mySetter: Setter<T> = (v?) => set(v!);
}
```

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Added a test case.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
