### PR TITLE
fix derived signal name in explanation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ function Counter() {
   console.log("The body of the function runs once...");
 
   // JSX allows you to write HTML within your JavaScript function and include dynamic expressions using the { } syntax
-  // The only part of this that will ever rerender is the count() text.
+  // The only part of this that will ever rerender is the doubleCount() text.
   return (
     <>
       <button onClick={() => setCount(c => c + 1)}>


### PR DESCRIPTION
it said "the only thing that will rerender is the count() text" but the text node references the `doubleCount()` derived signal not the `count()` signal