### PR TITLE
Fix `DistributeOverride` losing type

### DIFF
--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -139,7 +139,11 @@ const propTraps: ProxyHandler<{
   }
 };
 
-type DistributeOverride<T, F> = [T, F] extends [undefined, undefined] ? F & T : (F & T extends undefined ? never : F & T);
+type DistributeOverride<T, F> = [T, F] extends [undefined, undefined]
+  ? F & T
+  : F & T extends undefined
+  ? never
+  : F & T;
 type Override<T, U> = T extends any
   ? U extends any
     ? {

--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -139,7 +139,7 @@ const propTraps: ProxyHandler<{
   }
 };
 
-type DistributeOverride<T, F> = T extends undefined ? F : T;
+type DistributeOverride<T, F> = [T, F] extends [undefined, undefined] ? F & T : (F & T extends undefined ? never : F & T);
 type Override<T, U> = T extends any
   ? U extends any
     ? {


### PR DESCRIPTION
## Summary

The problem currently is that `DistributeOverride` looses the type that is `undefinable` completely which results in bad developer experience. Additionally I have run `pnpm format` which resulted in a few files get changed from `crlf` to `lf`

## How did you test this change?

```typescript
const foo: DistributeOverride<{}, { bar?: string }> = {};
console(foo.bar); // before this change `bar` was unresolved, because only `{}` was forwarded, now the types get combined and bar is resolved as `string | undefined`
```

