### PR TITLE
Add `.js` extension to import that is missing it

### DIFF
--- a/.changeset/wet-forks-melt.md
+++ b/.changeset/wet-forks-melt.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Add `.js` extension to import

--- a/packages/solid/src/render/hydration.ts
+++ b/packages/solid/src/render/hydration.ts
@@ -1,4 +1,4 @@
-import { Computation } from "../reactive/signal";
+import { Computation } from "../reactive/signal.js";
 
 export type HydrationContext = { id: string; count: number };
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Trying to build a Solid renderer using the Node16 `moduleResolution` of TypeScript and we're seeing this error:

```
node_modules/solid-js/types/render/hydration.d.ts:1:29 - error TS2834: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.

1 import { Computation } from "../reactive/signal";
                              ~~~~~~~~~~~~~~~~~~~~
```

This seems to be the only place in the `solid-js` package that doesn't add the `.js` extension to the import path.

## How did you test this change?

- [x] `pnpm test`
- [x] Confirm that it fixes issue

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
