### PR TITLE
Add `StoreBundle<T>` type

### DIFF
--- a/.changeset/lovely-mayflies-sniff.md
+++ b/.changeset/lovely-mayflies-sniff.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Add `StoreReturn<T>` type

--- a/packages/solid/store/src/index.ts
+++ b/packages/solid/store/src/index.ts
@@ -8,6 +8,7 @@ export type {
   SetStoreFunction,
   SolidStore,
   Store,
+  StoreBundle,
   StoreNode,
   StorePathRange,
   StoreSetter

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -490,6 +490,8 @@ export interface SetStoreFunction<T> {
   ): void;
 }
 
+export type StoreBundle<T> = [get: Store<T>, set: SetStoreFunction<T>];
+
 /**
  * Creates a reactive store that can be read through a proxy object and written with a setter function
  *

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -501,7 +501,7 @@ export function createStore<T extends object = {}>(
   ...[store, options]: {} extends T
     ? [store?: T | Store<T>, options?: { name?: string }]
     : [store: T | Store<T>, options?: { name?: string }]
-): [get: Store<T>, set: SetStoreFunction<T>] {
+): StoreBundle<T> {
   const unwrappedStore = unwrap((store || {}) as T);
   const isArray = Array.isArray(unwrappedStore);
   if ("_SOLID_DEV_" && typeof unwrappedStore !== "object" && typeof unwrappedStore !== "function")


### PR DESCRIPTION
## Summary

Here I added `StoreBundle<T>`; a useful type extracted directly from the `createStore` function's return type:
`type StoreBundle<T> = [get: Store<T>, set: SetStoreFunction<T>]`

## How did you test this change?

This type is identical to the return type of the `createStore` function, so nothing really should change, besides the fact that it's definitely more portable, more compact, and depending on who we ask, more readable.
All tests have been successfully ran, though.