### PR TITLE
fix: createSignal not found when bundled

### DIFF
--- a/.changeset/nasty-coins-call.md
+++ b/.changeset/nasty-coins-call.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+fix: createSignal not found when bundled

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -244,9 +244,6 @@ export function createSignal<T>(
   return [readSignal.bind(s), setter];
 }
 
-// keep immediately evaluated module code, below its dependencies like Listener & createSignal
-const [transPending, setTransPending] = /*@__PURE__*/ createSignal(false);
-
 export interface BaseOptions {
   name?: string;
 }
@@ -1074,6 +1071,9 @@ export function startTransition(fn: () => unknown): Promise<void> {
     return t ? t.done : undefined;
   });
 }
+
+// keep immediately evaluated module code, below its dependencies like Listener & createSignal
+const [transPending, setTransPending] = /*@__PURE__*/ createSignal(false);
 
 export type Transition = [Accessor<boolean>, (fn: () => void) => Promise<void>];
 

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -64,9 +64,6 @@ export const DevHooks: {
   afterCreateSignal: null
 };
 
-// keep immediately evaluated module code, below its indirect declared let dependencies like Listener
-const [transPending, setTransPending] = /*@__PURE__*/ createSignal(false);
-
 export type ComputationState = 0 | 1 | 2;
 
 export interface SourceMapValue {
@@ -246,6 +243,9 @@ export function createSignal<T>(
 
   return [readSignal.bind(s), setter];
 }
+
+// keep immediately evaluated module code, below its dependencies like Listener & createSignal
+const [transPending, setTransPending] = /*@__PURE__*/ createSignal(false);
 
 export interface BaseOptions {
   name?: string;


### PR DESCRIPTION
In some circumstances a global function export (like `createSignal`) can be transformed by rollup into a let binding, which will break the global evaluation of `transPending` since then `createSignal` will be defined after being used.
I.e. the code from `signal.ts` which looks like this:
```ts
const [transPending, setTransPending] = createSignal(false);

// ... some other code

export function createSignal(){}
```

will be translated to 

```js
let createSignal;

const [transPending, setTransPending] = createSignal(false);

export function createSignal(){}
```
which obviously won't work anymore since the let definition isn't hoisted. 

While I believe this bug should fundamentally be solved in rollup itself this is a quick, rather painless fix (it's interesting that rollup isn't smart enough to reason about in-file dependencies in this way) 

## How did you test this change?

The app that this came up in is still closed-source unfortunately, and this bug - being a codegen-bug - proofed itself to be hard to reproduce, but I hope the above reasoning is easy enough to follow. 