### PR TITLE
docs(signal): fix jsdoc description

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -950,7 +950,7 @@ export interface OnOptions {
  * });
  * ```
  *
- * @description https://docs.solidjs.com/reference/reactive-utilities/on
+ * @description https://docs.solidjs.com/reference/reactive-utilities/on-util
  */
 export function on<S, Next extends Prev, Prev = Next>(
   deps: AccessorArray<S> | Accessor<S>,
@@ -1778,7 +1778,7 @@ type TODO = any;
  *
  * * If the error is thrown again inside the error handler, it will trigger the next available parent handler
  *
- * @description https://www.solidjs.com/docs/latest/api#onerror | https://docs.solidjs.com/reference/reactive-utilities/catch-error
+ * @description https://docs.solidjs.com/reference/reactive-utilities/catch-error
  */
 export function onError(fn: (err: Error) => void): void {
   ERROR || (ERROR = Symbol("error"));


### PR DESCRIPTION
Thanks for the amazing library, i really enjoy developing with it in my daily work :smiley: .


Just updated some Jsdoc description. I tested all the remain jsdoc description and it seems no one left with 404 now.