### PR TITLE
Adjust some JSDocs

### DIFF
--- a/.changeset/real-deers-end.md
+++ b/.changeset/real-deers-end.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Adjust some JSDocs

--- a/packages/solid/src/reactive/array.ts
+++ b/packages/solid/src/reactive/array.ts
@@ -37,8 +37,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+
 /**
- * reactively transforms an array with a callback function - underlying helper for the `<For>` control flow
+ * Reactively transforms an array with a callback function - underlying helper for the `<For>` control flow
  *
  * similar to `Array.prototype.map`, but gets the index as accessor, transforms only values that changed and returns an accessor and reactively tracks changes to the list.
  *
@@ -175,7 +176,7 @@ export function mapArray<T, U>(
 }
 
 /**
- * reactively maps arrays by index instead of value - underlying helper for the `<Index>` control flow
+ * Reactively maps arrays by index instead of value - underlying helper for the `<Index>` control flow
  *
  * similar to `Array.prototype.map`, but gets the value as an accessor, transforms only changed items of the original arrays anew and returns an accessor.
  *

--- a/packages/solid/src/reactive/observable.ts
+++ b/packages/solid/src/reactive/observable.ts
@@ -34,7 +34,7 @@ export type ObservableObserver<T> =
       complete?: (v: boolean) => void;
     };
 /**
- * creates a simple observable from a signal's accessor to be used with the `from` operator of observable libraries like e.g. rxjs
+ * Creates a simple observable from a signal's accessor to be used with the `from` operator of observable libraries like e.g. rxjs
  * ```typescript
  * import { from } from "rxjs";
  * const [s, set] = createSignal(0);

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -902,7 +902,7 @@ export interface OnOptions {
 }
 
 /**
- * on - make dependencies of a computation explicit
+ * Makes dependencies of a computation explicit
  * ```typescript
  * export function on<S, U>(
  *   deps: Accessor<S> | AccessorArray<S>,
@@ -962,7 +962,7 @@ export function on<S, Next extends Prev, Prev = Next>(
 }
 
 /**
- * onMount - run an effect only after initial render on mount
+ * Runs an effect only after initial render on mount
  * @param fn an effect that should run only once on mount
  *
  * @description https://www.solidjs.com/docs/latest/api#onmount
@@ -972,7 +972,7 @@ export function onMount(fn: () => void) {
 }
 
 /**
- * onCleanup - run an effect once before the reactive scope is disposed
+ * Runs an effect once before the reactive scope is disposed
  * @param fn an effect that should run only once on cleanup
  *
  * @returns the same {@link fn} function that was passed in
@@ -989,7 +989,7 @@ export function onCleanup<T extends () => any>(fn: T): T {
 }
 
 /**
- * catchError - run an effect whenever an error is thrown within the context of the child scopes
+ * Runs an effect whenever an error is thrown within the context of the child scopes
  * @param fn boundary for the error
  * @param handler an error handler that receives the error
  *
@@ -1176,7 +1176,7 @@ export function createContext<T>(
 }
 
 /**
- * use a context to receive a scoped state from a parent's Context.Provider
+ * Uses a context to receive a scoped state from a parent's Context.Provider
  *
  * @param context Context object made by `createContext`
  * @returns the current or `defaultValue`, if present

--- a/packages/solid/src/render/Suspense.ts
+++ b/packages/solid/src/render/Suspense.ts
@@ -28,7 +28,7 @@ const suspenseListEquals = (a: SuspenseListRegisteredState, b: SuspenseListRegis
 const SuspenseListContext = createContext<SuspenseListContextType>();
 
 /**
- * **[experimental]** controls the order in which suspended content is rendered
+ * **[experimental]** Controls the order in which suspended content is rendered
  *
  * @description https://www.solidjs.com/docs/latest/api#suspenselist-experimental
  */
@@ -110,7 +110,7 @@ export function SuspenseList(props: {
 }
 
 /**
- * tracks all resources inside a component and renders a fallback until they are all resolved
+ * Tracks all resources inside a component and renders a fallback until they are all resolved
  * ```typescript
  * const AsyncComponent = lazy(() => import('./component'));
  *

--- a/packages/solid/src/render/flow.ts
+++ b/packages/solid/src/render/flow.ts
@@ -19,7 +19,7 @@ const narrowedError = (name: string) =>
     : `Stale read from <${name}>.`;
 
 /**
- * creates a list elements from a list
+ * Creates a list elements from a list
  *
  * it receives a map function as its child that receives a list element and an accessor with the index and returns a JSX-Element; if the list is empty, an optional fallback is returned:
  * ```typescript
@@ -144,7 +144,7 @@ export function Show<T>(props: {
 type EvalConditions = readonly [number, unknown?, MatchProps<unknown>?];
 
 /**
- * switches between content based on mutually exclusive conditions
+ * Switches between content based on mutually exclusive conditions
  * ```typescript
  * <Switch fallback={<FourOhFour />}>
  *   <Match when={state.route === 'home'}>
@@ -208,7 +208,7 @@ export type MatchProps<T> = {
   children: JSX.Element | ((item: NonNullable<T> | Accessor<NonNullable<T>>) => JSX.Element);
 };
 /**
- * selects a content based on condition when inside a `<Switch>` control flow
+ * Selects a content based on condition when inside a `<Switch>` control flow
  * ```typescript
  * <Match when={condition()}>
  *   <Content/>
@@ -238,7 +238,7 @@ export function resetErrorBoundaries() {
   Errors && [...Errors].forEach(fn => fn());
 }
 /**
- * catches uncaught errors inside components and renders a fallback content
+ * Catches uncaught errors inside components and renders a fallback content
  *
  * Also supports a callback form that passes the error and a reset function:
  * ```typescript

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -491,7 +491,7 @@ export interface SetStoreFunction<T> {
 }
 
 /**
- * creates a reactive store that can be read through a proxy object and written with a setter function
+ * Creates a reactive store that can be read through a proxy object and written with a setter function
  *
  * @description https://www.solidjs.com/docs/latest/api#createstore
  */

--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -47,7 +47,7 @@ export const hydrate: typeof hydrateCore = (...args) => {
 };
 
 /**
- * renders components somewhere else in the DOM
+ * Renders components somewhere else in the DOM
  *
  * Useful for inserting modals and tooltips outside of an cropping layout. If no mount point is given, the portal is inserted in document.body; it is wrapped in a `<div>` unless the target is document.head or `isSVG` is true. setting `useShadow` to true places the element in a shadow root to isolate styles.
  *
@@ -113,8 +113,9 @@ export type DynamicProps<T extends ValidComponent, P = ComponentProps<T>> = {
 } & {
   component: T | undefined;
 };
+
 /**
- * renders an arbitrary custom or native component and passes the other props
+ * Renders an arbitrary custom or native component and passes the other props
  * ```typescript
  * <Dynamic component={multiline() ? 'textarea' : 'input'} value={value()} />
  * ```


### PR DESCRIPTION
- Make casing consistent for all docs.
- Removes unnecessary prefixes in some docs like `onMount`
