### PR TITLE
add support for `is` in `Dynamic`, closes #2413

### DIFF
--- a/.changeset/tender-candles-live.md
+++ b/.changeset/tender-candles-live.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+add support for `is` in `Dynamic`, closes #2413

--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -37,8 +37,10 @@ export const isServer: boolean = false;
 export const isDev: boolean = "_SOLID_DEV_" as unknown as boolean;
 const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 
-function createElement(tagName: string, isSVG = false): HTMLElement | SVGElement {
-  return isSVG ? document.createElementNS(SVG_NAMESPACE, tagName) : document.createElement(tagName);
+function createElement(tagName: string, isSVG = false, is = undefined): HTMLElement | SVGElement {
+  return isSVG
+    ? document.createElementNS(SVG_NAMESPACE, tagName)
+    : document.createElement(tagName, { is });
 }
 
 export const hydrate: typeof hydrateCore = (...args) => {
@@ -140,7 +142,9 @@ export function createDynamic<T extends ValidComponent>(
 
       case "string":
         const isSvg = SVGElements.has(component);
-        const el = sharedConfig.context ? getNextElement() : createElement(component, isSvg);
+        const el = sharedConfig.context
+          ? getNextElement()
+          : createElement(component, isSvg, props.is);
         spread(el, props, isSvg);
         return el;
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

`Dynamic` is not considering `is` attribute when creating an element. See https://github.com/solidjs/solid/issues/2413
This PR adds support for it.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
Besides running `pnpm test` I made sure that `document.createElement("a", { is:undefined });` runs in the Chrome/Firefox/Safari.