### PR TITLE
feat(DEV): Add afterCreateSignal hook to DevHooks

### DIFF
--- a/.changeset/polite-coins-prove.md
+++ b/.changeset/polite-coins-prove.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+feat(DEV): Add afterCreateSignal hook to DevHooks

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -57,9 +57,11 @@ let ExecCount = 0;
 export const DevHooks: {
   afterUpdate: (() => void) | null;
   afterCreateOwner: ((owner: Owner) => void) | null;
+  afterCreateSignal: ((signal: SignalState<any>) => void) | null;
 } = {
   afterUpdate: null,
-  afterCreateOwner: null
+  afterCreateOwner: null,
+  afterCreateSignal: null
 };
 
 // keep immediately evaluated module code, below its indirect declared let dependencies like Listener
@@ -228,9 +230,10 @@ export function createSignal<T>(
     comparator: options.equals || undefined
   };
 
-  if ("_SOLID_DEV_" && !options.internal) {
+  if ("_SOLID_DEV_") {
     if (options.name) s.name = options.name;
-    registerGraph(s);
+    if (DevHooks.afterCreateSignal) DevHooks.afterCreateSignal(s);
+    if (!options.internal) registerGraph(s);
   }
 
   const setter: Setter<T | undefined> = (value?: unknown) => {

--- a/packages/solid/test/dev.spec.ts
+++ b/packages/solid/test/dev.spec.ts
@@ -129,6 +129,26 @@ describe("Dev features", () => {
     });
   });
 
+  test("afterCreateSignal Hook", () => {
+    createRoot(() => {
+      const owner = getOwner()!;
+      const cb = vi.fn();
+      DEV!.hooks.afterCreateSignal = cb;
+
+      createSignal(3, { name: "test" });
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenLastCalledWith(owner.sourceMap![0]);
+
+      createSignal(5);
+      expect(cb).toHaveBeenCalledTimes(2);
+      expect(cb).toHaveBeenLastCalledWith(owner.sourceMap![1]);
+
+      createSignal(6, { name: "explicit" });
+      expect(cb).toHaveBeenCalledTimes(3);
+      expect(cb).toHaveBeenLastCalledWith(owner.sourceMap![2]);
+    });
+  });
+
   test("OnStoreNodeUpdate Hook", () => {
     const cb = vi.fn();
     STORE_DEV!.hooks.onStoreNodeUpdate = cb;


### PR DESCRIPTION
A hook called whenever a new signal is created will allow to
1. track the amount of signals in use, compared to the amount of owners, to see the impact of using signals and stores for state management on overall memory use. Discovering memory leaks, and where signals are wastefully created.
2. track the state of signals created outside of owners, eg when doing a simple global state.