### PR TITLE
docs: fix "a accessor" → "an accessor" grammar typo

### DIFF
--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -104,7 +104,7 @@ import { createSignal } from "solid-js";
 
 // A component is just a function that (optionally) accepts properties and returns a DOM node
 const Counter = props => {
-  // Create a piece of reactive state, giving us a accessor, count(), and a setter, setCount()
+  // Create a piece of reactive state, giving us an accessor, count(), and a setter, setCount()
   const [count, setCount] = createSignal(props.startingCount || 1);
 
   // The increment function calls the setter

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1226,7 +1226,7 @@ export type ChildrenReturn = Accessor<ResolvedChildren> & { toArray: () => Resol
  * Resolves child elements to help interact with children
  *
  * @param fn an accessor for the children
- * @returns a accessor of the same children, but resolved
+ * @returns an accessor of the same children, but resolved
  *
  * @description https://docs.solidjs.com/reference/component-apis/children
  */


### PR DESCRIPTION

**Repo:** solidjs/solid (⭐ 31000)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-2

## What
Corrects the indefinite article before "accessor" in two places: the JSDoc `@returns` tag for the public `children()` API in `packages/solid/src/reactive/signal.ts`, and an inline code comment in `packages/solid/README.md`. Both read "a accessor" and should be "an accessor".

## Why
The JSDoc string is surfaced in IDEs (VS Code hover/IntelliSense) for anyone consuming `children()`, and the README comment is quoted from Solid's canonical "getting started" Counter example — both are user-facing surfaces where a grammar slip reads as sloppy. No behavior change.

## Testing
Visual diff only; no runtime or type changes. `tsc` output is unaffected since the edits are within comments.

## Risk
Low — comment-only change to two files.
