### PR TITLE
Fix broken README supporter links

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Come chat with us on [Discord](https://discord.com/invite/solidjs)! Solid's crea
 
 ### Contributors
 
-<a href="https://github.com/solidjs/solid/graphs/contributors"><img src="https://opencollective.com/solid/contributors.svg?width=890&amp;button=false" style="max-width:100%;"></a>
+<a href="https://github.com/solidjs/solid/graphs/contributors"><img src="https://contrib.rocks/image?repo=solidjs/solid" style="max-width:100%;"></a>
 
 ### Open Collective
 
@@ -217,7 +217,6 @@ Support us with a donation and help us continue our activities. [[Contribute](ht
 <a href="https://opencollective.com/solid/backer/6/website" target="_blank"><img src="https://opencollective.com/solid/backer/6/avatar.svg"></a>
 <a href="https://opencollective.com/solid/backer/7/website" target="_blank"><img src="https://opencollective.com/solid/backer/7/avatar.svg"></a>
 <a href="https://opencollective.com/solid/backer/8/website" target="_blank"><img src="https://opencollective.com/solid/backer/8/avatar.svg"></a>
-<a href="https://opencollective.com/solid/backer/9/website" target="_blank"><img src="https://opencollective.com/solid/backer/9/avatar.svg"></a>
 <a href="https://opencollective.com/solid/backer/10/website" target="_blank"><img src="https://opencollective.com/solid/backer/10/avatar.svg"></a>
 
 ### Sponsors
@@ -233,7 +232,6 @@ Become a sponsor and get your logo on our README on GitHub with a link to your s
 <a href="https://opencollective.com/solid/sponsor/6/website" target="_blank"><img src="https://opencollective.com/solid/sponsor/6/avatar.svg"></a>
 <a href="https://opencollective.com/solid/sponsor/7/website" target="_blank"><img src="https://opencollective.com/solid/sponsor/7/avatar.svg"></a>
 <a href="https://opencollective.com/solid/sponsor/8/website" target="_blank"><img src="https://opencollective.com/solid/sponsor/8/avatar.svg"></a>
-<a href="https://opencollective.com/solid/sponsor/9/website" target="_blank"><img src="https://opencollective.com/solid/sponsor/9/avatar.svg"></a>
 <a href="https://opencollective.com/solid/sponsor/10/website" target="_blank"><img src="https://opencollective.com/solid/sponsor/10/avatar.svg"></a>
 <a href="https://opencollective.com/solid/sponsor/11/website" target="_blank"><img src="https://opencollective.com/solid/sponsor/11/avatar.svg"></a>
 <a href="https://opencollective.com/solid/sponsor/12/website" target="_blank"><img src="https://opencollective.com/solid/sponsor/12/avatar.svg"></a>


### PR DESCRIPTION
## Summary
- Replace the broken Open Collective contributors image with a working contributors image.
- Remove the broken backer 9 avatar link.
- Remove the sponsor 9 link that redirects to a deleted GitHub account.

## Context
Closes #2733.

## Validation
- Verified https://opencollective.com/solid/backer/9/avatar.svg returns 404.
- Verified https://opencollective.com/solid/sponsor/9/website redirects to a 404 GitHub profile.
- Verified the replacement contributors image returns HTTP 200 with image/svg+xml.