### PR TITLE
Update typescript to 5.7

### DIFF
--- a/.changeset/many-crabs-reply.md
+++ b/.changeset/many-crabs-reply.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Update typescript to 5.7

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "symlink-dir": "^5.0.1",
     "tsconfig-replace-paths": "^0.0.11",
     "turbo": "^1.3.1",
-    "typescript": "~5.5.2",
+    "typescript": "~5.7.2",
     "vite-plugin-solid": "^2.6.1",
     "vitest": "^2.1.2"
   },

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -72,17 +72,15 @@ type JSXElement = JSX.Element;
 export type { JSXElement, JSX };
 
 // dev
-import { registerGraph, writeSignal, DevHooks } from "./reactive/signal.js";
-export const DEV = "_SOLID_DEV_"
-  ? ({ hooks: DevHooks, writeSignal, registerGraph } as const)
-  : undefined;
+import { registerGraph, writeSignal, DevHooks, IS_DEV } from "./reactive/signal.js";
+export const DEV = IS_DEV ? ({ hooks: DevHooks, writeSignal, registerGraph } as const) : undefined;
 
 // handle multiple instance check
 declare global {
   var Solid$$: boolean;
 }
 
-if ("_SOLID_DEV_" && globalThis) {
+if (IS_DEV && globalThis) {
   if (!globalThis.Solid$$) globalThis.Solid$$ = true;
   else
     console.warn(

--- a/packages/solid/src/reactive/array.ts
+++ b/packages/solid/src/reactive/array.ts
@@ -5,7 +5,8 @@ import {
   createSignal,
   Accessor,
   Setter,
-  $TRACK
+  $TRACK,
+  IS_DEV
 } from "./signal.js";
 
 const FALLBACK = Symbol("fallback");
@@ -166,7 +167,7 @@ export function mapArray<T, U>(
     function mapper(disposer: () => void) {
       disposers[j] = disposer;
       if (indexes) {
-        const [s, set] = "_SOLID_DEV_" ? createSignal(j, { name: "index" }) : createSignal(j);
+        const [s, set] = IS_DEV ? createSignal(j, { name: "index" }) : createSignal(j);
         indexes[j] = set;
         return mapFn(newItems[j], s);
       }
@@ -243,7 +244,7 @@ export function indexArray<T, U>(
     });
     function mapper(disposer: () => void) {
       disposers[i] = disposer;
-      const [s, set] = "_SOLID_DEV_"
+      const [s, set] = IS_DEV
         ? createSignal(newItems[i], { name: "value" })
         : createSignal(newItems[i]);
       signals[i] = set;

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -28,6 +28,9 @@ import { setHydrateContext, sharedConfig } from "../render/hydration.js";
 import type { JSX } from "../jsx.js";
 import type { FlowComponent, FlowProps } from "../render/index.js";
 
+// replaced during build
+export const IS_DEV = "_SOLID_DEV_" as string | boolean;
+
 export const equalFn = <T>(a: T, b: T) => a === b;
 export const $PROXY = Symbol("solid-proxy");
 export const SUPPORTS_PROXY = typeof Proxy === "function";
@@ -145,7 +148,7 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: typeof Owner)
     unowned = fn.length === 0,
     current = detachedOwner === undefined ? owner : detachedOwner,
     root: Owner = unowned
-      ? "_SOLID_DEV_"
+      ? IS_DEV
         ? { owned: null, cleanups: null, context: null, owner: null }
         : UNOWNED
       : {
@@ -155,7 +158,7 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: typeof Owner)
           owner: current
         },
     updateFn = unowned
-      ? "_SOLID_DEV_"
+      ? IS_DEV
         ? () =>
             fn(() => {
               throw new Error("Dispose method must be an explicit argument to createRoot function");
@@ -163,7 +166,7 @@ export function createRoot<T>(fn: RootFunction<T>, detachedOwner?: typeof Owner)
         : fn
       : () => fn(() => untrack(() => cleanNode(root)));
 
-  if ("_SOLID_DEV_") DevHooks.afterCreateOwner && DevHooks.afterCreateOwner(root);
+  if (IS_DEV) DevHooks.afterCreateOwner && DevHooks.afterCreateOwner(root);
 
   Owner = root;
   Listener = null;
@@ -231,7 +234,7 @@ export function createSignal<T>(
     comparator: options.equals || undefined
   };
 
-  if ("_SOLID_DEV_") {
+  if (IS_DEV) {
     if (options.name) s.name = options.name;
     if (DevHooks.afterCreateSignal) DevHooks.afterCreateSignal(s);
     if (!options.internal) registerGraph(s);
@@ -288,7 +291,7 @@ export function createComputed<Next, Init>(
   value?: Init,
   options?: EffectOptions
 ): void {
-  const c = createComputation(fn, value!, true, STALE, "_SOLID_DEV_" ? options : undefined);
+  const c = createComputation(fn, value!, true, STALE, IS_DEV ? options : undefined);
   if (Scheduler && Transition && Transition.running) Updates!.push(c);
   else updateComputation(c);
 }
@@ -319,7 +322,7 @@ export function createRenderEffect<Next, Init>(
   value?: Init,
   options?: EffectOptions
 ): void {
-  const c = createComputation(fn, value!, false, STALE, "_SOLID_DEV_" ? options : undefined);
+  const c = createComputation(fn, value!, false, STALE, IS_DEV ? options : undefined);
   if (Scheduler && Transition && Transition.running) Updates!.push(c);
   else updateComputation(c);
 }
@@ -351,7 +354,7 @@ export function createEffect<Next, Init>(
   options?: EffectOptions & { render?: boolean }
 ): void {
   runEffects = runUserEffects;
-  const c = createComputation(fn, value!, false, STALE, "_SOLID_DEV_" ? options : undefined),
+  const c = createComputation(fn, value!, false, STALE, IS_DEV ? options : undefined),
     s = SuspenseContext && useContext(SuspenseContext);
   if (s) c.suspense = s;
   if (!options || !options.render) c.user = true;
@@ -381,7 +384,7 @@ export function createReaction(onInvalidate: () => void, options?: EffectOptions
       undefined,
       false,
       0,
-      "_SOLID_DEV_" ? options : undefined
+      IS_DEV ? options : undefined
     ),
     s = SuspenseContext && useContext(SuspenseContext);
   if (s) c.suspense = s;
@@ -439,7 +442,7 @@ export function createMemo<Next extends Prev, Init, Prev>(
     value!,
     true,
     0,
-    "_SOLID_DEV_" ? options : undefined
+    IS_DEV ? options : undefined
   ) as Partial<Memo<Init, Next>>;
 
   c.observers = null;
@@ -591,7 +594,7 @@ export function createResource<T, S, R>(
   let source: ResourceSource<S>;
   let fetcher: ResourceFetcher<S, T, R>;
   let options: ResourceOptions<T, S>;
-  
+
   if (typeof pFetcher === "function") {
     source = pSource as ResourceSource<S>;
     fetcher = pFetcher as ResourceFetcher<S, T, R>;
@@ -829,7 +832,7 @@ export function createSelector<T, U = T>(
     undefined,
     true,
     STALE,
-    "_SOLID_DEV_" ? options : undefined
+    IS_DEV ? options : undefined
   ) as Memo<any>;
   updateComputation(node);
   return (key: U) => {
@@ -839,8 +842,8 @@ export function createSelector<T, U = T>(
       if ((l = subs.get(key))) l.add(listener);
       else subs.set(key, (l = new Set([listener])));
       onCleanup(() => {
-        l!.delete(listener!);
-        !l!.size && subs.delete(key);
+        l.delete(listener);
+        !l.size && subs.delete(key);
       });
     }
     return fn(
@@ -982,8 +985,7 @@ export function onMount(fn: () => void) {
  */
 export function onCleanup<T extends () => any>(fn: T): T {
   if (Owner === null)
-    "_SOLID_DEV_" &&
-      console.warn("cleanups created outside a `createRoot` or `render` will never be run");
+    IS_DEV && console.warn("cleanups created outside a `createRoot` or `render` will never be run");
   else if (Owner.cleanups === null) Owner.cleanups = [fn];
   else Owner.cleanups.push(fn);
   return fn;
@@ -1207,7 +1209,7 @@ export type ChildrenReturn = Accessor<ResolvedChildren> & { toArray: () => Resol
  */
 export function children(fn: Accessor<JSX.Element>): ChildrenReturn {
   const children = createMemo(fn);
-  const memo = "_SOLID_DEV_"
+  const memo = IS_DEV
     ? createMemo(() => resolveChildren(children()), undefined, { name: "children" })
     : createMemo(() => resolveChildren(children()));
   (memo as ChildrenReturn).toArray = () => {
@@ -1329,7 +1331,7 @@ export function writeSignal(node: SignalState<any> | Memo<any>, value: any, isCo
         }
         if (Updates!.length > 10e5) {
           Updates = [];
-          if ("_SOLID_DEV_") throw new Error("Potential Infinite Loop Detected.");
+          if (IS_DEV) throw new Error("Potential Infinite Loop Detected.");
           throw new Error();
         }
       }, false);
@@ -1426,7 +1428,7 @@ function createComputation<Next, Init = unknown>(
   }
 
   if (Owner === null)
-    "_SOLID_DEV_" &&
+    IS_DEV &&
       console.warn(
         "computations created outside a `createRoot` or `render` will never be disposed"
       );
@@ -1440,7 +1442,7 @@ function createComputation<Next, Init = unknown>(
     }
   }
 
-  if ("_SOLID_DEV_" && options && options.name) c.name = options.name;
+  if (IS_DEV && options && options.name) c.name = options.name;
 
   if (ExternalSourceConfig && c.fn) {
     const [track, trigger] = createSignal<void>(undefined, { equals: false });
@@ -1455,7 +1457,7 @@ function createComputation<Next, Init = unknown>(
     };
   }
 
-  if ("_SOLID_DEV_") DevHooks.afterCreateOwner && DevHooks.afterCreateOwner(c);
+  if (IS_DEV) DevHooks.afterCreateOwner && DevHooks.afterCreateOwner(c);
 
   return c;
 }
@@ -1464,8 +1466,7 @@ function runTop(node: Computation<any>) {
   const runningTransition = Transition && Transition.running;
   if ((runningTransition ? node.tState : node.state) === 0) return;
   if ((runningTransition ? node.tState : node.state) === PENDING) return lookUpstream(node);
-  if (node.suspense && untrack(node.suspense.inFallback!))
-    return node!.suspense.effects!.push(node!);
+  if (node.suspense && untrack(node.suspense.inFallback!)) return node.suspense.effects!.push(node);
   const ancestors = [node];
   while (
     (node = node.owner as Computation<any>) &&
@@ -1557,8 +1558,8 @@ function completeUpdates(wait: boolean) {
   }
   const e = Effects!;
   Effects = null;
-  if (e!.length) runUpdates(() => runEffects(e), false);
-  else if ("_SOLID_DEV_") DevHooks.afterUpdate && DevHooks.afterUpdate();
+  if (e.length) runUpdates(() => runEffects(e), false);
+  else if (IS_DEV) DevHooks.afterUpdate && DevHooks.afterUpdate();
   if (res) res();
 }
 
@@ -1675,7 +1676,7 @@ function cleanNode(node: Owner) {
   }
   if (Transition && Transition.running) (node as Computation<any>).tState = 0;
   else (node as Computation<any>).state = 0;
-  "_SOLID_DEV_" && delete node.sourceMap;
+  IS_DEV && delete node.sourceMap;
 }
 
 function reset(node: Computation<any>, top?: boolean) {
@@ -1707,7 +1708,7 @@ function handleError(err: unknown, owner = Owner) {
   if (!fns) throw error;
 
   if (Effects)
-    Effects!.push({
+    Effects.push({
       fn() {
         runErrors(error, fns, owner);
       },
@@ -1759,7 +1760,7 @@ type TODO = any;
 export function onError(fn: (err: Error) => void): void {
   ERROR || (ERROR = Symbol("error"));
   if (Owner === null)
-    "_SOLID_DEV_" &&
+    IS_DEV &&
       console.warn("error handlers created outside a `createRoot` or `render` will never be run");
   else if (Owner.context === null || !Owner.context[ERROR]) {
     // terrible de-opt

--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -7,7 +7,8 @@ import {
   $PROXY,
   SUPPORTS_PROXY,
   $DEVCOMP,
-  EffectFunction
+  EffectFunction,
+  IS_DEV
 } from "../reactive/signal.js";
 import { sharedConfig, nextHydrateContext, setHydrateContext } from "./hydration.js";
 import type { JSX } from "../jsx.js";
@@ -99,14 +100,14 @@ export function createComponent<T extends Record<string, any>>(
     if (sharedConfig.context) {
       const c = sharedConfig.context;
       setHydrateContext(nextHydrateContext());
-      const r = "_SOLID_DEV_"
+      const r = IS_DEV
         ? devComponent(Comp, props || ({} as T))
         : untrack(() => Comp(props || ({} as T)));
       setHydrateContext(c);
       return r;
     }
   }
-  if ("_SOLID_DEV_") return devComponent(Comp, props || ({} as T));
+  if (IS_DEV) return devComponent(Comp, props || ({} as T));
   return untrack(() => Comp(props || ({} as T)));
 }
 
@@ -376,7 +377,7 @@ export function lazy<T extends Component<any>>(
     return createMemo(() =>
       (Comp = comp())
         ? untrack(() => {
-            if ("_SOLID_DEV_") Object.assign(Comp!, { [$DEVCOMP]: true });
+            if (IS_DEV) Object.assign(Comp!, { [$DEVCOMP]: true });
             if (!ctx || sharedConfig.done) return Comp!(props);
             const c = sharedConfig.context;
             setHydrateContext(ctx);

--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -374,7 +374,6 @@ export function createResource<T, S>(
   fetcher?: ResourceFetcher<S, T> | ResourceOptions<T> | ResourceOptions<undefined>,
   options: ResourceOptions<T> | ResourceOptions<undefined> = {}
 ): ResourceReturn<T> | ResourceReturn<T | undefined> {
-  
   if (typeof fetcher !== "function") {
     source = true as ResourceSource<S>;
     fetcher = source as ResourceFetcher<S, T>;

--- a/packages/solid/store/src/index.ts
+++ b/packages/solid/store/src/index.ts
@@ -16,5 +16,5 @@ export * from "./mutable.js";
 export * from "./modifiers.js";
 
 // dev
-import { $NODE, isWrappable, DevHooks } from "./store.js";
-export const DEV = "_SOLID_DEV_" ? ({ $NODE, isWrappable, hooks: DevHooks } as const) : undefined;
+import { $NODE, isWrappable, DevHooks, IS_DEV } from "./store.js";
+export const DEV = IS_DEV ? ({ $NODE, isWrappable, hooks: DevHooks } as const) : undefined;

--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -10,7 +10,8 @@ import {
   $HAS,
   StoreNode,
   setProperty,
-  ownKeys
+  ownKeys,
+  IS_DEV
 } from "./store.js";
 
 function proxyDescriptor(target: StoreNode, property: PropertyKey) {
@@ -133,13 +134,13 @@ function wrap<T extends StoreNode>(value: T): T {
 
 export function createMutable<T extends StoreNode>(state: T, options?: { name?: string }): T {
   const unwrappedStore = unwrap(state || {});
-  if ("_SOLID_DEV_" && typeof unwrappedStore !== "object" && typeof unwrappedStore !== "function")
+  if (IS_DEV && typeof unwrappedStore !== "object" && typeof unwrappedStore !== "function")
     throw new Error(
       `Unexpected type ${typeof unwrappedStore} received when initializing 'createMutable'. Expected an object.`
     );
 
   const wrappedStore = wrap(unwrappedStore);
-  if ("_SOLID_DEV_") DEV!.registerGraph({ value: unwrappedStore, name: options && options.name });
+  if (IS_DEV) DEV!.registerGraph({ value: unwrappedStore, name: options && options.name });
   return wrappedStore;
 }
 

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -1,5 +1,8 @@
 import { getListener, batch, DEV, $PROXY, $TRACK, createSignal } from "solid-js";
 
+// replaced during build
+export const IS_DEV = "_SOLID_DEV_" as string | boolean;
+
 export const $RAW = Symbol("store-raw"),
   $NODE = Symbol("store-node"),
   $HAS = Symbol("store-has"),
@@ -192,12 +195,12 @@ const proxyTraps: ProxyHandler<StoreNode> = {
   },
 
   set() {
-    if ("_SOLID_DEV_") console.warn("Cannot mutate a Store directly");
+    if (IS_DEV) console.warn("Cannot mutate a Store directly");
     return true;
   },
 
   deleteProperty() {
-    if ("_SOLID_DEV_") console.warn("Cannot mutate a Store directly");
+    if (IS_DEV) console.warn("Cannot mutate a Store directly");
     return true;
   },
 
@@ -216,7 +219,7 @@ export function setProperty(
   const prev = state[property],
     len = state.length;
 
-  if ("_SOLID_DEV_")
+  if (IS_DEV)
     DevHooks.onStoreNodeUpdate && DevHooks.onStoreNodeUpdate(state, property, value, prev);
 
   if (value === undefined) {
@@ -502,12 +505,12 @@ export function createStore<T extends object = {}>(
 ): [get: Store<T>, set: SetStoreFunction<T>] {
   const unwrappedStore = unwrap((store || {}) as T);
   const isArray = Array.isArray(unwrappedStore);
-  if ("_SOLID_DEV_" && typeof unwrappedStore !== "object" && typeof unwrappedStore !== "function")
+  if (IS_DEV && typeof unwrappedStore !== "object" && typeof unwrappedStore !== "function")
     throw new Error(
       `Unexpected type ${typeof unwrappedStore} received when initializing 'createStore'. Expected an object.`
     );
   const wrappedStore = wrap(unwrappedStore);
-  if ("_SOLID_DEV_") DEV!.registerGraph({ value: unwrappedStore, name: options && options.name });
+  if (IS_DEV) DEV!.registerGraph({ value: unwrappedStore, name: options && options.name });
   function setStore(...args: any[]): void {
     batch(() => {
       isArray && args.length === 1

--- a/packages/solid/test/resource.spec.ts
+++ b/packages/solid/test/resource.spec.ts
@@ -387,33 +387,31 @@ describe("using Resource with custom store", () => {
 });
 
 describe("createResource can be wrapped", () => {
-
   const fns: [name: string, function: typeof createResource][] = [
     ["original createResource", createResource],
     // @ts-ignore
     ["createResource(...args)", (...args) => createResource(...args)],
     // @ts-ignore
-    ["createResource(a, b, c)", (a, b, c) => createResource(a, b, c)],
-  ]
+    ["createResource(a, b, c)", (a, b, c) => createResource(a, b, c)]
+  ];
 
   for (const [name, fn] of fns) {
-
     test(`only fetcher in ${name}`, () => {
-      const [[data], dispose] = createRoot(dispose => [fn(() => 123), dispose])
-      expect(data()).toBe(123)
-      dispose()
-    })
-    
+      const [[data], dispose] = createRoot(dispose => [fn(() => 123), dispose]);
+      expect(data()).toBe(123);
+      dispose();
+    });
+
     test(`fetcher and source in ${name}`, () => {
-      const [source, setSource] = createSignal(1)
+      const [source, setSource] = createSignal(1);
 
-      const [[data], dispose] = createRoot(dispose => [fn(source, v => v), dispose])
-      expect(data()).toBe(1)
+      const [[data], dispose] = createRoot(dispose => [fn(source, v => v), dispose]);
+      expect(data()).toBe(1);
 
-      setSource(2)
-      expect(data()).toBe(2)
+      setSource(2);
+      expect(data()).toBe(2);
 
-      dispose()
-    })
+      dispose();
+    });
   }
-})
+});

--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -128,7 +128,7 @@ export function Dynamic<T extends ValidComponent>(props: DynamicProps<T>): JSX.E
     const component = cached();
     switch (typeof component) {
       case "function":
-        if ("_DX_DEV_") Object.assign(component, { [$DEVCOMP]: true });
+        if (isDev) Object.assign(component, { [$DEVCOMP]: true });
         return untrack(() => component(others));
 
       case "string":

--- a/packages/solid/web/test/dynamic.spec.tsx
+++ b/packages/solid/web/test/dynamic.spec.tsx
@@ -8,7 +8,7 @@ import { createStore } from "../../store/src/index.js";
 import { Dynamic } from "../src/index.js";
 
 describe("Testing Dynamic control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
 
   interface ExampleProps {
     id: string;
@@ -56,7 +56,7 @@ describe("Testing Dynamic control flow", () => {
 });
 
 describe("Testing Dynamic with state spread", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
 
   interface ExampleProps {
     id: string;

--- a/packages/solid/web/test/errorboundary.spec.tsx
+++ b/packages/solid/web/test/errorboundary.spec.tsx
@@ -7,7 +7,7 @@ import { createRoot, resetErrorBoundaries } from "../../src/index.js";
 import { ErrorBoundary } from "../src/index.js";
 
 describe("Testing ErrorBoundary control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
 
   const Component = () => {
     throw new Error("Failure");

--- a/packages/solid/web/test/for.spec.tsx
+++ b/packages/solid/web/test/for.spec.tsx
@@ -7,7 +7,7 @@ import { createRoot, createSignal } from "../../src/index.js";
 import { insert, For } from "../src/index.js";
 
 describe("Testing an only child each control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const n1 = "a",
     n2 = "b",
     n3 = "c",
@@ -173,7 +173,7 @@ describe("Testing an multi child each control flow", () => {
 });
 
 describe("Testing an only child each control flow with fragment children", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const n1 = "a",
     n2 = "b",
     n3 = "c",
@@ -264,7 +264,7 @@ describe("Testing an only child each control flow with fragment children", () =>
 });
 
 describe("Testing an only child each control flow with array children", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const n1 = "a",
     n2 = "b",
     n3 = "c",
@@ -348,7 +348,7 @@ describe("Testing an only child each control flow with array children", () => {
 });
 
 describe("Testing each control flow with fallback", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const n1 = "a",
     n2 = "b",
     n3 = "c",
@@ -378,7 +378,7 @@ describe("Testing each control flow with fallback", () => {
 });
 
 describe("Testing each that maps to undefined", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const n1 = "a",
     n2 = "b",
     n3 = "c",
@@ -406,7 +406,7 @@ describe("Testing each that maps to undefined", () => {
 });
 
 describe("Testing each with indexes", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const n1 = "a",
     n2 = "b",
     n3 = "c",

--- a/packages/solid/web/test/index.spec.tsx
+++ b/packages/solid/web/test/index.spec.tsx
@@ -7,7 +7,7 @@ import { createRoot, createSignal } from "../../src/index.js";
 import { insert, Index } from "../src/index.js";
 
 describe("Testing an only child each control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const n1 = "a",
     n2 = "b",
     n3 = "c",
@@ -173,7 +173,7 @@ describe("Testing an multi child each control flow", () => {
 });
 
 describe("Testing an only child each control flow with fragment children", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const n1 = "a",
     n2 = "b",
     n3 = "c",
@@ -264,7 +264,7 @@ describe("Testing an only child each control flow with fragment children", () =>
 });
 
 describe("Testing an only child each control flow with array children", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const n1 = "a",
     n2 = "b",
     n3 = "c",
@@ -355,7 +355,7 @@ describe("Testing an only child each control flow with array children", () => {
 });
 
 describe("Testing each control flow with fallback", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const n1 = "a",
     n2 = "b",
     n3 = "c",
@@ -385,7 +385,7 @@ describe("Testing each control flow with fallback", () => {
 });
 
 describe("Testing each that maps to undefined", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const n1 = "a",
     n2 = "b",
     n3 = "c",
@@ -413,7 +413,7 @@ describe("Testing each that maps to undefined", () => {
 });
 
 describe("Testing each with indexes", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const n1 = "a",
     n2 = "b",
     n3 = "c",

--- a/packages/solid/web/test/portal.spec.tsx
+++ b/packages/solid/web/test/portal.spec.tsx
@@ -86,8 +86,8 @@ describe("Testing a Portal to the head", () => {
 describe("Testing a Portal with Synthetic Events", () => {
   let div = document.createElement("div"),
     disposer: () => void,
-    checkElem: HTMLDivElement,
-    testElem: HTMLDivElement,
+    checkElem!: HTMLDivElement,
+    testElem!: HTMLDivElement,
     clicked = false;
   const Component = () => (
     <Portal ref={checkElem}>
@@ -119,7 +119,7 @@ describe("Testing a Portal with direct reactive children", () => {
   let div = document.createElement("div"),
     disposer: () => void,
     [count, setCount] = createSignal(0),
-    portalElem: HTMLDivElement;
+    portalElem!: HTMLDivElement;
   const Component = () => <Portal ref={portalElem}>{count()}</Portal>;
 
   test("Create portal control flow", () => {

--- a/packages/solid/web/test/show.spec.tsx
+++ b/packages/solid/web/test/show.spec.tsx
@@ -7,7 +7,7 @@ import { createRoot, createSignal } from "../../src/index.js";
 import { Show } from "../src/index.js";
 
 describe("Testing an only child show control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [count, setCount] = createSignal(0);
   const Component = () => (
     <div ref={div}>
@@ -37,7 +37,7 @@ describe("Testing an only child show control flow", () => {
 });
 
 describe("Testing an only child show control flow with DOM children", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [count, setCount] = createSignal(0);
   const Component = () => (
     <div ref={div}>
@@ -70,7 +70,7 @@ describe("Testing an only child show control flow with DOM children", () => {
 });
 
 describe("Testing nonkeyed show control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [count, setCount] = createSignal(0);
   let executed = 0;
   const Component = () => (
@@ -108,7 +108,7 @@ describe("Testing nonkeyed show control flow", () => {
 });
 
 describe("Testing keyed show control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [count, setCount] = createSignal(0);
   let executed = 0;
   const Component = () => (
@@ -146,7 +146,7 @@ describe("Testing keyed show control flow", () => {
 });
 
 describe("Testing nonkeyed function show control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [count, setCount] = createSignal(0);
   let executed = 0;
   const Component = () => (
@@ -188,7 +188,7 @@ describe("Testing nonkeyed function show control flow", () => {
 });
 
 describe("Testing keyed function show control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [count, setCount] = createSignal(0);
   let executed = 0;
   const Component = () => (
@@ -230,7 +230,7 @@ describe("Testing keyed function show control flow", () => {
 });
 
 describe("Testing an only child show control flow with keyed function", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [data, setData] = createSignal<{ count: number }>();
   const Component = () => (
     <div ref={div}>
@@ -267,7 +267,7 @@ describe("Testing an only child show control flow with keyed function", () => {
 });
 
 describe("Testing an only child show control flow with non-keyed function", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [data, setData] = createSignal<{ count: number }>();
   const Component = () => (
     <div ref={div}>
@@ -304,7 +304,7 @@ describe("Testing an only child show control flow with non-keyed function", () =
 });
 
 describe("Testing an only child show control flow with DOM children and fallback", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [count, setCount] = createSignal(0);
   const Component = () => (
     <div ref={div}>

--- a/packages/solid/web/test/switch.spec.tsx
+++ b/packages/solid/web/test/switch.spec.tsx
@@ -8,7 +8,7 @@ import { createRoot, createSignal } from "../../src/index.js";
 import { createStore } from "../../store/src/index.js";
 
 describe("Testing a single match switch control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [count, setCount] = createSignal(0);
   const Component = () => (
     <div ref={div}>
@@ -38,7 +38,7 @@ describe("Testing a single match switch control flow", () => {
 });
 
 describe("Testing an only child Switch control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [count, setCount] = createSignal(0);
   const Component = () => (
     <div ref={div}>
@@ -83,7 +83,7 @@ describe("Testing an only child Switch control flow", () => {
 });
 
 describe("Testing keyed Switch control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [a, setA] = createSignal(0),
     [b, setB] = createSignal(0),
     [c, setC] = createSignal(0);
@@ -127,7 +127,7 @@ describe("Testing keyed Switch control flow", () => {
 });
 
 describe("Testing keyed function handler Switch control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [a, setA] = createSignal(0),
     [b, setB] = createSignal(0),
     [c, setC] = createSignal(0);
@@ -171,7 +171,7 @@ describe("Testing keyed function handler Switch control flow", () => {
 });
 
 describe("Testing non-keyed function handler Switch control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [a, setA] = createSignal(0),
     [b, setB] = createSignal(0),
     [c, setC] = createSignal(0);
@@ -209,7 +209,7 @@ describe("Testing non-keyed function handler Switch control flow", () => {
 });
 
 describe("Testing non-keyed function handler Switch control flow with dangling callback", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [a, setA] = createSignal(0),
     [b] = createSignal(2);
   let callback: () => void;
@@ -251,7 +251,7 @@ describe("Testing non-keyed function handler Switch control flow with dangling c
 });
 
 describe("Testing a For in a Switch control flow", () => {
-  let div: HTMLDivElement, disposer: () => void;
+  let div!: HTMLDivElement, disposer: () => void;
   const [state, setState] = createStore({
     users: [
       { firstName: "Jerry", certified: false },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,11 +105,11 @@ importers:
         specifier: ^1.3.1
         version: 1.13.4
       typescript:
-        specifier: ~5.5.2
-        version: 5.5.4
+        specifier: ~5.7.2
+        version: 5.7.2
       vite-plugin-solid:
         specifier: ^2.6.1
-        version: 2.10.2(solid-js@1.9.2)(vite@5.4.8(@types/node@22.7.5))
+        version: 2.10.2(solid-js@1.9.3)(vite@5.4.8(@types/node@22.7.5))
       vitest:
         specifier: ^2.1.2
         version: 2.1.2(@types/node@22.7.5)(jsdom@25.0.1)
@@ -2767,8 +2767,8 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  solid-js@1.9.2:
-    resolution: {integrity: sha512-fe/K03nV+kMFJYhAOE8AIQHcGxB4rMIEoEyrulbtmf217NffbbwBqJnJI4ovt16e+kaIt0czE2WA7mP/pYN9yg==}
+  solid-js@1.9.3:
+    resolution: {integrity: sha512-5ba3taPoZGt9GY3YlsCB24kCg0Lv/rie/HTD4kG6h4daZZz7+yK02xn8Vx8dLYBc9i6Ps5JwAbEiqjmKaLB3Ag==}
 
   solid-refresh@0.6.3:
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
@@ -3000,8 +3000,8 @@ packages:
     resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
     engines: {node: '>= 0.4'}
 
-  typescript@5.5.4:
-    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+  typescript@5.7.2:
+    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -6217,18 +6217,18 @@ snapshots:
 
   slash@3.0.0: {}
 
-  solid-js@1.9.2:
+  solid-js@1.9.3:
     dependencies:
       csstype: 3.1.3
       seroval: 1.1.1
       seroval-plugins: 1.1.1(seroval@1.1.1)
 
-  solid-refresh@0.6.3(solid-js@1.9.2):
+  solid-refresh@0.6.3(solid-js@1.9.3):
     dependencies:
       '@babel/generator': 7.25.7
       '@babel/helper-module-imports': 7.25.7
       '@babel/types': 7.25.7
-      solid-js: 1.9.2
+      solid-js: 1.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6474,7 +6474,7 @@ snapshots:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
 
-  typescript@5.5.4: {}
+  typescript@5.7.2: {}
 
   unbox-primitive@1.0.2:
     dependencies:
@@ -6548,14 +6548,14 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-solid@2.10.2(solid-js@1.9.2)(vite@5.4.8(@types/node@22.7.5)):
+  vite-plugin-solid@2.10.2(solid-js@1.9.3)(vite@5.4.8(@types/node@22.7.5)):
     dependencies:
       '@babel/core': 7.25.7
       '@types/babel__core': 7.20.5
       babel-preset-solid: link:packages/babel-preset-solid
       merge-anything: 5.1.7
-      solid-js: 1.9.2
-      solid-refresh: 0.6.3(solid-js@1.9.2)
+      solid-js: 1.9.3
+      solid-refresh: 0.6.3(solid-js@1.9.3)
       vite: 5.4.8(@types/node@22.7.5)
       vitefu: 0.2.5(vite@5.4.8(@types/node@22.7.5))
     transitivePeerDependencies:


### PR DESCRIPTION
Since version 5.7 typescript doesn't like comparing strings for truthiness

![image](https://github.com/user-attachments/assets/f5c51b49-afcc-417e-a293-7b6f0fa9e41a)

And inlining `"_SOLID_DEV_" as any as boolean` doesn't seem to do the trick.

So I've added a constant and use it in place of strings which silences the errors.
```ts
const IS_DEV = "_SOLID_DEV_" as string | boolean
```

The output looks almost identical to using strings directly - most code paths behind a dev check get removed in prod entries. Some uncleaned if statements remain, but as they did with strings before.
```js
const IS_DEV = false;
// ...
if (IS_DEV); // the block gets removed but if remains
else {
	// ...
}
```

The variable is not exported outside of the module, just internally between files to not redeclare it in every file.

Other option would be to use `@ts-expect-error` everywhere but that just seem a bit noisy.

---

Also had to add some additional assertions `!` to variable declarations for refs, as they are "being used before assigned" from ts point of view.