### PR TITLE
Isolate context id space inside createComponent under NoHydration

### DIFF
--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -146,7 +146,15 @@ export function createUniqueId(): string {
 }
 
 export function createComponent<T>(Comp: (props: T) => JSX.Element, props: T): JSX.Element {
-  if (sharedConfig.context && !sharedConfig.context.noHydrate) {
+  if (sharedConfig.context) {
+    // Even under noHydrate we still need to isolate the id space for each
+    // component, so that `createResource` calls in sibling/nested components
+    // do not collide on the same context id when a parent `Suspense` resets
+    // `count` back to 0. Without this, a non-hydrating render of
+    // `<Post><Suspense><User/></Suspense></Post>` (each with a resource)
+    // produces two resources sharing the same id key in
+    // `context.resources` and the inner resource reads back the outer one's
+    // value. See #2546.
     const c = sharedConfig.context;
     setHydrateContext(nextHydrateContext());
     const r = Comp(props || ({} as T));


### PR DESCRIPTION
Closes #2546.

Per the existing maintainer analysis in the issue thread (#2546 / #2131): under `<NoHydration>`, IDs aren't managed correctly, so two `createResource` calls in nested components can collide on the same key in `context.resources`.

Walking through the repro (https://github.com/fongandrew/solidjs-resource-repro):

```
<NoHydration>
  <Post id="post123">         // outer createComponent
    // const [post] = createResource(...)  -> getNextContextId
    <Suspense>
      <User id={post()?.userId}>   // inner createComponent
        // const [user] = createResource(...) -> getNextContextId
```

`createComponent` was:

```ts
export function createComponent<T>(Comp: (props: T) => JSX.Element, props: T): JSX.Element {
  if (sharedConfig.context && !sharedConfig.context.noHydrate) {
    const c = sharedConfig.context;
    setHydrateContext(nextHydrateContext());
    const r = Comp(props || ({} as T));
    setHydrateContext(c);
    return r;
  }
  return Comp(props || ({} as T));
}
```

Under noHydrate the function returned the child directly without pushing a new `HydrationContext`. So:

1. Post runs with the parent context. `post` resource gets `id = "parent-0"`, `count` becomes 1.
2. `<Suspense>` reads the current id (`"parent-1"`) and then runs its body with `setHydrateContext({ ...ctx, count: 0 })` — count is reset for the suspense boundary.
3. User runs with that same parent context (no isolation under noHydrate). `user` resource gets `id = "parent-0"` again because count was reset by Suspense — collision with `post.resources["parent-0"]`.

The fix is to always isolate the id space per component, even when noHydrate is set:

```ts
export function createComponent<T>(Comp: (props: T) => JSX.Element, props: T): JSX.Element {
  if (sharedConfig.context) {
    const c = sharedConfig.context;
    setHydrateContext(nextHydrateContext());
    const r = Comp(props || ({} as T));
    setHydrateContext(c);
    return r;
  }
  return Comp(props || ({} as T));
}
```

`nextHydrateContext` already spreads `...sharedConfig.context`, so the new context inherits `noHydrate: true` and downstream hydration markers continue to be skipped. The only behavior change is that the inner component's resource ids are derived from the outer component's freshly-allocated id, which keeps them unique across Suspense-driven count resets.

Verified: `pnpm test` in packages/solid → 469 / 469 pass (26 files).

No regression test added because the existing test surface for renderToStringAsync + NoHydration lives in `solid-ssr` / `dom-expressions` rather than this package's vitest suite. Happy to add one if you'd like — would need a few lines of harness to wire up `dom-expressions/src/server.js` here.
