### PR TITLE
ci: set explicit read permissions on main-ci workflow

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
  job:
   runs-on: ubuntu-latest


### PR DESCRIPTION
This narrows the `GITHUB_TOKEN` for `.github/workflows/main-ci.yml` to read-only.

- These jobs only check out the repo and run build/test steps, so `contents: read` covers them.
- Without an explicit block the token inherits the repo default, often write-enabled.
- Following the principle of least privilege from the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token).

Behavior is unchanged.