### PR TITLE
fix: track nested deep optimistic store pending state

### DIFF
--- a/.changeset/fix-nested-optimistic-store-pending.md
+++ b/.changeset/fix-nested-optimistic-store-pending.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Track pending state for nested deep optimistic store reads.

--- a/packages/solid-signals/src/store/utils.ts
+++ b/packages/solid-signals/src/store/utils.ts
@@ -9,6 +9,7 @@ import {
   getPropertyDescriptor,
   isWrappable,
   STORE_OVERRIDE,
+  STORE_LOOKUP,
   STORE_VALUE,
   storeLookup,
   trackSelf,
@@ -38,7 +39,7 @@ function snapshotImpl<T>(
         : target[STORE_VALUE]
     );
     item = target[STORE_VALUE];
-    lookup = storeLookup;
+    lookup = target[STORE_LOOKUP] ?? storeLookup;
   } else {
     isArray = Array.isArray(item);
     map.set(item, item);

--- a/packages/solid-signals/tests/store/createOptimisticStore.test.ts
+++ b/packages/solid-signals/tests/store/createOptimisticStore.test.ts
@@ -1770,6 +1770,56 @@ describe("createOptimisticStore", () => {
       expect(pendingValues.at(-1)).toBe(false);
     });
 
+    it("isPending tracks deep optimistic store reads from a nested proxy", async () => {
+      let state: Refreshable<{ items: { name: string }[] }>;
+      let setState: (fn: (s: { items: { name: string }[] }) => void) => void;
+      let save!: () => Promise<void>;
+      let resolveAction!: () => void;
+      const pendingValues: boolean[] = [];
+
+      createRoot(() => {
+        [state, setState] = createOptimisticStore(async () => ({ items: [{ name: "Initial" }] }), {
+          items: [{ name: "Initial" }]
+        });
+
+        createRenderEffect(
+          () => isPending(() => deep(state.items)),
+          value => {
+            pendingValues.push(value);
+          }
+        );
+
+        save = action(function* () {
+          setState(s => {
+            s.items[0].name = "Modified";
+          });
+          expect(isPending(() => deep(state.items))).toBe(true);
+          yield new Promise<void>(resolve => {
+            resolveAction = resolve;
+          });
+        });
+      });
+
+      flush();
+      await Promise.resolve();
+      await Promise.resolve();
+      flush();
+      expect(pendingValues.at(-1)).toBe(false);
+
+      const actionPromise = save();
+      flush();
+
+      expect(state!.items[0].name).toBe("Modified");
+      expect(pendingValues.at(-1)).toBe(true);
+
+      resolveAction();
+      await actionPromise;
+      await Promise.resolve();
+      flush();
+
+      expect(pendingValues.at(-1)).toBe(false);
+    });
+
     it("isPending clears for deep optimistic store reads when fresh projection data lands", async () => {
       let serverCount = 0;
       const fetches: Array<() => void> = [];

--- a/packages/solid-signals/tests/store/createOptimisticStore.test.ts
+++ b/packages/solid-signals/tests/store/createOptimisticStore.test.ts
@@ -1720,6 +1720,56 @@ describe("createOptimisticStore", () => {
       expect(pendingValues.at(-1)).toBe(false);
     });
 
+    it("isPending tracks deep nested optimistic store reads before async refresh starts", async () => {
+      let state: Refreshable<{ items: { name: string }[] }>;
+      let setState: (fn: (s: { items: { name: string }[] }) => void) => void;
+      let save!: () => Promise<void>;
+      let resolveAction!: () => void;
+      const pendingValues: boolean[] = [];
+
+      createRoot(() => {
+        [state, setState] = createOptimisticStore(async () => ({ items: [{ name: "Initial" }] }), {
+          items: [{ name: "Initial" }]
+        });
+
+        createRenderEffect(
+          () => isPending(() => deep(state)),
+          value => {
+            pendingValues.push(value);
+          }
+        );
+
+        save = action(function* () {
+          setState(s => {
+            s.items[0].name = "Modified";
+          });
+          expect(isPending(() => deep(state))).toBe(true);
+          yield new Promise<void>(resolve => {
+            resolveAction = resolve;
+          });
+        });
+      });
+
+      flush();
+      await Promise.resolve();
+      await Promise.resolve();
+      flush();
+      expect(pendingValues.at(-1)).toBe(false);
+
+      const actionPromise = save();
+      flush();
+
+      expect(state!.items[0].name).toBe("Modified");
+      expect(pendingValues.at(-1)).toBe(true);
+
+      resolveAction();
+      await actionPromise;
+      await Promise.resolve();
+      flush();
+
+      expect(pendingValues.at(-1)).toBe(false);
+    });
+
     it("isPending clears for deep optimistic store reads when fresh projection data lands", async () => {
       let serverCount = 0;
       const fetches: Array<() => void> = [];


### PR DESCRIPTION
Fixes #2718 

# Fix: Nested `deep(optimisticStore)` Pending State

## Problem

`isPending(() => deep(optimisticStore))` stayed `false` during an optimistic transition when the optimistic write happened inside a nested object or array.

Example:

```ts
setStore(s => {
  s.items[0].name = "Modified";
});
```

In this case, the optimistic value was visible immediately, but `isPending(() => deep(store))` did not become `true` until a later `refresh()`.

## Root Cause

`deep()` uses `snapshotImpl()` to recursively traverse a store and subscribe to every nested store node.

When `snapshotImpl()` found a store proxy, it reset the proxy lookup map to the global store lookup:

```ts
lookup = storeLookup;
```

That works for regular stores, but optimistic stores use their own `STORE_LOOKUP` map for nested proxies.

Because the traversal switched back to the global lookup, nested optimistic objects could be traversed as plain data instead of through their optimistic store proxies. As a result, `isPending()` did not collect the nested pending source.

## Fix

Preserve the current store's lookup map when one exists:

```ts
lookup = target[STORE_LOOKUP] ?? storeLookup;
```

This keeps nested traversal inside the optimistic store's proxy graph, allowing `deep()` to read the nested optimistic nodes and allowing `isPending()` to observe their pending state immediately.