### PR TITLE
dev: Add `internal` flag to signal

### DIFF
--- a/.changeset/eighty-parents-scream.md
+++ b/.changeset/eighty-parents-scream.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+dev: Add `internal` flag to signal

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -82,6 +82,8 @@ export interface SignalState<T> extends SourceMapValue {
   observerSlots: number[] | null;
   tValue?: T;
   comparator?: (prev: T, next: T) => boolean;
+  // development-only
+  internal?: true;
 }
 
 export interface Owner {
@@ -233,8 +235,12 @@ export function createSignal<T>(
 
   if ("_SOLID_DEV_") {
     if (options.name) s.name = options.name;
-    if (DevHooks.afterCreateSignal) DevHooks.afterCreateSignal(s);
-    if (!options.internal) registerGraph(s);
+    if (options.internal) {
+      s.internal = true;
+    } else {
+      registerGraph(s);
+      if (DevHooks.afterCreateSignal) DevHooks.afterCreateSignal(s);
+    }
   }
 
   const setter: Setter<T | undefined> = (value?: unknown) => {


### PR DESCRIPTION
Currently there is no way to tell if a signal is internal from within `afterCreateSignal` or being referenced as a source.