### PR TITLE
fix(signals): reset Repeat offset when window goes empty (closes #2767)

### DIFF
--- a/packages/solid-signals/src/map.ts
+++ b/packages/solid-signals/src/map.ts
@@ -325,6 +325,11 @@ function updateRepeat<MappedItem>(this: RepeatData<MappedItem>): any[] {
         this._nodes = [];
         this._mappings = [];
         this._len = 0;
+        // Reset offset to match the cleared data. Without this, a subsequent
+        // nonzero render with a smaller `from` would enter the end-clear loop
+        // with `prevTo = stale_offset + 0` > `to` and dispose `_nodes[-1]`
+        // (#2767, repro 2).
+        this._offset = 0;
       }
       if (this._fallback && !this._mappings[0]) {
         // create fallback

--- a/packages/solid-signals/tests/repeat.test.ts
+++ b/packages/solid-signals/tests/repeat.test.ts
@@ -284,3 +284,32 @@ it("should retain instances when only `offset` changes", () => {
   expect(e4.index).toBe(4);
   expect(computed).toHaveBeenCalledTimes(7);
 });
+
+it("recovers when count goes to 0, from changes, and count comes back nonzero (#2767)", () => {
+  const [count, setCount] = createSignal(2);
+  const [from, setFrom] = createSignal(2);
+
+  const map = repeat(count, (index) => ({ index }), { from });
+
+  let snapshot: any[] = [];
+  createRoot(() => {
+    createEffect(map, (rows) => {
+      snapshot = rows;
+    });
+  });
+  flush();
+  expect(snapshot.map((r) => r.index)).toEqual([2, 3]);
+
+  // 1. clear rows
+  setCount(0);
+  flush();
+  expect(snapshot.map((r: any) => r.index)).toEqual([]);
+
+  // 2. show row 0 — simultaneously moves `from` to 0 and `count` to 1.
+  // Without the `_offset` reset this throws "Cannot read properties of
+  // undefined (reading 'dispose')" inside updateRepeat.
+  setFrom(0);
+  setCount(1);
+  flush();
+  expect(snapshot.map((r: any) => r.index)).toEqual([0]);
+});


### PR DESCRIPTION
Closes #2767 (repro 2 — the \`count → 0 → nonzero with changed from\` crash). The companion repro 1 (forward-slide disposing the wrong rows) was already addressed by [d8921ac](https://github.com/solidjs/solid/commit/d8921ac103473dabba002b2a2cab3d0024499dbd) on \`next\`; this PR only handles the second symptom.

\`updateRepeat\` early-returns through the \`newLen === 0\` branch when the count goes to zero, clearing \`_nodes\`, \`_mappings\`, and \`_len\` but leaving \`_offset\` at whatever the last nonzero render set it to. The next call with \`from\` advanced to a smaller value and \`count\` back to nonzero then computes \`prevTo = stale_offset + 0\` greater than \`to\`, and the end-clear loop runs \`this._nodes[i - stale_offset].dispose()\` — which is \`this._nodes[-N].dispose()\` for a freshly-emptied node array. That's the crash the StackBlitz repro produces.

Fix is the smallest possible: when we transition from a non-empty window to an empty one, also reset \`this._offset = 0\` so the bookkeeping matches the cleared data. Initial state is already \`_offset: 0\` at \`createRepeat\` (\`map.ts:305\`), and every nonzero render writes \`this._offset = from\` at the end of \`updateRepeat\`, so this is the only path where the offset can become stale.

## Test

Added \`recovers when count goes to 0, from changes, and count comes back nonzero (#2767)\` in \`packages/solid-signals/tests/repeat.test.ts\`, mirroring repro 2:

1. \`from = 2\`, \`count = 2\` — renders rows \`[2, 3]\`.
2. \`count = 0\` — empties the window.
3. \`from = 0\` and \`count = 1\` in the same flush — expects row \`[0]\`.

Without the fix this throws \`Cannot read properties of undefined (reading 'dispose')\` inside \`updateRepeat\`. With the fix it produces \`[0]\`.

The full \`pnpm --filter @solidjs/signals test\` suite (42 files, 748 tests) stays green.