### PR TITLE
[nexr] DOM docs: document locked to properties attributes, add xmlns requirement for partials

### DIFF
--- a/documentation/solid-2.0/07-dom.md
+++ b/documentation/solid-2.0/07-dom.md
@@ -118,8 +118,6 @@ Used as:
 | `oncapture:` | Removed (replacement pattern TBD / use native event options where applicable) |
 | `attr:` / `bool:` namespaces | Single attribute/property model above |
 | `use:` directives | Use `ref` callbacks / directive factories (`ref={directive(opts)}`); arrays compose (`ref={[a, b]}`) |
-| `createMutable` (from Solid primitives) | Moved to / available from `@solidjs/signals` or primitives layer |
-| `scheduler` / `createDeferred` | Moved to primitives; use primitives API |
 
 `@solidjs/legacy` can provide compatibility for deprecated DOM APIs where feasible.
 

--- a/documentation/solid-2.0/07-dom.md
+++ b/documentation/solid-2.0/07-dom.md
@@ -18,7 +18,7 @@ DOM behavior in Solid 2.0 follows HTML standards by default: attributes over pro
 - **Attributes over properties:** Prefer setting attributes rather than properties in almost all cases. Aligns with web components and SSR.
 - **Lowercasing:** Use HTML lowercase for built-in attribute names (no camelCase for attributes). Exceptions:
   - **Event handlers** remain camelCase (e.g. `onClick`) to keep the `on` modifier clear.
-  - **Default to properties** such as `input.value`, `input.checked`, `select.value`, `option.value`, `option.selected`, `video/audio.muted` continue to be handled as props where that avoids confusion. However, attribute/property can still be used as `<input value="default value" prop:value={dynamic()}/>`
+  - **Default to attributes** But attributes such as `input.value`, `input.checked`, `select.value`, `option.value`, `option.selected`, `video/audio.muted` continue to be handled as props where that avoids confusion. However, attribute/property can still be used as `<input value="default value" prop:value={dynamic()}/>`
 - **Namespaces:** `attr:` and `bool:` namespaces are removed; the single standard behavior makes the model consistent.
 - **XML Namespaces:** `svg` and `math` work as expected, however when using XML partials, an `xmlns` attribute is required for the browser to create the elements with the correct namespace. Solid adds these automatically to the tags that can recognize as SVG/MathML. For example an `a` tag returned from a partial to be used in XML need `xmlns` added by the user.
  

--- a/documentation/solid-2.0/07-dom.md
+++ b/documentation/solid-2.0/07-dom.md
@@ -18,7 +18,7 @@ DOM behavior in Solid 2.0 follows HTML standards by default: attributes over pro
 - **Attributes over properties:** Prefer setting attributes rather than properties in almost all cases. Aligns with web components and SSR.
 - **Lowercasing:** Use HTML lowercase for built-in attribute names (no camelCase for attributes). Exceptions:
   - **Event handlers** remain camelCase (e.g. `onClick`) to keep the `on` modifier clear.
-  - **Default to attributes** But attributes such as `input.value`, `input.checked`, `select.value`, `option.value`, `option.selected`, `video/audio.muted` continue to be handled as props where that avoids confusion. However, attribute/property can still be used as `<input value="default value" prop:value={dynamic()}/>`
+  - **Default to attributes** But attributes such as `input.value`, `textarea.value`, `input.checked`, `select.value`, `option.value`, `option.selected`, `video/audio.muted` continue to be handled as props where that avoids confusion. However, attribute/property can still be used as `<input value="default value" prop:value={dynamic()}/>`. Unfortunately this leads to all form fields be special cases.
 - **Namespaces:** `attr:` and `bool:` namespaces are removed; the single standard behavior makes the model consistent.
 - **XML Namespaces:** `svg` and `math` work as expected, however when using XML partials, an `xmlns` attribute is required for the browser to create the elements with the correct namespace. Solid adds these automatically to the tags that can recognize as SVG/MathML. For example an `a` tag returned from a partial to be used in XML need `xmlns` added by the user.
  
@@ -128,4 +128,4 @@ Used as:
 
 ## Open questions
 
-- Exact list of "default" props that stay as props (`input.value`, `input.checked`, `select.value`, `option.value`, `option.selected`, `video/audio.muted`, …). Generally, stateful DOM properties should be considered on this list.
+- Exact list of "default" props that stay as props (`input.value`, `textarea.value`, `input.checked`, `select.value`, `option.value`, `option.selected`, `video/audio.muted`, …). Generally, stateful DOM properties should be considered on this list.

--- a/documentation/solid-2.0/07-dom.md
+++ b/documentation/solid-2.0/07-dom.md
@@ -18,7 +18,7 @@ DOM behavior in Solid 2.0 follows HTML standards by default: attributes over pro
 - **Attributes over properties:** Prefer setting attributes rather than properties in almost all cases. Aligns with web components and SSR.
 - **Lowercasing:** Use HTML lowercase for built-in attribute names (no camelCase for attributes). Exceptions:
   - **Event handlers** remain camelCase (e.g. `onClick`) to keep the `on` modifier clear.
