### PR TITLE
onCleanup accessible from onMount 

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -963,12 +963,15 @@ export function on<S, Next extends Prev, Prev = Next>(
 
 /**
  * Runs an effect only after initial render on mount
- * @param fn an effect that should run only once on mount
+ * @param fn an effect that should run only once on mount. It can return a function to be run on cleanup.
  *
  * @description https://docs.solidjs.com/reference/lifecycle/on-mount
  */
-export function onMount(fn: () => void) {
-  createEffect(() => untrack(fn));
+export function onMount(fn: () => (void | (() => void))) {
+  createEffect(() => untrack(() => {
+    const toRunOnCleanup = fn()
+    if (toRunOnCleanup) onCleanup(toRunOnCleanup)
+  }));
 }
 
 /**

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -969,8 +969,8 @@ export function on<S, Next extends Prev, Prev = Next>(
  */
 export function onMount(fn: () => (void | (() => void))) {
   createEffect(() => untrack(() => {
-    const toRunOnCleanup = fn()
-    if (toRunOnCleanup) onCleanup(toRunOnCleanup)
+    const toRunOnCleanup = fn();
+    if (toRunOnCleanup) onCleanup(toRunOnCleanup);
   }));
 }
 


### PR DESCRIPTION
## Summary
It would be very convenient to have a built-in way of adding a cleanup function from the scope of a function given to onMount, given that whatever variables are allocated in this scope, likely are tied to the component's lifespan. 

I, personally, am doing some networked pub/sub, and sure, I could createSignal and allocate the subscription reference within the component as such, but I'd much rather be able to simply go "return () => server.unsubscribe(ref)" from within the function given to onMount itself.
 
## How did you test this change?
I've yet to get pnpm working, but I'll try and add on some tests when I get it up and running. It might be some months before I get time for that though. If anyone has some minutes to spare and know *how* to test this in the first place, feel free to help me out.

From a statick analysis perspective, this code does not add anything new, nor does it expand on existing features. Its but an if statement and a type change. Taking a real "devils advocate" look on it, it does slightly increase memory cost for any function given to onMount, as it wraps the given function in order to extract and register the cleanup function (if any). However I currently do not know the solid code base well enough to know if there's a better alternative.
