### PR TITLE
adds test cases for swapping objects/arrays on stores

### DIFF
--- a/packages/solid/store/test/modifiers.spec.ts
+++ b/packages/solid/store/test/modifiers.spec.ts
@@ -156,6 +156,32 @@ describe("setState with reconcile", () => {
     setStore(reconcile({ value: { q: "aa" } }));
     expect(store.value).toEqual({ q: "aa" });
   });
+  test("reconciles an object with an array", () => {
+    const [store, setStore] = createStore<{ value: {} | [] }>({
+      value: { foo: "bar" }
+    });
+
+    const value = [0, 1, 2];
+    setStore("value", reconcile(value));
+
+    expect(Array.isArray(store.value)).toBe(true);
+    expect(store).toEqual({
+      value: [0, 1, 2]
+    });
+  });
+
+  test("reconciles an array with an object", () => {
+    const [store, setStore] = createStore<{ value: {} | [] }>({
+      value: [0, 1, 2]
+    });
+
+    const value = { foo: "bar" };
+    setStore("value", reconcile(value));
+    expect(Array.isArray(store.value)).toBe(false);
+    expect(store).toEqual({
+      value: { foo: "bar" }
+    });
+  });
 });
 
 describe("setState with produce", () => {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary
Was reading the `isArray` condition on `applyState` ..  investigating the issues here found this comment https://github.com/solidjs/solid/issues/1973#issuecomment-2152496877  
This other post may be relevant https://github.com/solidjs/solid/issues/2017#issuecomment-1881586257 I haven't considered you could patch an array at an index with an object describing the patch.

Admittedly, needing to swap object types seems weird, don't remember having run into this myself. In any case this PR adds two failing test cases for it. I tried to give it a shot but couldn't pass the test, so Im leaving this here.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->


