### PR TITLE
chore(types): return mapped type for splitProps excluded `other` value

### DIFF
--- a/.changeset/calm-numbers-itch.md
+++ b/.changeset/calm-numbers-itch.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+chore(types): return mapped type for splitProps excluded `other` value

--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -271,7 +271,7 @@ export type SplitProps<T, K extends (readonly (keyof T)[])[]> = [
       ? Pick<T, Extract<K[P], readonly (keyof T)[]>[number]>
       : never;
   },
-  Omit<T, K[number][number]>
+  { [P in keyof T as Exclude<P, K[number][number]>]: T[P] }
 ];
 
 export function splitProps<


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary
`splitProps` returns omitted type that melts when props are extends any.
For example, using UnoCSS preset attributify and settings following declarations:
```ts
interface HTMLAttributes<T> {
   [prop: string]: ComponentProps<T>
}
```
`other` returned value from `splitProps` fails to infer type (see video).


https://github.com/solidjs/solid/assets/17229619/8904281c-766c-401d-8d79-da5831942c77


<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
I just tested only for my case. I don't know how to test it better since I'm not familiar with typescript types testing.