### PR TITLE
make a named export for solid-js/html for autocompletion in IDEs

### DIFF
--- a/.changeset/grumpy-jars-invite.md
+++ b/.changeset/grumpy-jars-invite.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+expose `html` with a named export from `solid-js/html`

--- a/packages/solid/html/src/index.ts
+++ b/packages/solid/html/src/index.ts
@@ -23,7 +23,7 @@ import {
   SVGNamespace
 } from "solid-js/web";
 
-const html: HTMLTag = createHTML({
+export const html: HTMLTag = createHTML({
   effect,
   style,
   insert,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

Clearly-named exports appear as autocomplete results in IDEs like VS Code. This allows someone to, for example, write the following JS code with `|` representing the cursor location:

```js
function Comp() {
  return html|
}
```

and IDEs that use TypeScript Language Server (f.e. VS Code) will propose to automatically add `import {html} from 'solid-js/html'`, converting the code to the following when the user hits the Tab key (default in most IDEs) to accept the auto-completion:

```js
import {html} from 'solid-js/html'

function Comp() {
  return html|
}
```
