### PR TITLE
Add types directory export for each package

### DIFF
--- a/.changeset/cyan-dolls-lay.md
+++ b/.changeset/cyan-dolls-lay.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Add types directory export for each package

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -80,6 +80,7 @@
       "require": "./dist/solid.cjs"
     },
     "./dist/*": "./dist/*",
+    "./types/*": "./types/*",
     "./jsx-runtime": {
       "types": "./types/jsx.d.ts",
       "default": "./dist/solid.js"
@@ -124,6 +125,7 @@
       "require": "./store/dist/store.cjs"
     },
     "./store/dist/*": "./store/dist/*",
+    "./store/types/*": "./store/types/*",
     "./web": {
       "worker": {
         "types": "./web/types/index.d.ts",
@@ -164,6 +166,7 @@
       "require": "./web/dist/storage.cjs"
     },
     "./web/dist/*": "./web/dist/*",
+    "./web/types/*": "./web/types/*",
     "./universal": {
       "development": {
         "types": "./universal/types/index.d.ts",
@@ -175,6 +178,7 @@
       "require": "./universal/dist/universal.cjs"
     },
     "./universal/dist/*": "./universal/dist/*",
+    "./universal/types/*": "./universal/types/*",
     "./h": {
       "types": "./h/types/index.d.ts",
       "import": "./h/dist/h.js",
@@ -191,6 +195,7 @@
       "require": "./h/jsx-runtime/dist/jsx.cjs"
     },
     "./h/dist/*": "./h/dist/*",
+    "./h/types/*": "./h/types/*",
     "./html": {
       "types": "./html/types/index.d.ts",
       "import": "./html/dist/html.js",


### PR DESCRIPTION
When selecting a `"moduleResolution"` option is tsconfig other than `"node"` you cannot import the other not-exported from main modules types, which is useful for importing a very specific internal type, eg in devtools. 🙃

![Screenshot from 2023-11-07 18-35-55](https://github.com/solidjs/solid/assets/24491503/d417e06a-cabc-4b59-8785-253339c56a2c)

But when the types directories are explicitly exported one can import a specific `.d.ts` file.

![image](https://github.com/solidjs/solid/assets/24491503/a014f4d8-af8a-46e0-ba92-77a1b097867d)

Another solution would be to export every internal type from main modules, which is fine too.