### PR TITLE
Reordering setter overloads

### DIFF
--- a/.changeset/empty-cars-jog.md
+++ b/.changeset/empty-cars-jog.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Reordering setter overloads

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -179,12 +179,12 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: typeof Owner)
 export type Accessor<T> = () => T;
 
 export type Setter<in out T> = {
-  <U extends T>(value: Exclude<U, Function> | ((prev: T) => U)): U;
   <U extends T>(
     ...args: undefined extends T ? [] : [value: Exclude<U, Function> | ((prev: T) => U)]
   ): undefined extends T ? undefined : U;
   <U extends T>(value: (prev: T) => U): U;
   <U extends T>(value: Exclude<U, Function>): U;
+  <U extends T>(value: Exclude<U, Function> | ((prev: T) => U)): U;
 };
 
 export type Signal<T> = [get: Accessor<T>, set: Setter<T>];


### PR DESCRIPTION
Made changes based on discord discussions.

Compared to the type before #2297, the current type only modifies the first overload to widen the type of the parameter to allow auto-completion for literal unions, and it shouldn't break anything now.