### PR TITLE
dev: Add afterRegisterGraph hook replacing afterCreateSignal

### DIFF
--- a/.changeset/wise-crabs-destroy.md
+++ b/.changeset/wise-crabs-destroy.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+dev: Add afterRegisterGraph hook replacing afterCreateSignal

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -61,11 +61,14 @@ let ExecCount = 0;
 export const DevHooks: {
   afterUpdate: (() => void) | null;
   afterCreateOwner: ((owner: Owner) => void) | null;
+  /** @deprecated use `afterRegisterGraph` */
   afterCreateSignal: ((signal: SignalState<any>) => void) | null;
+  afterRegisterGraph: ((sourceMapValue: SourceMapValue) => void) | null;
 } = {
   afterUpdate: null,
   afterCreateOwner: null,
-  afterCreateSignal: null
+  afterCreateSignal: null,
+  afterRegisterGraph: null,
 };
 
 export type ComputationState = 0 | 1 | 2;
@@ -1131,10 +1134,12 @@ export function devComponent<P, V>(Comp: (props: P) => V, props: P): V {
 }
 
 export function registerGraph(value: SourceMapValue): void {
-  if (!Owner) return;
-  if (Owner.sourceMap) Owner.sourceMap.push(value);
-  else Owner.sourceMap = [value];
-  value.graph = Owner;
+  if (Owner) {
+    if (Owner.sourceMap) Owner.sourceMap.push(value);
+    else Owner.sourceMap = [value];
+    value.graph = Owner;
+  }
+  if (DevHooks.afterRegisterGraph) DevHooks.afterRegisterGraph(value)
 }
 
 export type ContextProviderComponent<T> = FlowComponent<{ value: T }>;

--- a/packages/solid/test/dev.spec.ts
+++ b/packages/solid/test/dev.spec.ts
@@ -130,23 +130,31 @@ describe("Dev features", () => {
     });
   });
 
-  test("afterCreateSignal Hook", () => {
+  test("afterRegisterGraph Hook", () => {
     createRoot(() => {
       const owner = getOwner()!;
       const cb = vi.fn();
-      DEV!.hooks.afterCreateSignal = cb;
+      DEV!.hooks.afterRegisterGraph = cb;
 
-      createSignal(3, { name: "test" });
+      createSignal(1);
       expect(cb).toHaveBeenCalledTimes(1);
       expect(cb).toHaveBeenLastCalledWith(owner.sourceMap![0]);
+      expect(owner.sourceMap).toHaveLength(1);
 
-      createSignal(5);
+      createSignal(2, { internal: true });
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(owner.sourceMap).toHaveLength(1);
+
+      createStore({});
       expect(cb).toHaveBeenCalledTimes(2);
       expect(cb).toHaveBeenLastCalledWith(owner.sourceMap![1]);
+      expect(owner.sourceMap).toHaveLength(2);
 
-      createSignal(6, { name: "explicit" });
+      const customValue = {value: 3};
+      DEV!.registerGraph(customValue);
       expect(cb).toHaveBeenCalledTimes(3);
-      expect(cb).toHaveBeenLastCalledWith(owner.sourceMap![2]);
+      expect(cb).toHaveBeenLastCalledWith(customValue);
+      expect(owner.sourceMap).toHaveLength(3);
     });
   });
 


### PR DESCRIPTION
A `afterRegisterGraph` hook allows for both signals, stores and any other custom value registered with `DEV.registerGraph` to be captured by the devtools when they are created, and even if created outside of a reactive graph - unowned.
This also makes the `afterCreateSignal` hook, that I added before, pointless so I deprecated it. My bad for not thinking about this before.