### PR TITLE
fix class/prototype getters not being reactive

### DIFF
--- a/.changeset/young-mirrors-begin.md
+++ b/.changeset/young-mirrors-begin.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+fix class/prototype getters not getting wrapped

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -1,4 +1,4 @@
-import { getListener, batch, DEV, $PROXY, $TRACK, createSignal } from "solid-js";
+import { $PROXY, $TRACK, batch, createSignal, DEV, getListener } from "solid-js";
 
 export const $RAW = Symbol("store-raw"),
   $NODE = Symbol("store-node"),
@@ -49,11 +49,27 @@ function wrap<T extends StoreNode>(value: T): T {
     Object.defineProperty(value, $PROXY, { value: (p = new Proxy(value, proxyTraps)) });
     if (!Array.isArray(value)) {
       const keys = Object.keys(value),
-        desc = Object.getOwnPropertyDescriptors(value);
+        desc = Object.getOwnPropertyDescriptors(value),
+        proto = Object.getPrototypeOf(value);
+
+      const isClass =
+        proto !== null &&
+        value !== null &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        proto !== Object.prototype;
+      if (isClass) {
+        const descriptors = Object.getOwnPropertyDescriptors(proto);
+        keys.push(...Object.keys(descriptors));
+        Object.assign(desc, descriptors);
+      }
+
       for (let i = 0, l = keys.length; i < l; i++) {
         const prop = keys[i];
+        if (isClass && prop === "constructor") continue;
         if (desc[prop].get) {
           Object.defineProperty(value, prop, {
+            configurable: true,
             enumerable: desc[prop].enumerable,
             get: desc[prop].get!.bind(p)
           });

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -722,6 +722,37 @@ describe("Nested Classes", () => {
     expect(sum).toBe(15);
   });
 
+  test("wrapped nested class getter", () => {
+    class CustomThing {
+      a: number;
+      b: number;
+      constructor(value: number) {
+        this.a = value;
+        this.b = 10;
+      }
+      get sum(): number {
+        return this.a + this.b;
+      }
+    }
+
+    const [inner] = createStore(new CustomThing(1));
+    const [store, setStore] = createStore({ inner });
+
+    expect(store.inner.sum).toBe(11);
+
+    let sum;
+    createRoot(() => {
+      createEffect(() => {
+        sum = store.inner.sum;
+      });
+    });
+    expect(sum).toBe(11);
+    setStore("inner", "a", 10);
+    expect(sum).toBe(20);
+    setStore("inner", "b", 5);
+    expect(sum).toBe(15);
+  });
+
   test("not wrapped nested class", () => {
     class CustomThing {
       a: number;
@@ -747,6 +778,37 @@ describe("Nested Classes", () => {
     expect(sum).toBe(11);
     setStore("inner", "b", 5);
     expect(sum).toBe(11);
+  });
+
+  test("not wrapped nested class getter", () => {
+    class CustomThing {
+      a: number;
+      b: number;
+      constructor(value: number) {
+        this.a = value;
+        this.b = 10;
+      }
+      get sum(): number {
+        return this.a + this.b;
+      }
+    }
+
+    const [store, setStore] = createStore({ inner: new CustomThing(1) });
+
+    let sum;
+    createRoot(() => {
+      createEffect(() => {
+        sum = store.inner.sum;
+      });
+    });
+    expect(sum).toBe(11);
+    expect(store.inner.sum).toBe(11);
+    setStore("inner", "a", 10);
+    expect(sum).toBe(11);
+    expect(store.inner.sum).toBe(20);
+    setStore("inner", "b", 5);
+    expect(sum).toBe(11);
+    expect(store.inner.sum).toBe(15);
   });
 });
 


### PR DESCRIPTION
This fixes class getter methods not being reactive.
It is the same fix that was already applied for `createMutable` in #2027.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->