### PR TITLE
fix catchError propagation

### DIFF
--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -621,6 +621,29 @@ describe("catchError", () => {
     ).not.toThrow("fail");
     expect(errored).toBe(true);
   });
+
+  test("Correct propagation", () => {
+    let afterError = false;
+    let afterCaught = false;
+    let error;
+    expect(() => {
+      createRoot(() => {
+        catchError(
+          () => {
+            createMemo(() => {
+              throw "error";
+            });
+            afterError = true;
+          },
+          e => (error = true)
+        );
+        afterCaught = true;
+      });
+    }).not.toThrow();
+    expect(afterError).toBe(false);
+    expect(error).toBe(true);
+    expect(afterCaught).toBe(true);
+  });
 });
 
 describe("createDeferred", () => {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary
Opening this up just for the idea. I initially used a separate `const ErrorHandled = Symbol()` but changed to `ERROR`.

fixes https://github.com/solidjs/solid/issues/1895

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
IMO, `catchError` should work like one we have in the language. It should stop further execution inside the boundary. Everything outside should work as usual.
https://playground.solidjs.com/anonymous/a42cb5b3-37b9-4469-9b48-a5fc0d50937e

## How did you test this change?
Added a narrowed down test for `catchError` though I'm not sure if there's any other edge cases.
`pnpm test` seems to pass including the one added.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
