### PR TITLE
Bump node version in CI to > 16

### DIFF
--- a/.changeset/fuzzy-chefs-destroy.md
+++ b/.changeset/fuzzy-chefs-destroy.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Bump node version in CI

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -12,11 +12,11 @@ jobs:
  job:
   runs-on: ubuntu-latest
   steps:
-  - uses: actions/checkout@v2
-  - uses: pnpm/action-setup@v2.2.2
-  - uses: actions/setup-node@v2
+  - uses: actions/checkout@v4
+  - uses: pnpm/action-setup@v2
+  - uses: actions/setup-node@v3
     with:
-      node-version: 16
+      node-version: 18
       cache: 'pnpm'
 
   - name: Installing deps


### PR DESCRIPTION
Due to the [Node 16 EOL](https://nodejs.org/en/blog/announcements/nodejs16-eol):

actions/checkout: node 14 -> 20 (there was no 18 release)
pnpm/action-setup: still on node 16, but this bumps from 2.2.2 -> 2.4.0
actions/setup-node: node 16 -> 18