### PR TITLE
Fix stale mappings for primitive store arrays

### DIFF
--- a/.changeset/thin-badgers-move.md
+++ b/.changeset/thin-badgers-move.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+update primitive store array mappings

--- a/packages/solid-signals/src/store/reconcile.ts
+++ b/packages/solid-signals/src/store/reconcile.ts
@@ -137,9 +137,11 @@ function applyStateFast(next: any, target: any, keyFn: (item: NonNullable<any>) 
     } else if (next.length) {
       for (let i = 0, len = next.length; i < len; i++) {
         const item = previous[i];
-        isWrappable(item)
-          ? applyState(next[i], wrap(item, target), keyFn)
-          : target[STORE_NODE][i] && setSignal(target[STORE_NODE][i], next[i]);
+        if (isWrappable(item)) applyState(next[i], wrap(item, target), keyFn);
+        else {
+          if (item !== next[i]) changed = true;
+          target[STORE_NODE][i] && setSignal(target[STORE_NODE][i], next[i]);
+        }
       }
     }
 
@@ -279,9 +281,11 @@ function applyStateSlow(next: any, target: any, keyFn: (item: NonNullable<any>) 
     } else if (next.length) {
       for (let i = 0, len = next.length; i < len; i++) {
         const item = getOverrideValue(previous, override, i as any, optOverride);
-        isWrappable(item)
-          ? applyState(next[i], wrap(item, target), keyFn)
-          : target[STORE_NODE][i] && setSignal(target[STORE_NODE][i], next[i]);
+        if (isWrappable(item)) applyState(next[i], wrap(item, target), keyFn);
+        else {
+          if (item !== next[i]) changed = true;
+          target[STORE_NODE][i] && setSignal(target[STORE_NODE][i], next[i]);
+        }
       }
     }
 

--- a/packages/solid-signals/tests/maparray-store-nonkeyed.test.ts
+++ b/packages/solid-signals/tests/maparray-store-nonkeyed.test.ts
@@ -8,7 +8,10 @@ describe("mapArray backed by derived store arrays", () => {
 
     const dispose = createRoot(dispose => {
       const [issue, set] = createSignal(0);
-      const [comments] = createStore(() => [`issue ${issue()} comment 0`, `issue ${issue()} comment 1`], []);
+      const [comments] = createStore(
+        () => [`issue ${issue()} comment 0`, `issue ${issue()} comment 1`],
+        []
+      );
       setIssue = set;
       mapped = mapArray(
         () => comments,

--- a/packages/solid-signals/tests/maparray-store-nonkeyed.test.ts
+++ b/packages/solid-signals/tests/maparray-store-nonkeyed.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, test } from "vitest";
-import { createRoot, createStore, mapArray, flush } from "../src/index.js";
+import { createRoot, createSignal, createStore, mapArray, flush } from "../src/index.js";
+
+describe("mapArray backed by derived store arrays", () => {
+  test("updates when same-length primitive array items are replaced", () => {
+    let setIssue!: (issue: number) => void;
+    let mapped!: () => string[];
+
+    const dispose = createRoot(dispose => {
+      const [issue, set] = createSignal(0);
+      const [comments] = createStore(() => [`issue ${issue()} comment 0`, `issue ${issue()} comment 1`], []);
+      setIssue = set;
+      mapped = mapArray(
+        () => comments,
+        comment => comment
+      );
+      return dispose;
+    });
+
+    expect(mapped()).toEqual(["issue 0 comment 0", "issue 0 comment 1"]);
+
+    setIssue(1);
+    flush();
+
+    expect(mapped()).toEqual(["issue 1 comment 0", "issue 1 comment 1"]);
+    dispose();
+  });
+});
 
 describe("mapArray keyed:false backed by a store (#2687)", () => {
   // Regression: mapArray's internal owner is a Root, so untracked store-proxy


### PR DESCRIPTION
Fixes `<For>` / `mapArray` updates when a derived store replaces a same-length array of primitive values.

When store reconciliation updated primitive array entries, it set the per-index signals but did not mark the array as changed. As a result, `$TRACK` subscribers such as `mapArray` could keep stale row mappings when the array length stayed the same.

This marks primitive item replacements as array changes so the list mapping reruns correctly.

Added a regression test covering a derived store returning a flat string array.

Fixes #2720.