### PR TITLE
chore: replace broken hope-ui link with kobalte in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Do more with less: use simple, composable primitives without hidden rules and go
 
 ### Productive
 
-Solid is built on established tools like JSX and TypeScript and integrates with the Vite ecosystem. Solid's bare-metal, minimal abstractions give you direct access to the DOM, making it easy to use your favorite native JavaScript libraries like D3. And the Solid ecosystem is growing fast, with [custom primitives](https://github.com/solidjs-community/solid-primitives), [component libraries](https://hope-ui.com/), and build-time utilities that let you [write Solid code in new ways](https://github.com/LXSMNSYC/solid-labels).
+Solid is built on established tools like JSX and TypeScript and integrates with the Vite ecosystem. Solid's bare-metal, minimal abstractions give you direct access to the DOM, making it easy to use your favorite native JavaScript libraries like D3. And the Solid ecosystem is growing fast, with [custom primitives](https://github.com/solidjs-community/solid-primitives), [component libraries](https://kobalte.dev), and build-time utilities that let you [write Solid code in new ways](https://github.com/LXSMNSYC/solid-labels).
 
 ## More
 


### PR DESCRIPTION
## Summary

Currently **component libraries** links out to https://hope-ui.com/ which no longer works. Looking at the [hope-ui](https://github.com/hope-ui/hope-ui) repo, we find a working link (https://hope-ui.netlify.app/).

However, this library is deprecated and points to https://pigment.kobalte.dev as a successor. I've opted to instead link to https://kobalte.dev as it has more documented components than the pigment site.

Could also link to https://www.solidjs.com/ecosystem#ui if that is preferred.

## How did you test this change?

I clicked some links.
