### PR TITLE
use correct hydration id in server lazy

### DIFF
--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -493,7 +493,7 @@ export function lazy<T extends Component<any>>(
   const wrap: Component<ComponentProps<T>> & {
     preload?: () => Promise<{ default: T }>;
   } = props => {
-    const id = sharedConfig.context!.id.slice(0, -1);
+    const id = sharedConfig.context!.id;
     let ref = sharedConfig.context!.lazy[id];
     if (ref) p = ref;
     else load(id);


### PR DESCRIPTION
fixes https://github.com/solidjs/solid/issues/2302

with the new hydration key generation introduced in https://github.com/solidjs/solid/commit/424a31a31a956ad84f7e49c6b654e290ebea4fac, it's not necessary to cut the `-` at the end anymore.