### PR TITLE
Improve resolving arguments in createResource

### DIFF
--- a/.changeset/twelve-comics-knock.md
+++ b/.changeset/twelve-comics-knock.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Improve resolving arguments in createResource

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -591,14 +591,15 @@ export function createResource<T, S, R>(
   let source: ResourceSource<S>;
   let fetcher: ResourceFetcher<S, T, R>;
   let options: ResourceOptions<T, S>;
-  if ((arguments.length === 2 && typeof pFetcher === "object") || arguments.length === 1) {
-    source = true as ResourceSource<S>;
-    fetcher = pSource as ResourceFetcher<S, T, R>;
-    options = (pFetcher || {}) as ResourceOptions<T, S>;
-  } else {
+  
+  if (typeof pFetcher === "function") {
     source = pSource as ResourceSource<S>;
     fetcher = pFetcher as ResourceFetcher<S, T, R>;
     options = pOptions || ({} as ResourceOptions<T, S>);
+  } else {
+    source = true as ResourceSource<S>;
+    fetcher = pSource as ResourceFetcher<S, T, R>;
+    options = (pFetcher || {}) as ResourceOptions<T, S>;
   }
 
   let pr: Promise<T> | null = null,

--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -374,16 +374,13 @@ export function createResource<T, S>(
   fetcher?: ResourceFetcher<S, T> | ResourceOptions<T> | ResourceOptions<undefined>,
   options: ResourceOptions<T> | ResourceOptions<undefined> = {}
 ): ResourceReturn<T> | ResourceReturn<T | undefined> {
-  if (arguments.length === 2) {
-    if (typeof fetcher === "object") {
-      options = fetcher as ResourceOptions<T> | ResourceOptions<undefined>;
-      fetcher = source as ResourceFetcher<S, T>;
-      source = true as ResourceSource<S>;
-    }
-  } else if (arguments.length === 1) {
-    fetcher = source as ResourceFetcher<S, T>;
+  
+  if (typeof fetcher !== "function") {
     source = true as ResourceSource<S>;
+    fetcher = source as ResourceFetcher<S, T>;
+    options = (fetcher || {}) as ResourceOptions<T> | ResourceOptions<undefined>;
   }
+
   const contexts = new Set<SuspenseContextType>();
   const id = sharedConfig.getNextContextId();
   let resource: { ref?: any; data?: T } = {};

--- a/packages/solid/test/resource.spec.ts
+++ b/packages/solid/test/resource.spec.ts
@@ -385,3 +385,35 @@ describe("using Resource with custom store", () => {
     expect(street).toBe(2);
   });
 });
+
+describe("createResource can be wrapped", () => {
+
+  const fns: [name: string, function: typeof createResource][] = [
+    ["original createResource", createResource],
+    // @ts-ignore
+    ["createResource(...args)", (...args) => createResource(...args)],
+    // @ts-ignore
+    ["createResource(a, b, c)", (a, b, c) => createResource(a, b, c)],
+  ]
+
+  for (const [name, fn] of fns) {
+
+    test(`only fetcher in ${name}`, () => {
+      const [[data], dispose] = createRoot(dispose => [fn(() => 123), dispose])
+      expect(data()).toBe(123)
+      dispose()
+    })
+    
+    test(`fetcher and source in ${name}`, () => {
+      const [source, setSource] = createSignal(1)
+
+      const [[data], dispose] = createRoot(dispose => [fn(source, v => v), dispose])
+      expect(data()).toBe(1)
+
+      setSource(2)
+      expect(data()).toBe(2)
+
+      dispose()
+    })
+  }
+})


### PR DESCRIPTION
Check `typeof` the second argument instead of using the `arguments` variable.
This fixes case where some arguments were passed explicitely as `undefined` instead of being omitted.
Which helps with wrapping the resource in own function.

```ts
createRecource(fetcher, undefined) // used to cause TypeError: fetcher is not a function
```