-  - **Default to attributes** But attributes such as `input.value`, `textarea.value`, `input.checked`, `select.value`, `option.value`, `option.selected`, `video/audio.muted` continue to be handled as props where that avoids confusion. However, attribute/property can still be used as `<input value="default value" prop:value={dynamic()}/>`. Unfortunately this leads to all form fields be special cases.
+  - **Default to attributes** But attributes such as `input.value`, `input.defaultValue`, `input.checked`, `input.defaultChecked`, `select.value`, `option.value`, `option.selected`, `option.defaultSelected`, `textarea.value`, `textarea.defaultValue`, `video.muted`, `video.defaultMuted`, `audio.muted`, `audio.defaultMuted` continue to be handled as props where that avoids confusion. Unfortunately, this leads to all form fields be special cased. For example: `<input value={dynamicCurrentValue()} defaultValue={dynamicDefaultValue()}/>` either can be dynamic or static, and in the absense of `defaultValue`, then, `value` is SSRed.
 - **Namespaces:** `attr:` and `bool:` namespaces are removed; the single standard behavior makes the model consistent.
 - **XML Namespaces:** `svg` and `math` work as expected, however when using XML partials, an `xmlns` attribute is required for the browser to create the elements with the correct namespace. Solid adds these automatically to the tags that can recognize as SVG/MathML. For example an `a` tag returned from a partial to be used in XML need `xmlns` added by the user.
  
@@ -128,4 +128,4 @@ Used as:
 
 ## Open questions
 
-- Exact list of "default" props that stay as props (`input.value`, `textarea.value`, `input.checked`, `select.value`, `option.value`, `option.selected`, `video/audio.muted`, …). Generally, stateful DOM properties should be considered on this list.
+- Exact list of "default" props that stay as props (`input.value`, `input.defaultValue`, `input.checked`, `input.defaultChecked`, `select.value`, `option.value`, `option.selected`, `option.defaultSelected`, `textarea.value`, `textarea.defaultValue`, `video.muted`, `video.defaultMuted`, `audio.muted`, `audio.defaultMuted`, …). Generally, stateful DOM properties should be considered on this list.

--- a/documentation/solid-2.0/07-dom.md
+++ b/documentation/solid-2.0/07-dom.md
@@ -20,8 +20,8 @@ DOM behavior in Solid 2.0 follows HTML standards by default: attributes over pro
   - **Event handlers** remain camelCase (e.g. `onClick`) to keep the `on` modifier clear.
   - **Default to properties** such as `input.value`, `input.checked`, `select.value`, `option.value`, `option.selected`, `video/audio.muted` continue to be handled as props where that avoids confusion. However, attribute/property can still be used as `<input value="default value" prop:value={dynamic()}/>`
 - **Namespaces:** `attr:` and `bool:` namespaces are removed; the single standard behavior makes the model consistent.
-- **XML Namespaces:** `svg` and `math` work as expected, however when using XML partials, an `xmlns` attribute is required for the browser to create the elements with the correct namespace.
-
+- **XML Namespaces:** `svg` and `math` work as expected, however when using XML partials, an `xmlns` attribute is required for the browser to create the elements with the correct namespace. Solid adds these automatically to the tags that can recognize as SVG/MathML. For example an `a` tag returned from a partial to be used in XML need `xmlns` added by the user.
+ 
 ### Enhanced class prop
 
 - **`classList` is removed;** its behavior is merged into `class`.

--- a/documentation/solid-2.0/07-dom.md
+++ b/documentation/solid-2.0/07-dom.md
@@ -18,8 +18,9 @@ DOM behavior in Solid 2.0 follows HTML standards by default: attributes over pro
 - **Attributes over properties:** Prefer setting attributes rather than properties in almost all cases. Aligns with web components and SSR.
 - **Lowercasing:** Use HTML lowercase for built-in attribute names (no camelCase for attributes). Exceptions:
   - **Event handlers** remain camelCase (e.g. `onClick`) to keep the `on` modifier clear.
-  - **Default attributes** such as `value`, `selected`, `checked`, `muted` continue to be handled as props where that avoids confusion.
+  - **Default to properties** such as `input.value`, `input.checked`, `select.value`, `option.value`, `option.selected`, `video/audio.muted` continue to be handled as props where that avoids confusion. However, attribute/property can still be used as `<input value="default value" prop:value={dynamic()}/>`
 - **Namespaces:** `attr:` and `bool:` namespaces are removed; the single standard behavior makes the model consistent.
+- **XML Namespaces:** `svg` and `math` work as expected, however when using XML partials, an `xmlns` attribute is required for the browser to create the elements with the correct namespace.
 
 ### Enhanced class prop
 
@@ -129,4 +130,4 @@ Used as:
 
 ## Open questions
 
-- Exact list of "default" props that stay as props (`value`, `selected`, `checked`, `muted`, …).
+- Exact list of "default" props that stay as props (`input.value`, `input.checked`, `select.value`, `option.value`, `option.selected`, `video/audio.muted`, …). Generally, stateful DOM properties should be considered on this list.


### PR DESCRIPTION
For whenever https://github.com/ryansolid/dom-expressions/pull/499 is merged