### PR TITLE
chore: rename property reload to load in lazy component

### DIFF
--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -342,15 +342,14 @@ export function splitProps<
 }
 
 type AsyncComponent<T extends Component<any>> = () => Promise<{ default: T }>;
-
-// lazy load a function component asynchronously
-export function lazy<T extends Component<any>>(
-  fn: AsyncComponent<T>
-): T & {
+type LazyReturns<T extends Component<any>> = T & {
   /** @deprecated use `load` instead */
   preload: AsyncComponent<T>;
   load: AsyncComponent<T>;
-} {
+};
+
+// lazy load a function component asynchronously
+export function lazy<T extends Component<any>>(fn: AsyncComponent<T>): LazyReturns<T> {
   let comp: () => T | undefined;
   let p: Promise<{ default: T }> | undefined;
   const wrap: T & {
@@ -391,11 +390,7 @@ export function lazy<T extends Component<any>>(
   }) as T;
   wrap.preload = () => p || ((p = fn()).then(mod => (comp = () => mod.default)), p);
   wrap.load = () => p || ((p = fn()).then(mod => (comp = () => mod.default)), p);
-  return wrap as T & {
-    /** @deprecated use `load` instead */
-    preload: AsyncComponent<T>;
-    load: AsyncComponent<T>;
-  };
+  return wrap as LazyReturns<T>;
 }
 
 let counter = 0;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Rename `preload` to `load` in `lazy` method's return value

In this PR:

- The `preload` property from the `lazy` method's return value has been renamed to `load`.
- To ensure backward compatibility with existing project, the `preload` property has been deprecated but not removed. Developers are encouraged to use the new `load` property going forward.

It's recommended for all teams and developers to start transitioning to the use of load as preload may be removed in future releases.

Close #1726.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
None.