### PR TITLE
improve `<Portal/>` container, add 2 new properties

### DIFF
--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -63,6 +63,8 @@ export function Portal<T extends boolean = false, S extends boolean = false>(pro
         el: (T extends true ? { readonly shadowRoot: ShadowRoot } : {}) &
           (S extends true ? SVGGElement : HTMLDivElement)
       ) => void);
+  asElement?: keyof HTMLElementTagNameMap;
+  class?: string[];
   children: JSX.Element;
 }) {
   const { useShadow } = props,
@@ -84,11 +86,13 @@ export function Portal<T extends boolean = false, S extends boolean = false>(pro
         createRoot(dispose => insert(el, () => (!clean() ? content!() : dispose()), null));
         onCleanup(cleanup);
       } else {
-        const container = createElement(props.isSVG ? "g" : "div", props.isSVG),
-          renderRoot =
-            useShadow && container.attachShadow
-              ? container.attachShadow({ mode: "open" })
-              : container;
+        const container = createElement(props.isSVG ? "g" : props.asElement || "div", props.isSVG);
+        props.class && container.classList.add(...props.class.flatMap(str => str.split(" ")));
+
+        const renderRoot =
+          useShadow && container.attachShadow
+            ? container.attachShadow({ mode: "open" })
+            : container;
 
         Object.defineProperty(container, "_$host", {
           get() {

--- a/packages/solid/web/test/portal.spec.tsx
+++ b/packages/solid/web/test/portal.spec.tsx
@@ -25,6 +25,56 @@ describe("Testing a simple Portal", () => {
   });
 });
 
+describe("Testing an Portal custom container", () => {
+  let div = document.createElement("div"),
+    disposer: () => void;
+  const testMount = document.createElement("div");
+  const Component = () => (
+    <Portal mount={testMount} asElement="section">
+      Hi
+    </Portal>
+  );
+
+  test("Create portal control flow", () => {
+    disposer = render(Component, div);
+    expect(div.innerHTML).toBe("");
+    const container = testMount.firstChild as HTMLElement & { _$host: HTMLElement };
+    expect(container.tagName).toBe("SECTION");
+    expect(container.innerHTML).toBe("Hi");
+    expect(container._$host).toBe(div);
+  });
+
+  test("dispose", () => {
+    disposer();
+    expect(div.innerHTML).toBe("");
+  });
+});
+
+describe('Testing Portal "class" property', () => {
+  let div = document.createElement("div"),
+    disposer: () => void;
+  const testMount = document.createElement("div");
+  const Component = () => (
+    <Portal mount={testMount} class={["flex flex-col", "text-gold bg-red"]}>
+      ★
+    </Portal>
+  );
+
+  test("Create portal control flow", () => {
+    disposer = render(Component, div);
+    expect(div.innerHTML).toBe("");
+    const container = testMount.firstChild as HTMLElement & { _$host: HTMLElement };
+    expect(container.classList.toString()).toBe("flex flex-col text-gold bg-red");
+    expect(container.innerHTML).toBe("★");
+    expect(container._$host).toBe(div);
+  });
+
+  test("dispose", () => {
+    disposer();
+    expect(div.innerHTML).toBe("");
+  });
+});
+
 describe("Testing an SVG Portal", () => {
   let div = document.createElement("div"),
     disposer: () => void;


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

I don't know what is "three mandatory fields" since I only saw 2 headings. But I filled all of them.

## Summary

```git
improve `<Portal/>` container, add 2 new properties

- `asElement` allows to change Portal container element type
- `class` allows to set class for Portal container
```

Bascially, I don't like a bare `<div/>` wrap children component so I would like to suggest make Portal `container` be more customisable with tagName and class. We can find a way to support dataset later if it requires.

## How did you test this change?

I've update test file and run test script from `package.json`s:

1. `/` → `pnpm test`
2. `cd ./packages/solid` → `pnpm test`

Both of them return all pass results so I assume there is nothing would break the framework. As for testing on real field, I'm not sure how to do that yet.