### PR TITLE
make reactive and non reactive jsx attributes consistent in ssr when expression evaluates to falsey

### DIFF
--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -101,7 +101,7 @@ export function mergeProps(...sources: any): any {
           get() {
             for (let i = sources.length - 1; i >= 0; i--) {
               let s = sources[i] || {};
-              if (typeof s === "function") s = s();
+              if (typeof s === "function") s = s() || {};
               const v = s[key];
               if (v !== undefined) return v;
             }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary
Just got a massive stack trace in a solid start project due to reactive and non reactive attributes acting differently in ssr.
```jsx
<Foo {...bar && { bar }}/>
```
is fine whether `bar` is defined or `undefined`

```jsx
<Foo {...bar() && { bar: bar() }}/>
```
throws an exception when the `bar` `Accessor` is falsey.

You'll see that the fix is very simple.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
I patched `solid-js` locally in my project and am currently dogfooding the change.
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
