### PR TITLE
Fix createResource initial value inference

### DIFF
--- a/.changeset/silly-berries-bake.md
+++ b/.changeset/silly-berries-bake.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Fix createResource initial value inference

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -577,19 +577,19 @@ function isPromise(v: any): v is Promise<any> {
  *
  * @description https://docs.solidjs.com/reference/basic-reactivity/create-resource
  */
-export function createResource<T, R = unknown>(
-  fetcher: ResourceFetcher<true, T, R>,
-  options: InitializedResourceOptions<NoInfer<T>, true>
-): InitializedResourceReturn<T, R>;
+export function createResource<T, R = unknown, I = T>(
+  fetcher: (k: true, info: ResourceFetcherInfo<T | I, R>) => T | Promise<T>,
+  options: ResourceOptions<T | I, true> & { initialValue: I }
+): InitializedResourceReturn<T | I, R>;
 export function createResource<T, R = unknown>(
   fetcher: ResourceFetcher<true, T, R>,
   options?: ResourceOptions<NoInfer<T>, true>
 ): ResourceReturn<T, R>;
-export function createResource<T, S, R = unknown>(
+export function createResource<T, S, R = unknown, I = T>(
   source: ResourceSource<S>,
-  fetcher: ResourceFetcher<S, T, R>,
-  options: InitializedResourceOptions<NoInfer<T>, S>
-): InitializedResourceReturn<T, R>;
+  fetcher: (k: S, info: ResourceFetcherInfo<T | I, R>) => T | Promise<T>,
+  options: ResourceOptions<T | I, S> & { initialValue: I }
+): InitializedResourceReturn<T | I, R>;
 export function createResource<T, S, R = unknown>(
   source: ResourceSource<S>,
   fetcher: ResourceFetcher<S, T, R>,

--- a/packages/solid/test/resource.type-tests.ts
+++ b/packages/solid/test/resource.type-tests.ts
@@ -56,6 +56,21 @@ type Equals<X, Y> =
   type Tests = Assert<Equals<ResourceActions["mutate"], Setter<number>>>;
 }
 
+// without source
+// with fetcher, nullable initialValue
+{
+  const resourceReturn = createResource(
+    () => {
+      return Promise.resolve(1);
+    },
+    {
+      initialValue: null
+    }
+  );
+
+  type Tests = Assert<Equals<typeof resourceReturn, InitializedResourceReturn<number | null>>>;
+}
+
 // without initialValue
 // with source, fetcher
 {
@@ -103,6 +118,21 @@ type Equals<X, Y> =
       }
     }
   );
+}
+
+// with source, fetcher, nullable initialValue
+{
+  const resourceReturn = createResource(
+    () => 1,
+    () => {
+      return Promise.resolve(1);
+    },
+    {
+      initialValue: null
+    }
+  );
+
+  type Tests = Assert<Equals<typeof resourceReturn, InitializedResourceReturn<number | null>>>;
 }
 
 /* Resource type tests */


### PR DESCRIPTION
Used AI to change the types for `createResource` to close #2676 

Not 100% sure how well the tests cover type regressions but the new test passes