### PR TITLE
fix: resolve solid-element owner marker lookup

### DIFF
--- a/.changeset/fix-element-owner-markers.md
+++ b/.changeset/fix-element-owner-markers.md
@@ -1,0 +1,5 @@
+---
+"solid-element": patch
+---
+
+Fix owner marker lookup so nested custom elements can inherit context from ancestor host markers as well as assigned slot markers.

--- a/packages/solid-element/src/index.ts
+++ b/packages/solid-element/src/index.ts
@@ -29,15 +29,13 @@ function createProps<T extends object>(raw: T) {
 function lookupContext(el: ICustomElement & { _$owner?: any }) {
   if (el.assignedSlot && el.assignedSlot._$owner) return el.assignedSlot._$owner;
   let next: Element & { _$owner?: any } = el.parentNode;
-  while (
-    next &&
-    !next._$owner &&
-    !(next.assignedSlot && (next.assignedSlot as Element & { _$owner?: any })._$owner)
-  )
+  while (next) {
+    if (next._$owner) return next._$owner;
+    if (next.assignedSlot && (next.assignedSlot as Element & { _$owner?: any })._$owner)
+      return (next.assignedSlot as Element & { _$owner?: any })._$owner;
     next = next.parentNode as Element;
-  return next && next.assignedSlot
-    ? (next.assignedSlot as Element & { _$owner?: any })._$owner
-    : el._$owner;
+  }
+  return el._$owner;
 }
 
 function withSolid<T extends object>(ComponentType: ComponentType<T>): ComponentType<T> {


### PR DESCRIPTION
## Summary
- Fix `solid-element` owner lookup so ancestor host `_$owner` markers are returned when found during the parent walk.
- Add a patch changeset for `solid-element`.

Fixes #2364

## Test plan
- `git diff --check`
- Attempted `pnpm --filter solid-element build`; blocked in the fresh worktree by existing Solid 1 generated type/self-resolution setup after dependency install and Solid JS build.


Made with [Cursor](https://cursor.com)