### PR TITLE
Stores: fix overwriting underscore property

### DIFF
--- a/.changeset/metal-chefs-begin.md
+++ b/.changeset/metal-chefs-begin.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Fix underscore property

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -2,7 +2,8 @@ import { getListener, batch, DEV, $PROXY, $TRACK, createSignal } from "solid-js"
 
 export const $RAW = Symbol("store-raw"),
   $NODE = Symbol("store-node"),
-  $HAS = Symbol("store-has");
+  $HAS = Symbol("store-has"),
+  $SELF = Symbol("store-self");
 
 // debug hooks for devtools
 export const DevHooks: { onStoreNodeUpdate: OnStoreNodeUpdate | null } = {
@@ -143,7 +144,7 @@ export function proxyDescriptor(target: StoreNode, property: PropertyKey) {
 }
 
 export function trackSelf(target: StoreNode) {
-  getListener() && getNode(getNodes(target, $NODE), "_")();
+  getListener() && getNode(getNodes(target, $NODE), $SELF)();
 }
 
 export function ownKeys(target: StoreNode) {
@@ -233,7 +234,7 @@ export function setProperty(
     for (let i = state.length; i < len; i++) (node = nodes[i]) && node.$();
     (node = getNode(nodes, "length", len)) && node.$(state.length);
   }
-  (node = nodes._) && node.$();
+  (node = nodes[$SELF]) && node.$();
 }
 
 function mergeStoreNode(state: StoreNode, value: Partial<StoreNode>) {


### PR DESCRIPTION
## Summary

Store doesn't handle `_` property well. It works fine when adding element first time, but when you try to modify the same element, property will be `undefined`.

## How did you test this change?

`pnpm t`