### PR TITLE
fix #2017 reconcile fails to replace nested array with object

### DIFF
--- a/packages/solid/store/src/modifiers.ts
+++ b/packages/solid/store/src/modifiers.ts
@@ -14,9 +14,16 @@ function applyState(
   merge: boolean | undefined,
   key: string | null
 ) {
-  const previous = parent[property];
+  let previous = parent[property];
   if (target === previous) return;
   const isArray = Array.isArray(target);
+  if (Array.isArray(previous) && !isArray) {
+    parent[property] = {};
+  } else if (!Array.isArray(previous) && isArray) {
+    parent[property] = [];
+  }
+
+  previous = parent[property];
   if (
     property !== $ROOT &&
     (!isWrappable(target) ||

--- a/packages/solid/store/test/modifiers.spec.ts
+++ b/packages/solid/store/test/modifiers.spec.ts
@@ -134,6 +134,28 @@ describe("setState with reconcile", () => {
     expect(store.id).toBe(undefined);
     expect(store.value).toBe(undefined);
   });
+
+  test("Reconcile overwirte an object with an array", () => {
+    const [store, setStore] = createStore<{ value: {} | [] }>({
+      value: { a: { b: 1 } }
+    });
+
+    setStore(reconcile({ value: { c: [1, 2, 3] } }));
+    expect(store.value).toEqual({ c: [1, 2, 3] });
+  });
+
+  test("Reconcile overwirte an array with an object", () => {
+    const [store, setStore] = createStore<{ value: {} | [] }>({
+      value: [1, 2, 3]
+    });
+    setStore(reconcile({ value: { name: "John" } }));
+    expect(Array.isArray(store.value)).toBeFalsy();
+    expect(store.value).toEqual({ name: "John" });
+    setStore(reconcile({ value: [1, 2, 3] }));
+    expect(store.value).toEqual([1, 2, 3]);
+    setStore(reconcile({ value: { q: "aa" } }));
+    expect(store.value).toEqual({ q: "aa" });
+  });
 });
 
 describe("setState with produce", () => {


### PR DESCRIPTION
1. fix #2017 reconcile fails to replace nested array with object
2. add tests