### PR TITLE
Bump GitHub workflow actions to latest versions

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -13,8 +13,8 @@ jobs:
   runs-on: ubuntu-latest
   steps:
   - uses: actions/checkout@v4
-  - uses: pnpm/action-setup@v2
-  - uses: actions/setup-node@v3
+  - uses: pnpm/action-setup@v3.0.0
+  - uses: actions/setup-node@v4
     with:
       node-version: 18
       cache: 'pnpm'
@@ -38,7 +38,7 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
   - name: Archive production artifacts
-    uses: actions/upload-artifact@v2
+    uses: actions/upload-artifact@v4
     with:
       name: dist-folder
       path: |


### PR DESCRIPTION
This PR bumps GitHub workflow actions to latest versions, thus avoiding deprecation warnings as seen e.g. [here](https://github.com/solidjs/solid/actions/runs/8455413443).