### PR TITLE
add optional initalValue argument to `from` helper

### DIFF
--- a/.changeset/dull-bikes-reply.md
+++ b/.changeset/dull-bikes-reply.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+add optional initalValue argument to `from` helper

--- a/packages/solid/src/reactive/observable.ts
+++ b/packages/solid/src/reactive/observable.ts
@@ -84,18 +84,20 @@ export function observable<T>(input: Accessor<T>): Observable<T> {
   };
 }
 
-export function from<T>(
-  producer:
-    | ((setter: Setter<T | undefined>) => () => void)
-    | { subscribe: (fn: (v: T) => void) => (() => void) | { unsubscribe: () => void } }
-): Accessor<T | undefined> {
-  const [s, set] = createSignal<T | undefined>(undefined, { equals: false });
-  if ("subscribe" in producer) {
-    const unsub = producer.subscribe(v => set(() => v));
-    onCleanup(() => ("unsubscribe" in unsub ? unsub.unsubscribe() : unsub()));
-  } else {
-    const clean = producer(set);
-    onCleanup(clean);
-  }
-  return s;
+type Producer<T> =
+    | ((setter: Setter<T>) => () => void)
+    | { subscribe: (fn: (v: T) => void) => (() => void) | { unsubscribe: () => void } };
+
+export function from<T>(producer: Producer<T>, initalValue: T): Accessor<T>;
+export function from<T>(producer: Producer<T|undefined>): Accessor<T|undefined>;
+export function from<T>(producer: Producer<T|undefined>, initalValue: T|undefined = undefined): Accessor<T | undefined> {
+    const [s, set] = createSignal<T | undefined>(initalValue, { equals: false });
+    if ("subscribe" in producer) {
+        const unsub = producer.subscribe(v => set(() => v));
+        onCleanup(() => ("unsubscribe" in unsub ? unsub.unsubscribe() : unsub()));
+    } else {
+        const clean = producer(set);
+        onCleanup(clean);
+    }
+    return s;
 }


### PR DESCRIPTION
I just discovered the from helper and immediately went and used it to change my own helper I had made to create a clock and then discovered that the `Accessor` that it returned was always `T | undefined`. I then went to the source code of `from` and found out that the underlying signal was initialized with undefined. 

So this PR aims to add an optional `initalValue` argument so that the return value can be `Accessor<T>` if you would prefer that