### PR TITLE
fix!: Remove browser field from package.json

### DIFF
--- a/.changeset/rare-birds-train.md
+++ b/.changeset/rare-birds-train.md
@@ -1,0 +1,5 @@
+---
+"solid-js": minor
+---
+
+fix!: Remove browser field from package.json

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -11,10 +11,6 @@
   },
   "main": "./dist/server.cjs",
   "module": "./dist/server.js",
-  "browser": {
-    "./dist/server.cjs": "./dist/solid.cjs",
-    "./dist/server.js": "./dist/solid.js"
-  },
   "unpkg": "./dist/solid.cjs",
   "types": "types/index.d.ts",
   "sideEffects": false,

--- a/packages/solid/store/package.json
+++ b/packages/solid/store/package.json
@@ -2,10 +2,6 @@
   "name": "solid-js/store",
   "main": "./dist/server.cjs",
   "module": "./dist/server.js",
-  "browser": {
-    "./dist/server.cjs": "./dist/store.cjs",
-    "./dist/server.js": "./dist/store.js"
-  },
   "unpkg": "./dist/store.cjs",
   "types": "./types/index.d.ts",
   "type": "module",

--- a/packages/solid/web/package.json
+++ b/packages/solid/web/package.json
@@ -2,10 +2,6 @@
   "name": "solid-js/web",
   "main": "./dist/server.cjs",
   "module": "./dist/server.js",
-  "browser": {
-    "./dist/server.cjs": "./dist/web.cjs",
-    "./dist/server.js": "./dist/web.js"
-  },
   "unpkg": "./dist/web.cjs",
   "types": "./types/index.d.ts",
   "type": "module",


### PR DESCRIPTION
 Remove browser field from package.json of core packages so that worker export doesn't get mapped back the browser field by Vite, Rollup, Webpack etc; 

BREAKING CHANGE: Jest was previously mentioned as the reason that wasn't removed, but Jest now supports package.json modules. That said, some other tooling might still not support esm exports.

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
A couple of years ago, it was noted that rollup, vite, and webpack map the `worker` export condition back to the browser field, which broke solid in certain edge runtimes (cloudflare) due to the need to load the server build of solid instead of the browser field. (notably, esbuild does not follow that behavior) Issues were opened with the respective bundlers, but vite closed as expected, and rollup didn't respond at the time.  The fix as noted was to remove the browser field from pacakge.json, but it was noted that would break Jest and other non esm envs, which didn't support exports, but now they (Jest) do.  (And esm adoption has continue to increase)
Full discussion of the issue here:
https://github.com/solidjs/solid-start/issues/263

Recently, the cloudflare adapter for astro removed their esbuild step, which resulted in breaking the adapter for users of solid bringing this back to attention.  Context here:
https://github.com/withastro/adapters/issues/224

Jest however, now supports package.json exports:
https://jestjs.io/blog/2022/04/25/jest-28#packagejson-exports, 
and allows configuring how the exports of a package.json are resolved:
https://jestjs.io/blog/2022/04/25/jest-28#packagejson-exports


## How did you test this change?
Here is an example repo showing Jest working with solid, while I've remove the browser field in a patch:
https://github.com/wkelly17/Solid-Jest-repro

Besides Jest now working, this would fix workarounds for users of cloudflare + astro + solid, and I think for anyone trying to bundle for Cloudflare using anything other than esbuild (and maybe some other edge runtimes? uncertain). 

The main question I'm not sure about is, are there any other common community packages besides Jest that would preclude from making this merge now that some upstream issues have solved? 