### PR TITLE
fix: catch synchronous error

### DIFF
--- a/.changeset/chilled-buttons-hammer.md
+++ b/.changeset/chilled-buttons-hammer.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Catch synchronous errors in `createResource`.

--- a/packages/solid/test/resource.spec.ts
+++ b/packages/solid/test/resource.spec.ts
@@ -211,6 +211,29 @@ describe("using Resource with errors", () => {
   });
 });
 
+describe("using Resource with synchronous error", () => {
+  let value: Resource<number | undefined>;
+  let error: Error;
+  test("catches the error", async () => {
+    createRoot(() => {
+      catchError(
+        () => {
+          [value] = createResource(() => {
+            throw new Error("Fetcher error");
+          });
+          createRenderEffect(value);
+        },
+        e => {
+          error = e;
+        }
+      );
+    });
+    expect(value.state === "errored").toBe(true);
+    expect(value.error).toBe(error);
+    expect(value.error.message).toBe("Fetcher error");
+  });
+});
+
 describe("using Resource with custom store", () => {
   type User = {
     firstName: string;


### PR DESCRIPTION
## Summary

Synchronous (non-promise) errors cannot be caught by `ErrorBoundary`.

https://playground.solidjs.com/anonymous/98e1258d-67c8-4c53-b9cb-4bfa029d451e

```ts
import { render } from "solid-js/web";
import { ErrorBoundary, createResource } from "solid-js";

function Counter() {
  const [res] = createResource(() => {
    if (1) throw new Error(); // this error is not captured by ErrorBoundary
    return 1;
  });

  return (
    <ErrorBoundary fallback={(error) => <>{error.toString()}</>}>
      {res()}
    </ErrorBoundary>
  );
}

render(() => <Counter />, document.getElementById("app")!);
```

Using an async function as fetcher it works:

https://playground.solidjs.com/anonymous/0e5e5348-57ef-41b3-aebf-66f8567122c8

## How did you test this change?

An unit test was added to the commit.