### PR TITLE
Optimize `splitProps`

### DIFF
--- a/.changeset/thirty-eggs-learn.md
+++ b/.changeset/thirty-eggs-learn.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Improve `splitProps` performance

--- a/packages/solid/test/component.bench.ts
+++ b/packages/solid/test/component.bench.ts
@@ -1,4 +1,5 @@
 import { mergeProps, splitProps } from "../src/index.js";
+import { $PROXY } from "../src/reactive/signal.js";
 import { bench, describe } from "vitest";
 
 const staticDesc = {
@@ -81,7 +82,26 @@ type SplitProps = (...args: any[]) => Record<string, any>[];
 const generator = {
   static: (amount: number) => createObject("static", amount, () => staticDesc),
   signal: (amount: number) => createObject("signal", amount, () => signalDesc),
-  mixed: (amount: number) => createObject("mixed", amount, v => (v % 2 ? staticDesc : signalDesc))
+  mixed: (amount: number) => createObject("mixed", amount, v => (v % 2 ? staticDesc : signalDesc)),
+  store: (amount: number) => {
+    const data = createObject("store", amount, () => staticDesc);
+    // Create a proxy that mimics store behavior with $PROXY symbol
+    const proxy = new Proxy(data, {
+      get(target, property) {
+        if (property === $PROXY) return proxy;
+        return target[property];
+      },
+      has(target, property) {
+        if (property === $PROXY) return true;
+        return property in target;
+      },
+      ownKeys(target) {
+        return Reflect.ownKeys(target);
+      }
+    });
+    Object.defineProperty(data, $PROXY, { value: proxy, configurable: true });
+    return proxy;
+  }
 } as const;
 
 const filter = new RegExp(process.env.FILTER || ".+");
@@ -98,14 +118,16 @@ const splitPropsTests = createTest({
   generator,
   inputs: g => ({
     "(5, 1)": [g(5), keys(g(1))],
-    "(5, 1, 2)": [g(5), keys(g(1)), keys(g(2))],
+    "(2, 15)": [g(2), keys(g(15))],
+    "(2, 100)": [g(2), keys(g(100))],
     "(0, 15)": [g(0), keys(g(15))],
-    "(0, 3, 2)": [g(0), keys(g(3)), keys(g(2))],
-    "(0, 100)": [g(0), keys(g(100))],
-    "(0, 100, 3, 2)": [g(0), keys(g(100)), keys(g(3)), keys(g(2))],
+    "(25, 5)": [g(25), keys(g(5))],
     "(25, 100)": [g(25), keys(g(100))],
     "(50, 100)": [g(50), keys(g(100))],
-    "(100, 25)": [g(100), keys(g(25))]
+    "(100, 25)": [g(100), keys(g(25))],
+    "(5, 1, 2)": [g(5), keys(g(1)), keys(g(2))],
+    "(2, 3, 2)": [g(2), keys(g(3)), keys(g(2))],
+    "(2, 100, 3, 2)": [g(2), keys(g(100)), keys(g(3)), keys(g(2))]
   })
 });
 
@@ -121,14 +143,16 @@ const mergePropsTest = createTest({
   generator,
   inputs: g => ({
     "(5, 1)": [g(5), g(1)],
-    "(5, 1, 2)": [g(5), g(1), g(2)],
+    "(2, 15)": [g(2), g(15)],
+    "(2, 100)": [g(2), g(100)],
     "(0, 15)": [g(0), g(15)],
-    "(0, 3, 2)": [g(0), g(3), g(2)],
-    "(0, 100)": [g(0), g(100)],
-    "(0, 100, 3, 2)": [g(0), g(100), g(3), g(2)],
+    "(25, 5)": [g(25), g(5)],
     "(25, 100)": [g(25), g(100)],
     "(50, 100)": [g(50), g(100)],
-    "(100, 25)": [g(100), g(25)]
+    "(100, 25)": [g(100), g(25)],
+    "(5, 1, 2)": [g(5), g(1), g(2)],
+    "(2, 3, 2)": [g(2), g(3), g(2)],
+    "(2, 100, 3, 2)": [g(2), g(100), g(3), g(2)]
   })
 });
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Following [this reddit thread](https://www.reddit.com/r/solidjs/comments/1nc3vye/why_is_solidjs_significantly_slower_than_react/), I wanted to see if splitProps could be improved further:

1. `Set` is only faster when there are >100 elements. In practice, most components do not have so many keys.
2. Avoid spreading to concat
3. Logic can be simplified to remove 2 branches

## How did you test this change?


```
cd packages/solid
pnpm t
```

<details>
<summary>FILTER=splitProps-store pnpx vitest bench --run</summary>
BENCH  Summary

splitProps - packages/solid/test/component.bench.ts > splitProps-store(5, 1)
  1.26x faster than oldSplitProps

splitProps - packages/solid/test/component.bench.ts > splitProps-store(2, 15)
  2.64x faster than oldSplitProps

splitProps - packages/solid/test/component.bench.ts > splitProps-store(2, 100)
  14.59x faster than oldSplitProps

splitProps - packages/solid/test/component.bench.ts > splitProps-store(0, 15)
  2.71x faster than oldSplitProps

splitProps - packages/solid/test/component.bench.ts > splitProps-store(25, 5)
  1.50x faster than oldSplitProps

splitProps - packages/solid/test/component.bench.ts > splitProps-store(25, 100)
  15.96x faster than oldSplitProps

splitProps - packages/solid/test/component.bench.ts > splitProps-store(50, 100)
  14.48x faster than oldSplitProps

splitProps - packages/solid/test/component.bench.ts > splitProps-store(100, 25)
  4.46x faster than oldSplitProps

splitProps - packages/solid/test/component.bench.ts > splitProps-store(5, 1, 2)
  1.20x faster than oldSplitProps

splitProps - packages/solid/test/component.bench.ts > splitProps-store(2, 3, 2)
  1.21x faster than oldSplitProps

splitProps - packages/solid/test/component.bench.ts > splitProps-store(2, 100, 3, 2)
  2.43x faster than oldSplitProps
</details>

<details>
<summary>FILTER=splitProps-mixed pnpx vitest bench --run</summary>
 BENCH  Summary

  splitProps - packages/solid/test/component.bench.ts > splitProps-mixed(5, 1)
    1.01x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-mixed(2, 15)
    1.04x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-mixed(2, 100)
    1.07x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-mixed(0, 15)
    1.15x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-mixed(25, 5)
    1.03x faster than oldSplitProps

  oldSplitProps - packages/solid/test/component.bench.ts > splitProps-mixed(25, 100)
    1.02x faster than splitProps

  oldSplitProps - packages/solid/test/component.bench.ts > splitProps-mixed(50, 100)
    1.06x faster than splitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-mixed(100, 25)
    1.04x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-mixed(5, 1, 2)
    1.25x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-mixed(2, 3, 2)
    1.74x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-mixed(2, 100, 3, 2)
    2.40x faster than oldSplitProps
</details>


<details>
<summary>FILTER=splitProps-static pnpx vitest bench --run</summary>
 BENCH  Summary

  splitProps - packages/solid/test/component.bench.ts > splitProps-static(5, 1)
    1.08x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-static(2, 15)
    1.20x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-static(2, 100)
    1.21x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-static(0, 15)
    1.23x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-static(25, 5)
    1.03x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-static(25, 100)
    1.14x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-static(50, 100)
    1.10x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-static(100, 25)
    1.25x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-static(5, 1, 2)
    1.15x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-static(2, 3, 2)
    1.39x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-static(2, 100, 3, 2)
    1.45x faster than oldSplitProps
</details>



<details>
<summary>FILTER=splitProps-signal pnpx vitest bench --run</summary>

 BENCH  Summary

  oldSplitProps - packages/solid/test/component.bench.ts > splitProps-signal(5, 1)
    1.01x faster than splitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-signal(2, 15)
    1.03x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-signal(2, 100)
    1.01x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-signal(0, 15)
    1.18x faster than oldSplitProps

  oldSplitProps - packages/solid/test/component.bench.ts > splitProps-signal(25, 5)
    1.01x faster than splitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-signal(25, 100)
    1.01x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-signal(50, 100)
    1.11x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-signal(100, 25)
    1.00x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-signal(5, 1, 2)
    1.20x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-signal(2, 3, 2)
    1.85x faster than oldSplitProps

  splitProps - packages/solid/test/component.bench.ts > splitProps-signal(2, 100, 3, 2)
    2.65x faster than oldSplitProps
</details>

And some browser tests on macOS with a modified bench forked from the reddit post. Times are in milliseconds:

### Original splitProps

| Test Name | Chrome | Firefox | Safari |
| --------- | ------ | ------- | ------ |
| Kobalte   | 100.8  | 172.3   | 157.1  |
| Ark UI    | 174.3  | 273.8   | 233.4  |
| SUID      | 197.2  | 356.0   | 382.9  |

## Optimized splitProps

| Test Name | Chrome | Firefox | Safari |  Avg mprovement (%) |
| --------- | ------ | ------- | ------ | ----------- |
| Kobalte   | 93.9   | 158.3   | 152.6  | 5.95%       |
| Ark UI    | 166.6  | 236.5   | 262.3  | 1.89%       |
| SUID      | 190.8  | 330.4   | 350.6  | 6.29%       |

