### PR TITLE
Add example of using noShadowDOM()

### DIFF
--- a/packages/solid-element/README.md
+++ b/packages/solid-element/README.md
@@ -41,6 +41,17 @@ Props get assigned as element properties and hyphenated attributes. This exposes
 
 This is all you need to get started with Solid Element.
 
+A shadow DOM is used by default for style isolation. If you want to disable the shadow DOM, you can do it with `noShadowDOM()` like this:
+
+```jsx
+import { customElement, noShadowDOM } from 'solid-element';
+
+customElement('my-component', {someProp: 'one', otherProp: 'two'}, (props, { element }) => {
+  noShadowDOM();
+  // ... Solid code
+})
+```
+
 ## Examples
 
 [Web Component Todos](https://wc-todo.firebaseapp.com/) Simple Todos Comparison


### PR DESCRIPTION
## Summary

I wanted to share css classes between web components and struggled to disable the shadow DOM. I found out reading the component-register code there was a `noShadowDOM()` function but I had a hard time finding how to use it, I didn't see any documentation for it, so here it is.

## How did you test this change?

I tested it on my project. I don't care of style isolation for those web components, I just want an easy way to reuse the solid components on a static index.html file without build tool.

Code: [ui-components.tsx](https://github.com/networked-aframe/naf-nametag-solidjs/blob/9df49e7bb9de5a1e2538329335c818f916020f4c/src/ui-components.tsx) and [ui-components.html](https://github.com/networked-aframe/naf-nametag-solidjs/blob/9df49e7bb9de5a1e2538329335c818f916020f4c/public/ui-components.html#L76-L116)

Demo: https://naf-nametag-solidjs.glitch.me/ui-components.html
