### PR TITLE
Add missing `indexArray` to server-side runtime.

### DIFF
--- a/.changeset/modern-oranges-own.md
+++ b/.changeset/modern-oranges-own.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Add missing `indexArray` to server-side runtime.

--- a/packages/solid/src/server/index.ts
+++ b/packages/solid/src/server/index.ts
@@ -24,6 +24,7 @@ export {
   equalFn,
   requestCallback,
   mapArray,
+  indexArray,
   observable,
   from,
   $PROXY,

--- a/packages/solid/src/server/reactive.ts
+++ b/packages/solid/src/server/reactive.ts
@@ -267,11 +267,11 @@ export function requestCallback(fn: () => void, options?: { timeout: number }): 
 export function cancelCallback(task: Task) {}
 
 export function mapArray<T, U>(
-  list: () => T[],
-  mapFn: (v: T, i: () => number) => U,
-  options: { fallback?: () => any } = {}
+  list: Accessor<readonly T[] | undefined | null | false>,
+  mapFn: (v: T, i: Accessor<number>) => U,
+  options: { fallback?: Accessor<any> } = {}
 ): () => U[] {
-  const items = list();
+  const items = list() || [];
   let s: U[] = [];
   if (items.length) {
     for (let i = 0, len = items.length; i < len; i++) s.push(mapFn(items[i], () => i));
@@ -279,9 +279,17 @@ export function mapArray<T, U>(
   return () => s;
 }
 
-function getSymbol() {
-  const SymbolCopy = Symbol as any;
-  return SymbolCopy.observable || "@@observable";
+export function indexArray<T, U>(
+  list: Accessor<readonly T[] | undefined | null | false>,
+  mapFn: (v: Accessor<T>, i: number) => U,
+  options: { fallback?: Accessor<any> } = {}
+): () => U[] {
+  const items = list() || [];
+  let s: U[] = [];
+  if (items.length) {
+    for (let i = 0, len = items.length; i < len; i++) s.push(mapFn(() => items[i], i));
+  } else if (options.fallback) s = [options.fallback()];
+  return () => s;
 }
 
 export type ObservableObserver<T> =


### PR DESCRIPTION
- Add missing `indexArray` to server-side runtime.
- prevent `cannot access property "length" of undefined` when passing `undefined` to `mapArray` on the server