### PR TITLE
docs: update Index component documentation link

### DIFF
--- a/packages/solid/src/render/flow.ts
+++ b/packages/solid/src/render/flow.ts
@@ -59,7 +59,7 @@ export function For<T extends readonly any[], U extends JSX.Element>(props: {
  * ```
  * If you have a list with changing indices, better use `<For>`.
  *
- * @description https://docs.solidjs.com/reference/components/index
+ * @description https://docs.solidjs.com/reference/components/index-component
  */
 export function Index<T extends readonly any[], U extends JSX.Element>(props: {
   each: T | undefined | null | false;


### PR DESCRIPTION
Updates the documentation link for the Index component from /reference/components/index to /reference/components/index-component to match the correct URL structure in the SolidJS documentation.

This ensures that the `@description` link in the Index component JSDoc points to the correct documentation page.

Fixes the broken documentation link in packages/solid/src/render/flow.ts line 62.