### PR TITLE
Fix seroval 1.3.0 compat

### DIFF
--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -237,7 +237,7 @@
   ],
   "dependencies": {
     "csstype": "^3.1.0",
-    "seroval": "^1.1.0",
-    "seroval-plugins": "^1.1.0"
+    "seroval": "^1.3.0",
+    "seroval-plugins": "^1.3.0"
   }
 }

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -709,9 +709,9 @@ export function createResource<T, S, R>(
       return p;
     }
     pr = p;
-    if ("value" in p) {
-      if ((p as any).status === "success") loadEnd(pr, p.value as T, undefined, lookup);
-      else loadEnd(pr, undefined, castError(p.value), lookup);
+    if ("v" in p) {
+      if ((p as any).s === 1) loadEnd(pr, p.v as T, undefined, lookup);
+      else loadEnd(pr, undefined, castError(p.v), lookup);
       return p;
     }
     scheduled = true;

--- a/packages/solid/src/render/Suspense.ts
+++ b/packages/solid/src/render/Suspense.ts
@@ -145,7 +145,7 @@ export function Suspense(props: { fallback?: JSX.Element; children: JSX.Element 
     const key = sharedConfig.getContextId();
     let ref = sharedConfig.load(key);
     if (ref) {
-      if (typeof ref !== "object" || ref.status !== "success") p = ref;
+      if (typeof ref !== "object" || ref.s !== 1) p = ref;
       else sharedConfig.gather!(key);
     }
     if (p && p !== "$$f") {


### PR DESCRIPTION

> [!CAUTION]
> I haven't updated the lockfile because Solid is currently locked to PNPM 9, I'm using PNPM 10.

This PR fixes a potential incompatibility with Seroval 1.3.0 (latest release) which reworks the serialized status/value of a serialized Promise. The change was imminent because it made Seroval incompatible for use in the React ecosystem (due to React's internal suspense mechanism which relies coincidentally with the `status` property)