### PR TITLE
Make hyperscript API more type safe

### DIFF
--- a/packages/solid/h/src/index.ts
+++ b/packages/solid/h/src/index.ts
@@ -1,5 +1,4 @@
 import { createHyperScript } from "./hyperscript";
-import type { HyperScript } from "./hyperscript";
 import {
   spread,
   assign,
@@ -8,14 +7,51 @@ import {
   dynamicProperty,
   SVGElements
 } from "solid-js/web";
+import type { Component, JSX } from "solid-js";
 
-const h: HyperScript = createHyperScript({
+export type MaybeFn<T> = T | (() => T);
+export type MaybeArr<T> = T | T[];
+export type MaybeSelector<T extends string> = T | `${T}#${string}` | `${T}.${string}`;
+
+export type MaybeFnProps<T extends object> = {
+  [K in keyof T]: MaybeFn<T[K]>;
+};
+
+export interface SolidHyperScript {
+  <K extends keyof JSX.IntrinsicElements, P extends MaybeFnProps<JSX.IntrinsicElements[K]>>(
+    key: MaybeSelector<K>,
+    props: MaybeFnProps<P>,
+    ...children: MaybeArr<MaybeFn<JSX.Element>>[]
+  ): () => MaybeArr<JSX.Element>;
+
+  <K extends keyof JSX.IntrinsicElements, P extends MaybeFnProps<JSX.IntrinsicElements[K]>>(
+    key: {} extends JSX.IntrinsicElements[K] ? MaybeSelector<K> : never, // Prevent skipping args if mandatory props present
+    ...children: MaybeArr<MaybeFn<JSX.Element>>[]
+  ): () => MaybeArr<JSX.Element>;
+
+  <P extends object>(
+    component: Component<P>,
+    props: MaybeFnProps<P>,
+    ...children: MaybeArr<MaybeFn<JSX.Element>>[]
+  ): () => MaybeArr<JSX.Element>;
+
+  <P extends object>(
+    component: {} extends P ? Component<P> : never, // Prevent skipping args if mandatory props present
+    ...children: MaybeArr<MaybeFn<JSX.Element>>[]
+  ): () => MaybeArr<JSX.Element>;
+
+  Fragment: (props: {
+    children: (() => JSX.Element) | (() => JSX.Element)[];
+  }) => MaybeArr<JSX.Element>;
+}
+
+const h = createHyperScript({
   spread,
   assign,
   insert,
   createComponent,
   dynamicProperty,
   SVGElements
-});
+}) as SolidHyperScript;
 
 export default h;

--- a/packages/solid/h/src/index.ts
+++ b/packages/solid/h/src/index.ts
@@ -11,7 +11,9 @@ import type { Component, JSX } from "solid-js";
 
 export type MaybeFn<T> = T | (() => T);
 export type MaybeArr<T> = T | T[];
-export type MaybeSelector<T extends string> = T | `${T}#${string}` | `${T}.${string}`;
+export type Selector<T extends string> = `${T}#${string}` | `${T}.${string}`;
+export type BareSelector = Selector<"">
+export type MaybeSelector<T extends string> = T | Selector<T>;
 
 export type MaybeFnProps<T extends object> = {
   [K in keyof T]: MaybeFn<T[K]>;
@@ -26,6 +28,17 @@ export interface SolidHyperScript {
 
   <K extends keyof JSX.IntrinsicElements, P extends MaybeFnProps<JSX.IntrinsicElements[K]>>(
     key: {} extends JSX.IntrinsicElements[K] ? MaybeSelector<K> : never, // Prevent skipping args if mandatory props present
+    ...children: MaybeArr<MaybeFn<JSX.Element>>[]
+  ): () => MaybeArr<JSX.Element>;
+
+  <P extends MaybeFnProps<JSX.IntrinsicElements["div"]>>(
+    key: BareSelector,
+    props: MaybeFnProps<P>,
+    ...children: MaybeArr<MaybeFn<JSX.Element>>[]
+  ): () => MaybeArr<JSX.Element>;
+
+  <P extends MaybeFnProps<JSX.IntrinsicElements["div"]>>(
+    key: BareSelector,
     ...children: MaybeArr<MaybeFn<JSX.Element>>[]
   ): () => MaybeArr<JSX.Element>;
 


### PR DESCRIPTION
Ensure that invalid props for native elements, solid components and custo elements result in type errors.

## Summary

Currently the hyperscript api (`import h from "solid-js/h"`) is not type-safe. Errors are not reported when using incorrect props for components. This PR makes the types stricter.

## How did you test this change?

By trying out invalid usages in editor.
