### PR TITLE
Fix `For` component `keyed` prop type

### DIFF
--- a/packages/solid/src/client/flow.ts
+++ b/packages/solid/src/client/flow.ts
@@ -30,7 +30,7 @@ const narrowedError = (name: string) =>
 export function For<T extends readonly any[], U extends JSX.Element>(props: {
   each: T | undefined | null | false;
   fallback?: JSX.Element;
-  keyed?: boolean | ((item: T) => any);
+  keyed?: boolean | ((item: T[number]) => any);
   children: (item: Accessor<T[number]>, index: Accessor<number>) => U;
 }) {
   const options =


### PR DESCRIPTION
## Summary

looks like there was a small type error and because of that in the <For /> component inside the keyed prop we were getting the array instead of the array element

## How did you test this change?

current `mapArray` function types:
```ts
export declare function mapArray<Item, MappedItem>(list: Accessor<Maybe<readonly Item[]>>, map: (value: Accessor<Item>, index: Accessor<number>) => MappedItem, options?: {
    keyed?: boolean | ((item: Item) => any);
    fallback?: Accessor<any>;
}): Accessor<MappedItem[]>;
```

current `For` types:
```tsx
export declare function For<T extends readonly any[], U extends JSX.Element>(props: {
    each: T | undefined | null | false;
    fallback?: JSX.Element;
    keyed?: boolean | ((item: T) => any);
    children: (item: Accessor<T[number]>, index: Accessor<number>) => U;
}): JSX.Element;
```

**fixed** `For` types:
```tsx
export declare function For<T extends readonly any[], U extends JSX.Element>(props: {
    each: T | undefined | null | false;
    fallback?: JSX.Element;
    keyed?: boolean | ((item: T[number]) => any);
    children: (item: Accessor<T[number]>, index: Accessor<number>) => U;
}): JSX.Element;
```

notice that keyed has `(item: T[number]) => any` instead of `(item: T) => any`