### PR TITLE
fix #2282: Add Check for Proxy support

### DIFF
--- a/.changeset/quick-mirrors-mix.md
+++ b/.changeset/quick-mirrors-mix.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+fix #2282: Add Check for Proxy support

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -30,6 +30,7 @@ import type { FlowComponent, FlowProps } from "../render/index.js";
 
 export const equalFn = <T>(a: T, b: T) => a === b;
 export const $PROXY = Symbol("solid-proxy");
+export const SUPPORTS_PROXY = typeof Proxy === "function";
 export const $TRACK = Symbol("solid-track");
 export const $DEVCOMP = Symbol("solid-dev-component");
 const signalOptions = { equals: equalFn };

--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -5,6 +5,7 @@ import {
   createMemo,
   devComponent,
   $PROXY,
+  SUPPORTS_PROXY,
   $DEVCOMP,
   EffectFunction
 } from "../reactive/signal.js";
@@ -197,7 +198,7 @@ export function mergeProps<T extends unknown[]>(...sources: T): MergeProps<T> {
     sources[i] =
       typeof s === "function" ? ((proxy = true), createMemo(s as EffectFunction<unknown>)) : s;
   }
-  if (proxy) {
+  if (SUPPORTS_PROXY && proxy) {
     return new Proxy(
       {
         get(property: string | number | symbol) {
@@ -280,7 +281,7 @@ export function splitProps<
   T extends Record<any, any>,
   K extends [readonly (keyof T)[], ...(readonly (keyof T)[])[]]
 >(props: T, ...keys: K): SplitProps<T, K> {
-  if ($PROXY in props) {
+  if (SUPPORTS_PROXY && $PROXY in props) {
     const blocked = new Set<keyof T>(keys.length > 1 ? keys.flat() : keys[0]);
     const res = keys.map(k => {
       return new Proxy(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

On older browsers (Chrome < 49) Proxy is not supported. When using core-js to polyfill features - `$PROXY in s` always returns true, leading to proxy being true and Solid trying to use Proxy even though the browser doesn't support it.

## How did you test this change?

I've tested these changes using lambdatest.com.
![Chrome38](https://github.com/user-attachments/assets/6f34332e-d9e6-47ce-a943-6e22e12031f9)
https://github.com/lightning-tv/solid-demo-app


