### PR TITLE
mark `SuspenseListContext` as PURE to allow treeshaking

### DIFF
--- a/packages/solid/src/render/Suspense.ts
+++ b/packages/solid/src/render/Suspense.ts
@@ -25,7 +25,7 @@ interface SuspenseListState extends Array<SuspenseListRegisteredState> {
 
 const suspenseListEquals = (a: SuspenseListRegisteredState, b: SuspenseListRegisteredState) =>
   a.showContent === b.showContent && a.showFallback === b.showFallback;
-const SuspenseListContext = createContext<SuspenseListContextType>();
+const SuspenseListContext = /* #__PURE__ */ createContext<SuspenseListContextType>();
 
 /**
  * **[experimental]** Controls the order in which suspended content is rendered


### PR DESCRIPTION
Doing `export { className } from "solid-js@1.8/web"; ` exports the whole unused reactive utils, seems to me the `createContext` call for  `SuspenseListContext` is causing the issue.

references: 
https://x.com/jlarky/status/1806908281618890951
https://bundlejs.com/?q=solid-js%401.8%2Fweb&treeshake=%5B%7B+className+%7D%5D&config=%7B%22esbuild%22%3A%7B%22minify%22%3Afalse%7D%7D
https://esbuild.github.io/api/#tree-shaking

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->


<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

I haven't test this change

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
