### PR TITLE
Add babel preset bugs metadata

### DIFF
--- a/packages/babel-preset-solid/package.json
+++ b/packages/babel-preset-solid/package.json
@@ -4,6 +4,9 @@
   "description": "Babel preset to transform JSX for Solid.js",
   "author": "Ryan Carniato <ryansolid@gmail.com>",
   "homepage": "https://github.com/solidjs/solid/blob/main/packages/babel-preset-solid#readme",
+  "bugs": {
+    "url": "https://github.com/solidjs/solid/issues"
+  },
   "license": "MIT",
   "repository": "https://github.com/solidjs/solid/blob/main/packages/babel-preset-solid",
   "main": "index.js",


### PR DESCRIPTION
## Summary

- add standard npm `bugs.url` metadata for `babel-preset-solid`
- point the issue tracker link at the public Solid issues page

The published package currently exposes homepage and repository metadata, but does not expose a usable `bugs` link in npm package metadata.

## Verification

- `node -e "const p=require('./packages/babel-preset-solid/package.json'); console.log(JSON.stringify({name:p.name,version:p.version,homepage:p.homepage,bugs:p.bugs,repository:p.repository},null,2)); if(p.name!=='babel-preset-solid'||p.bugs?.url!=='https://github.com/solidjs/solid/issues') process.exit(1)"`
- `git diff --check`