### PR TITLE
fix(server): propagate effect errors to error boundaries (closes #2777)

### DIFF
--- a/packages/solid/src/server/signals.ts
+++ b/packages/solid/src/server/signals.ts
@@ -935,7 +935,14 @@ function serverEffect<T>(
     }
     effectFn?.((ssrSource ? (comp.value ?? result) : result) as any, undefined);
   } catch (err) {
-    // Swallow errors from effects on server
+    // NotReadyError is suspense control flow — must keep propagating so the
+    // surrounding Loading boundary can react. For real errors, record on the
+    // computation and re-throw so a wrapping `createErrorBoundary` /
+    // `<Errored>` can catch instead of the error vanishing into the void
+    // (#2777).
+    if (err instanceof NotReadyError) throw err;
+    comp.error = err;
+    throw err;
   }
 }
 

--- a/packages/solid/test/server/signals.spec.ts
+++ b/packages/solid/test/server/signals.spec.ts
@@ -417,6 +417,27 @@ describe("Server createErrorBoundary", () => {
       { id: "test" }
     );
   });
+
+  test("catches errors thrown from createEffect on the server (#2777)", () => {
+    createRoot(
+      () => {
+        const result = createErrorBoundary(
+          () => {
+            createEffect(
+              () => {
+                throw new Error("server effect boom");
+              },
+              () => {}
+            );
+            return "children";
+          },
+          (err: () => unknown) => `caught: ${(err() as Error).message}`
+        );
+        expect(result()).toBe("caught: server effect boom");
+      },
+      { id: "test" }
+    );
+  });
 });
 
 // === createLoadingBoundary ===


### PR DESCRIPTION
## Summary

Closes #2777.

`serverEffect` in `packages/solid/src/server/signals.ts` was wrapping the compute / effect path in `try { … } catch (err) { /* Swallow errors from effects on server */ }`. That left SSR producing successful child HTML even when a render-effect threw — and silently diverged from the client/hydration path where the same kind of error would reach the surrounding `<Errored>` / `createErrorBoundary`. As reporter notes, the error also disappears from every diagnostic path, so it can't be logged either.

Mirror how `serverSignal`'s pull path already handles the same situation (L630-634): `NotReadyError` is suspense control flow and must keep propagating, real errors get recorded on the computation and re-thrown so a wrapping boundary can catch them.

## Repro / test commands

Added a regression case to the existing `Server createErrorBoundary` describe block in `packages/solid/test/server/signals.spec.ts`:

```ts
test("catches errors thrown from createEffect on the server (#2777)", () => {
  createRoot(() => {
    const result = createErrorBoundary(
      () => {
        createEffect(() => { throw new Error("server effect boom"); }, () => {});
        return "children";
      },
      (err) => `caught: ${(err() as Error).message}`
    );
    expect(result()).toBe("caught: server effect boom");
  }, { id: "test" });
});
```

```
pnpm --filter @solidjs/signals build
pnpm --filter ./packages/solid test test/server/signals.spec.ts
```

Result: **48/48 pass**, including the new regression. The reporter's StackBlitz now produces `error: server effect boom` instead of `children` when wrapped in `<Errored>`.
