### PR TITLE
migrate to biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
+  "vcs": {
+    "enabled": false,
+    "clientKind": "git",
+    "useIgnoreFile": false
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "includes": ["**/*.{js,jsx,ts,tsx}"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "arrowParentheses": "asNeeded",
+      "semicolons": "always",
+      "trailingCommas": "none"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,72 +1,72 @@
 {
-  "name": "solid-js",
-  "description": "A declarative JavaScript library for building user interfaces.",
-  "version": "1.0.0",
-  "author": "Ryan Carniato",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/solidjs/solid"
-  },
-  "private": true,
-  "scripts": {
-    "preinstall": "npx only-allow pnpm",
-    "postinstall": "simple-git-hooks",
-    "test": "turbo run test test-types",
-    "coverage": "turbo run coverage",
-    "build": "turbo run build",
-    "types": "turbo run types",
-    "publish": "pnpm run build && pnpm run types && pnpm run release:only",
-    "bump": "changeset add",
-    "release:only": "changeset publish",
-    "format": "prettier --write --cache \"**/*.[tj]s?(x)\""
-  },
-  "devDependencies": {
-    "@babel/cli": "^7.18.9",
-    "@babel/core": "^7.20.12",
-    "@babel/preset-env": "^7.18.9",
-    "@babel/preset-typescript": "^7.18.6",
-    "@changesets/cli": "^2.25.2",
-    "@rollup/plugin-babel": "^6.0.3",
-    "@rollup/plugin-commonjs": "^24.0.0",
-    "@rollup/plugin-json": "^6.0.0",
-    "@rollup/plugin-node-resolve": "^15.0.1",
-    "@rollup/plugin-replace": "^5.0.2",
-    "@types/node": "^22.7.5",
-    "@vitest/coverage-v8": "^2.1.2",
-    "babel-plugin-jsx-dom-expressions": "^0.39.8",
-    "coveralls": "^3.1.1",
-    "csstype": "^3.1.0",
-    "dom-expressions": "0.39.10",
-    "hyper-dom-expressions": "0.39.10",
-    "jsdom": "^25.0.1",
-    "lit-dom-expressions": "0.39.10",
-    "ncp": "^2.0.0",
-    "npm-run-all": "^4.1.5",
-    "prettier": "^2.8.8",
-    "rimraf": "^3.0.2",
-    "rollup": "^4.24.0",
-    "rollup-plugin-cleanup": "^3.2.1",
-    "rollup-plugin-copy": "^3.4.0",
-    "seroval": "^1.1.0",
-    "simple-git-hooks": "^2.8.1",
-    "symlink-dir": "^5.0.1",
-    "tsconfig-replace-paths": "^0.0.11",
-    "turbo": "^1.3.1",
-    "typescript": "~5.7.2",
-    "vite-plugin-solid": "^2.6.1",
-    "vitest": "^2.1.2"
-  },
-  "simple-git-hooks": {
-    "pre-commit": "pnpm run format"
-  },
-  "pnpm": {
-    "overrides": {
-      "babel-preset-solid": "workspace:*"
-    }
-  },
-  "engines": {
-    "pnpm": "^9.15.0"
-  },
-  "packageManager": "pnpm@9.15.0"
+	"name": "solid-js",
+	"description": "A declarative JavaScript library for building user interfaces.",
+	"version": "1.0.0",
+	"author": "Ryan Carniato",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/solidjs/solid"
+	},
+	"private": true,
+	"scripts": {
+		"preinstall": "npx only-allow pnpm",
+		"postinstall": "simple-git-hooks",
+		"test": "turbo run test test-types",
+		"coverage": "turbo run coverage",
+		"build": "turbo run build",
+		"types": "turbo run types",
+		"publish": "pnpm run build && pnpm run types && pnpm run release:only",
+		"bump": "changeset add",
+		"release:only": "changeset publish",
+		"format": "biome format --write"
+	},
+	"devDependencies": {
+		"@babel/cli": "^7.18.9",
+		"@babel/core": "^7.20.12",
+		"@babel/preset-env": "^7.18.9",
+		"@babel/preset-typescript": "^7.18.6",
+		"@biomejs/biome": "2.0.6",
+		"@changesets/cli": "^2.25.2",
+		"@rollup/plugin-babel": "^6.0.3",
+		"@rollup/plugin-commonjs": "^24.0.0",
+		"@rollup/plugin-json": "^6.0.0",
+		"@rollup/plugin-node-resolve": "^15.0.1",
+		"@rollup/plugin-replace": "^5.0.2",
+		"@types/node": "^22.7.5",
+		"@vitest/coverage-v8": "^2.1.2",
+		"babel-plugin-jsx-dom-expressions": "^0.39.8",
+		"coveralls": "^3.1.1",
+		"csstype": "^3.1.0",
+		"dom-expressions": "0.39.10",
+		"hyper-dom-expressions": "0.39.10",
+		"jsdom": "^25.0.1",
+		"lit-dom-expressions": "0.39.10",
+		"ncp": "^2.0.0",
+		"npm-run-all": "^4.1.5",
+		"rimraf": "^3.0.2",
+		"rollup": "^4.24.0",
+		"rollup-plugin-cleanup": "^3.2.1",
+		"rollup-plugin-copy": "^3.4.0",
+		"seroval": "^1.1.0",
+		"simple-git-hooks": "^2.8.1",
+		"symlink-dir": "^5.0.1",
+		"tsconfig-replace-paths": "^0.0.11",
+		"turbo": "^1.3.1",
+		"typescript": "~5.7.2",
+		"vite-plugin-solid": "^2.6.1",
+		"vitest": "^2.1.2"
+	},
+	"simple-git-hooks": {
+		"pre-commit": "pnpm run format"
+	},
+	"pnpm": {
+		"overrides": {
+			"babel-preset-solid": "workspace:*"
+		}
+	},
+	"engines": {
+		"pnpm": "^9.15.0"
+	},
+	"packageManager": "pnpm@9.15.0"
 }

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -909,8 +909,8 @@ export function untrack<T>(fn: Accessor<T>): T {
 export type ReturnTypes<T> = T extends readonly Accessor<unknown>[]
   ? { [K in keyof T]: T[K] extends Accessor<infer I> ? I : never }
   : T extends Accessor<infer I>
-  ? I
-  : never;
+    ? I
+    : never;
 
 // transforms a tuple to a tuple of accessors in a way that allows generics to be inferred
 export type AccessorArray<T> = [...Extract<{ [K in keyof T]: Accessor<T[K]> }, readonly unknown[]>];

--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -82,8 +82,8 @@ export type ValidComponent = keyof JSX.IntrinsicElements | Component<any> | (str
 export type ComponentProps<T extends ValidComponent> = T extends Component<infer P>
   ? P
   : T extends keyof JSX.IntrinsicElements
-  ? JSX.IntrinsicElements[T]
-  : Record<string, unknown>;
+    ? JSX.IntrinsicElements[T]
+    : Record<string, unknown>;
 
 /**
  * Type of `props.ref`, for use in `Component` or `props` typing.
@@ -163,8 +163,8 @@ type OverrideSpread<T, U> = T extends any
       })]: K extends keyof T
         ? Exclude<U extends any ? U[K & keyof U] : never, undefined> | T[K]
         : U extends any
-        ? U[K & keyof U]
-        : never;
+          ? U[K & keyof U]
+          : never;
     }
   : T & U;
 type Simplify<T> = T extends any ? { [K in keyof T]: T[K] } : T;
@@ -174,12 +174,12 @@ type _MergeProps<T extends unknown[], Curr = {}> = T extends [
 ]
   ? _MergeProps<Rest, Override<Curr, Next>>
   : T extends [...infer Rest, infer Next | (() => infer Next)]
-  ? Override<_MergeProps<Rest, Curr>, Next>
-  : T extends []
-  ? Curr
-  : T extends (infer I | (() => infer I))[]
-  ? OverrideSpread<Curr, I>
-  : Curr;
+    ? Override<_MergeProps<Rest, Curr>, Next>
+    : T extends []
+      ? Curr
+      : T extends (infer I | (() => infer I))[]
+        ? OverrideSpread<Curr, I>
+        : Curr;
 
 export type MergeProps<T extends unknown[]> = Simplify<_MergeProps<T>>;
 
@@ -250,8 +250,8 @@ export function mergeProps<T extends unknown[]>(...sources: T): MergeProps<T> {
               get: resolveSources.bind((sourcesMap[key] = [desc.get.bind(source)]))
             }
           : desc.value !== undefined
-          ? desc
-          : undefined;
+            ? desc
+            : undefined;
       } else {
         const sources = sourcesMap[key];
         if (sources) {

--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -26,8 +26,8 @@ export type ValidComponent = keyof JSX.IntrinsicElements | Component<any> | (str
 export type ComponentProps<T extends ValidComponent> = T extends Component<infer P>
   ? P
   : T extends keyof JSX.IntrinsicElements
-  ? JSX.IntrinsicElements[T]
-  : Record<string, unknown>;
+    ? JSX.IntrinsicElements[T]
+    : Record<string, unknown>;
 
 // these methods are duplicates from solid-js/web
 // we need a better solution for this in the future

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -316,18 +316,18 @@ export function updatePath(current: StoreNode, path: any[], traversed: PropertyK
 export type DeepReadonly<T> = 0 extends 1 & T
   ? T
   : T extends NotWrappable
-  ? T
-  : {
-      readonly [K in keyof T]: DeepReadonly<T[K]>;
-    };
+    ? T
+    : {
+        readonly [K in keyof T]: DeepReadonly<T[K]>;
+      };
 /** @deprecated */
 export type DeepMutable<T> = 0 extends 1 & T
   ? T
   : T extends NotWrappable
-  ? T
-  : {
-      -readonly [K in keyof T]: DeepMutable<T[K]>;
-    };
+    ? T
+    : {
+        -readonly [K in keyof T]: DeepMutable<T[K]>;
+      };
 
 export type CustomPartial<T> = T extends readonly unknown[]
   ? "0" extends keyof T
@@ -367,11 +367,11 @@ type KeyOf<T> = number extends keyof T // have to check this otherwise ts won't 
   ? 0 extends 1 & T // if it's any just return keyof T
     ? keyof T
     : [T] extends [never]
-    ? never // keyof never is PropertyKey, which number extends. this must go before
-    : // checking [T] extends [readonly unknown[]] because never extends everything
-    [T] extends [readonly unknown[]]
-    ? number // it's an array or tuple; exclude the non-number properties
-    : keyof T // it's something which contains an index signature for strings or numbers
+      ? never // keyof never is PropertyKey, which number extends. this must go before
+      : // checking [T] extends [readonly unknown[]] because never extends everything
+        [T] extends [readonly unknown[]]
+        ? number // it's an array or tuple; exclude the non-number properties
+        : keyof T // it's something which contains an index signature for strings or numbers
   : keyof T;
 
 type MutableKeyOf<T> = KeyOf<T> & keyof PickMutable<T>;
@@ -380,10 +380,10 @@ type MutableKeyOf<T> = KeyOf<T> & keyof PickMutable<T>;
 type Rest<T, U extends PropertyKey[], K extends KeyOf<T> = KeyOf<T>> = [T] extends [never]
   ? never
   : K extends MutableKeyOf<T>
-  ? [Part<T, K>, ...RestSetterOrContinue<T[K], [K, ...U]>]
-  : K extends KeyOf<T>
-  ? [Part<T, K>, ...RestContinue<T[K], [K, ...U]>]
-  : never;
+    ? [Part<T, K>, ...RestSetterOrContinue<T[K], [K, ...U]>]
+    : K extends KeyOf<T>
+      ? [Part<T, K>, ...RestContinue<T[K], [K, ...U]>]
+      : never;
 
 type RestContinue<T, U extends PropertyKey[]> = 0 extends 1 & T
   ? [...Part<any>[], StoreSetter<any, PropertyKey[]>]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.18.6
         version: 7.26.0(@babel/core@7.26.0)
+      '@biomejs/biome':
+        specifier: 2.0.6
+        version: 2.0.6
       '@changesets/cli':
         specifier: ^2.25.2
         version: 2.27.11
@@ -74,9 +77,6 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
-      prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -109,7 +109,7 @@ importers:
         version: 5.7.3
       vite-plugin-solid:
         specifier: ^2.6.1
-        version: 2.11.0(solid-js@1.9.6)(vite@5.4.14(@types/node@22.10.7))
+        version: 2.11.0(solid-js@1.9.7)(vite@5.4.14(@types/node@22.10.7))
       vitest:
         specifier: ^2.1.2
         version: 2.1.8(@types/node@22.10.7)(jsdom@25.0.1)
@@ -722,6 +722,59 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@biomejs/biome@2.0.6':
+    resolution: {integrity: sha512-RRP+9cdh5qwe2t0gORwXaa27oTOiQRQvrFf49x2PA1tnpsyU7FIHX4ZOFMtBC4QNtyWsN7Dqkf5EDbg4X+9iqA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.0.6':
+    resolution: {integrity: sha512-AzdiNNjNzsE6LfqWyBvcL29uWoIuZUkndu+wwlXW13EKcBHbbKjNQEZIJKYDc6IL+p7bmWGx3v9ZtcRyIoIz5A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.0.6':
+    resolution: {integrity: sha512-wJjjP4E7bO4WJmiQaLnsdXMa516dbtC6542qeRkyJg0MqMXP0fvs4gdsHhZ7p9XWTAmGIjZHFKXdsjBvKGIJJQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.0.6':
+    resolution: {integrity: sha512-CVPEMlin3bW49sBqLBg2x016Pws7eUXA27XYDFlEtponD0luYjg2zQaMJ2nOqlkKG9fqzzkamdYxHdMDc2gZFw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@2.0.6':
+    resolution: {integrity: sha512-ZSVf6TYo5rNMUHIW1tww+rs/krol7U5A1Is/yzWyHVZguuB0lBnIodqyFuwCNqG9aJGyk7xIMS8HG0qGUPz0SA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@2.0.6':
+    resolution: {integrity: sha512-mKHE/e954hR/hSnAcJSjkf4xGqZc/53Kh39HVW1EgO5iFi0JutTN07TSjEMg616julRtfSNJi0KNyxvc30Y4rQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@2.0.6':
+    resolution: {integrity: sha512-geM1MkHTV1Kh2Cs/Xzot9BOF3WBacihw6bkEmxkz4nSga8B9/hWy5BDiOG3gHDGIBa8WxT0nzsJs2f/hPqQIQw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@2.0.6':
+    resolution: {integrity: sha512-290V4oSFoKaprKE1zkYVsDfAdn0An5DowZ+GIABgjoq1ndhvNxkJcpxPsiYtT7slbVe3xmlT0ncdfOsN7KruzA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.0.6':
+    resolution: {integrity: sha512-bfM1Bce0d69Ao7pjTjUS+AWSZ02+5UHdiAP85Th8e9yV5xzw6JrHXbL5YWlcEKQ84FIZMdDc7ncuti1wd2sdbw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@changesets/apply-release-plan@7.0.7':
     resolution: {integrity: sha512-qnPOcmmmnD0MfMg9DjU1/onORFyRpDXkMMl2IJg9mECY6RnxL3wN0TCCc92b2sXt1jt8DgjAUUsZYGUGTdYIXA==}
@@ -2848,8 +2901,8 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  solid-js@1.9.6:
-    resolution: {integrity: sha512-PoasAJvLk60hRtOTe9ulvALOdLjjqxuxcGZRolBQqxOnXrBXHGzqMT4ijNhGsDAYdOgEa8ZYaAE94PSldrFSkA==}
+  solid-js@1.9.7:
+    resolution: {integrity: sha512-/saTKi8iWEM233n5OSi1YHCCuh66ZIQ7aK2hsToPe4tqGm7qAejU1SwNuTPivbWAYq7SjuHVVYxxuZQNRbICiw==}
 
   solid-refresh@0.6.3:
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
@@ -4020,6 +4073,41 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.9
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@biomejs/biome@2.0.6':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.0.6
+      '@biomejs/cli-darwin-x64': 2.0.6
+      '@biomejs/cli-linux-arm64': 2.0.6
+      '@biomejs/cli-linux-arm64-musl': 2.0.6
+      '@biomejs/cli-linux-x64': 2.0.6
+      '@biomejs/cli-linux-x64-musl': 2.0.6
+      '@biomejs/cli-win32-arm64': 2.0.6
+      '@biomejs/cli-win32-x64': 2.0.6
+
+  '@biomejs/cli-darwin-arm64@2.0.6':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.0.6':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.0.6':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.0.6':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.0.6':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.0.6':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.0.6':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.0.6':
+    optional: true
 
   '@changesets/apply-release-plan@7.0.7':
     dependencies:
@@ -6344,18 +6432,18 @@ snapshots:
 
   slash@3.0.0: {}
 
-  solid-js@1.9.6:
+  solid-js@1.9.7:
     dependencies:
       csstype: 3.1.3
       seroval: 1.3.1
       seroval-plugins: 1.3.1(seroval@1.3.1)
 
-  solid-refresh@0.6.3(solid-js@1.9.6):
+  solid-refresh@0.6.3(solid-js@1.9.7):
     dependencies:
       '@babel/generator': 7.26.5
       '@babel/helper-module-imports': 7.25.9
       '@babel/types': 7.26.5
-      solid-js: 1.9.6
+      solid-js: 1.9.7
     transitivePeerDependencies:
       - supports-color
 
@@ -6679,14 +6767,14 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-solid@2.11.0(solid-js@1.9.6)(vite@5.4.14(@types/node@22.10.7)):
+  vite-plugin-solid@2.11.0(solid-js@1.9.7)(vite@5.4.14(@types/node@22.10.7)):
     dependencies:
       '@babel/core': 7.26.0
       '@types/babel__core': 7.20.5
       babel-preset-solid: link:packages/babel-preset-solid
       merge-anything: 5.1.7
-      solid-js: 1.9.6
-      solid-refresh: 0.6.3(solid-js@1.9.6)
+      solid-js: 1.9.7
+      solid-refresh: 0.6.3(solid-js@1.9.7)
       vite: 5.4.14(@types/node@22.10.7)
       vitefu: 1.0.5(vite@5.4.14(@types/node@22.10.7))
     transitivePeerDependencies:


### PR DESCRIPTION
**Summary**
Replaced Prettier with [Biome](https://biomejs.dev/) as the code formatter and linter.
This change simplifies the toolchain by unifying formatting and linting, improves performance, and reduces dependencies.

**Changes include:**
- Removed Prettier and its config files
- Added biome.json with formatting rules equivalent to the previous Prettier config
- Updated the format script in package.json to use biome format --write 

Reformatted relevant files using Biome to ensure consistency

**Test:**
Ran pnpm format to verify Biome formatting works correctly ✅
Checked that formatting matches previous style expectations ✅
Manually reviewed changed files to confirm proper formatting behavior ✅