### PR TITLE
fix wrapping of object with `null` prototype

### DIFF
--- a/.changeset/yellow-rings-report.md
+++ b/.changeset/yellow-rings-report.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+fix wrapping of object with `null` prototype

--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -97,6 +97,7 @@ function wrap<T extends StoreNode>(value: T): T {
 
     const proto = Object.getPrototypeOf(value);
     const isClass =
+      proto !== null &&
       value !== null &&
       typeof value === "object" &&
       !Array.isArray(value) &&

--- a/packages/solid/store/test/mutable.spec.ts
+++ b/packages/solid/store/test/mutable.spec.ts
@@ -2,6 +2,11 @@ import { createRoot, createSignal, createMemo, batch, createEffect } from "../..
 import { Accessor, Setter } from "../../types";
 import { createMutable, unwrap, $RAW } from "../src";
 
+test("Object.create(null) is allowed", () => {
+  const user = createMutable(Object.assign(Object.create(null), { name: "John" }));
+  expect(user.name).toBe("John");
+});
+
 describe("State Mutability", () => {
   test("Setting a property", () => {
     const user = createMutable({ name: "John" });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Could not add object with `null` prototype to store/mutable
https://playground.solidjs.com/anonymous/90e80787-1a13-41ff-82ea-90c0d1f20a80
```
Uncaught TypeError: Cannot convert undefined or null to object
    at Function.getOwnPropertyDescriptors (<anonymous>)
```
## How did you test this change?
```ts
test("Object.create(null) is allowed", () => {
  const user = createMutable(Object.assign(Object.create(null), { name: "John" }));
  expect(user.name).toBe("John");
});
```
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
