### PR TITLE
Added `class` prop for the `Portal` component

### DIFF
--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -57,6 +57,7 @@ export function Portal<T extends boolean = false, S extends boolean = false>(pro
   mount?: Node;
   useShadow?: T;
   isSVG?: S;
+  class?: string;
   ref?:
     | (S extends true ? SVGGElement : HTMLDivElement)
     | ((
@@ -90,6 +91,7 @@ export function Portal<T extends boolean = false, S extends boolean = false>(pro
               ? container.attachShadow({ mode: "open" })
               : container;
 
+        container.setAttribute("class", props.class ?? "");
         Object.defineProperty(container, "_$host", {
           get() {
             return marker.parentNode;

--- a/packages/solid/web/test/portal.spec.tsx
+++ b/packages/solid/web/test/portal.spec.tsx
@@ -17,6 +17,32 @@ describe("Testing a simple Portal", () => {
     expect(div.innerHTML).toBe("");
     expect((testMount.firstChild as HTMLDivElement).innerHTML).toBe("Hi");
     expect((testMount.firstChild as HTMLDivElement & { _$host: HTMLElement })._$host).toBe(div);
+    expect((testMount.firstChild as HTMLDivElement).classList.value).toBe("");
+  });
+
+  test("dispose", () => {
+    disposer();
+    expect(div.innerHTML).toBe("");
+  });
+});
+
+describe("Testing a Portal with class prop", () => {
+  const className = "test classname";
+  let div = document.createElement("div"),
+    disposer: () => void;
+  const testMount = document.createElement("div");
+  const Component = () => (
+    <Portal mount={testMount} class={className}>
+      Hi
+    </Portal>
+  );
+
+  test("Create portal control flow", () => {
+    disposer = render(Component, div);
+    expect(div.innerHTML).toBe("");
+    expect((testMount.firstChild as HTMLDivElement).innerHTML).toBe("Hi");
+    expect((testMount.firstChild as HTMLDivElement & { _$host: HTMLElement })._$host).toBe(div);
+    expect((testMount.firstChild as HTMLDivElement).classList.value).toBe(className);
   });
 
   test("dispose", () => {
@@ -40,6 +66,29 @@ describe("Testing an SVG Portal", () => {
     expect(div.innerHTML).toBe("");
     expect((testMount.firstChild as SVGGElement).innerHTML).toBe("Hi");
     expect((testMount.firstChild as SVGGElement & { _$host: SVGElement })._$host).toBe(div);
+    expect((testMount.firstChild as SVGGElement).classList.value).toBe("");
+  });
+
+  test("dispose", () => disposer());
+});
+
+describe("Testing an SVG Portal with class prop", () => {
+  const className = "test svg classname";
+  let div = document.createElement("div"),
+    disposer: () => void;
+  const testMount = document.createElement("svg");
+  const Component = () => (
+    <Portal mount={testMount} isSVG={true} class={className}>
+      Hi
+    </Portal>
+  );
+
+  test("Create portal control flow", () => {
+    disposer = render(Component, div);
+    expect(div.innerHTML).toBe("");
+    expect((testMount.firstChild as SVGGElement).innerHTML).toBe("Hi");
+    expect((testMount.firstChild as SVGGElement & { _$host: SVGElement })._$host).toBe(div);
+    expect((testMount.firstChild as SVGGElement).classList.value).toBe(className);
   });
 
   test("dispose", () => disposer());


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

This is a possible fix for #1873, it adds a `class` prop for the `Portal` component to allow styling the wrapper `div`.

## How did you test this change?

I have added new tests for the `Portal` component with the `class` prop and added assertions for previous tests.