### PR TITLE
Handle failed serialized promises in createResource

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -696,8 +696,9 @@ export function createResource<T, S, R>(
       return p;
     }
     pr = p;
-    if ("value" in p) {
-      if ((p as any).status === "success") loadEnd(pr, p.value as T, undefined, lookup);
+    if (isSerializedPromise(p)) {
+      if (p.status === "success") loadEnd(pr, p.value, undefined, lookup);
+      else if (p.status === "failure") loadEnd(pr, undefined, castError(p.value), lookup);
       else loadEnd(pr, undefined, undefined, lookup);
       return p;
     }
@@ -733,6 +734,13 @@ export function createResource<T, S, R>(
   if (dynamic) createComputed(() => load(false));
   else load(false);
   return [read as Resource<T>, { refetch: load, mutate: setValue }];
+}
+
+// Promises from seroval have 'value' and 'status'
+function isSerializedPromise<T>(
+  p: Promise<T>
+): p is Promise<T> & ({ status: "success"; value: T } | { status: "failure"; value: unknown }) {
+  return "value" in p;
 }
 
 export interface DeferredOptions<T> {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

https://github.com/solidjs/solid-start/issues/1520 provides a repro where a resource throws an error on the server, gets serialized during streaming, and then hydrates on the client with the status `"ready"` instead of `"errored"`.
From what I can tell, this happens because resources that contain streamed promises don't handle the promise rejecting.
Notice how `p.value` isn't used anywhere for error handling.

```ts
if ("value" in p) {
  if ((p as any).status === "success") loadEnd(pr, p.value as T, undefined, lookup);
  else loadEnd(pr, undefined, undefined, lookup);
  return p;
}
```

To fix this I've added an extra branch that checks for `status === "failure"` and calls `loadEnd` with `castError(p.value)` as the third argument. This makes the repro work as expected.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

Ran the repro with this PR's changes using `pnpm link`.