### PR TITLE
dev: add warning when context is undefined

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1201,9 +1201,11 @@ export function createContext<T>(
  */
 export function useContext<T>(context: Context<T>): T {
   let value: undefined | T;
-  return Owner && Owner.context && (value = Owner.context[context.id]) !== undefined
-    ? value
-    : context.defaultValue;
+	let ctx = Owner && Owner.context && (value = Owner.context[context.id]) !== undefined
+	? value
+	: context.defaultValue;
+	IS_DEV && !ctx && console.warn("`useContext` returns null. Is it being called inside a provider?")
+  return ctx;
 }
 
 export type ResolvedJSXElement = Exclude<JSX.Element, JSX.ArrayElement>;

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1204,7 +1204,7 @@ export function useContext<T>(context: Context<T>): T {
 	let ctx = Owner && Owner.context && (value = Owner.context[context.id]) !== undefined
 	? value
 	: context.defaultValue;
-	IS_DEV && !ctx && console.warn("`useContext` returns null. Is it being called inside a provider?")
+	IS_DEV && !ctx && console.warn("`useContext` is returning undefined. Is it being called inside a provider?")
   return ctx;
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

Using `useContext` outside of a provider can cause unforeseen and cryptic errors. This PR adds a warning (in dev) when the result of `useContext` is falsy.

See https://discord.com/channels/722131463138705510/1358899310116213008

Typescript does protect against using an undefined context somewhat, but I thought a warning could be nice, especially for new users.

## How did you test this change?

Created a project and consumed a context without being in its provider:
![image](https://github.com/user-attachments/assets/db90ee5c-35ba-4994-aa07-ea246e95996d)

Warning is printed to the console.

After the project has been built, the warning is not logged.
