### PR TITLE
Improve signal setter type for code completion of string literal unions.

### DIFF
--- a/.changeset/shy-islands-talk.md
+++ b/.changeset/shy-islands-talk.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Improve signal setter type for code completion of string literal unions.

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -178,12 +178,11 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: typeof Owner)
 export type Accessor<T> = () => T;
 
 export type Setter<in out T> = {
-  <U extends T>(...args: undefined extends T ? [] : [value: (prev: T) => U]): undefined extends T
-    ? undefined
-    : U;
-  <U extends T>(value: (prev: T) => U): U;
   <U extends T>(value: Exclude<U, Function>): U;
-  <U extends T>(value: Exclude<U, Function> | ((prev: T) => U)): U;
+  <U extends T>(value: (prev: T) => U): U;
+  <U extends T>(...args: undefined extends T ? [] : [value: (prev: T) => U]): undefined extends T
+  ? undefined
+  : U;
 };
 
 export type Signal<T> = [get: Accessor<T>, set: Setter<T>];

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -178,11 +178,12 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: typeof Owner)
 export type Accessor<T> = () => T;
 
 export type Setter<in out T> = {
+  <U extends T>(value: Exclude<U, Function> | ((prev: T) => U)): U;
+  <U extends T>(...args: undefined extends T ? [] : [value: (prev: T) => U]): undefined extends T
+    ? undefined
+    : U;
   <U extends T>(value: Exclude<U, Function>): U;
   <U extends T>(value: (prev: T) => U): U;
-  <U extends T>(...args: undefined extends T ? [] : [value: (prev: T) => U]): undefined extends T
-  ? undefined
-  : U;
 };
 
 export type Signal<T> = [get: Accessor<T>, set: Setter<T>];


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary
Improve signal setter type for code completion of string literal unions.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
Reorder overload signatures
```typescript
type setterNew<in out T> = {
    <U extends T>(value: Exclude<U, Function> | ((prev: T) => U)): U;
    <U extends T>(
        ...args: undefined extends T ? [] : [value: (prev: T) => U]
    ): undefined extends T ? undefined : U
    <U extends T>(value: Exclude<U, Function>): U
    <U extends T>(value: (prev: T) => U): U

}

type SetterOld<in out T> = {
  <U extends T>(...args: undefined extends T ? [] : [value: (prev: T) => U]): undefined extends T
    ? undefined
    : U;
  <U extends T>(value: (prev: T) => U): U;
  <U extends T>(value: Exclude<U, Function>): U;
  <U extends T>(value: Exclude<U, Function> | ((prev: T) => U)): U;
};


type strUnion = "foo" | "bar"

const setterNew: setterNew<strUnion> = (x) => x
const setterOld: SetterOld<strUnion> = (x) => x

setterNew() // completion: "foo" | "bar"
setterNew(x => "") // completion: "foo" | "bar"
// We can all get completion
setterOld() // completion: none
setterOld(x => "") // completion: "foo" | "bar"
// We cant get completionon first function
```
[typescript playground](https://www.typescriptlang.org/play/?#code/C4TwDgpgBAzhzAgJwHIQO4B4CWA7KA9gK7BQAqAfFALxQDeAUFM1JgKpQQAeiuAJjHIUAFADcAhgBsiEAFxQAolwDG0vhHYAaKADEiuZcGwFcVAD5RhwsEgij5ZAJQ0qbR4-lsA3ExbtOPBD8gpTCviwsAHTR4kgA5jDy+uoAZngQfAG8AuRQAPxQANoAulDyhRLScpY2dg7O1K7F4VAeUMkQabgZWUE5ZPnt-J3pmZ4t-tzZISKVMvJKqkTqWrr6hsambWwTHFN9M2JS8zW29uQNrtsMDAC+N6CQUADK8IhIAPKSfDj4xKSUGj0XyTQLBITCaKRWIJJLDLo9fbggYFEplIpzarWM71FxQNjFNodBGZJH9FoFYmjFqeHzMUHTCGY+TYuoXPFuWkgvZg-qzY7VRZqDRsbR6AxGEwUbZ01g8xmhZmKFTC1bijZSqAWKy1c5ODnuLm3HwPcDQGDAJBsXCbIEAIhSBAIdq1UDtACNYnabsoTBbYG9kGh0PI4AggxhMBarTbNbRhFxLlAuAxfbh-WH3l8+PJXuHPt8o5brZsqPHE3iUwxMxH0MJnAB6BtQPCISSSbBwdPVB1Ol0WD1e6uB1AYBN4u12xvN1sQdudoJweS952uwdIb1NqAAdWgynE+CkkigcXgUAAkrg2x3Xt3h-ns-WoFvZ-Ou0uoLgTBB71nvuPGjdKdnxnK85w7d8e0dVcB09DcGC3XcoH3K8TzPV8IMXaATCgNIkH9FJ1klXAgA)
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
