### PR TITLE
Fix pnpm corepack version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,5 @@
   "engines": {
     "pnpm": ">=8.6.1"
   },
-  "packageManager": "pnpm@8.6.1"
+  "packageManager": "pnpm@10.0.0+sha512.b8fef5494bd3fe4cbd4edabd0745df2ee5be3e4b0b8b08fa643aa3e4c6702ccc0f00d68fa8a8c9858a735a0032485a44990ed2810526c875e416f001b17df12b"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,7 +178,14 @@ importers:
 
   packages/solid-universal: {}
 
-  packages/solid-web: {}
+  packages/solid-web:
+    dependencies:
+      seroval:
+        specifier: ^1.1.0
+        version: 1.1.1
+      seroval-plugins:
+        specifier: ^1.1.0
+        version: 1.1.1(seroval@1.1.1)
 
   packages/test-integration:
     dependencies:


### PR DESCRIPTION
When trying to clone and set up the solid repo (on `next` branch), I realized the corepack version of pnpm (`packageManager` field in `package.json`) was set to v8. When running `pnpm i`, it seems to ignore the lockfile (says it's broken), probably because the lockfile version (9) is incompatible with pnpm v8.

To remediate this, I upgraded the corepack version to latest (v10) and re-ran `pnpm i`, which seems to add some minor changes to the lockfile itself.

Feel free to replicate this process to verify the contents of this PR. From the `next` branch:

```sh
corepack use pnpm # to upgrade pnpm
pnpm i # to update lockfile
```