### PR TITLE
Fix createProjection seed type inference

### DIFF
--- a/.changeset/fix-create-projection-seed-inference.md
+++ b/.changeset/fix-create-projection-seed-inference.md
@@ -1,0 +1,6 @@
+---
+"@solidjs/signals": patch
+"solid-js": patch
+---
+
+Fix `createProjection` seed typing so readonly store seeds do not override inference from the projection function return type.

--- a/packages/solid-signals/src/store/projection.ts
+++ b/packages/solid-signals/src/store/projection.ts
@@ -108,7 +108,7 @@ export function createProjectionInternal<T extends object = {}>(
  */
 export function createProjection<T extends object = {}>(
   fn: (draft: T) => void | T | Promise<void | T> | AsyncIterable<void | T>,
-  seed: NoFn<T> | Store<NoFn<T>>,
+  seed: Partial<T> | Store<NoFn<T>>,
   options?: ProjectionOptions
 ): Refreshable<Store<T>> {
   return createProjectionInternal(fn, seed, options).store;

--- a/packages/solid-signals/src/store/projection.ts
+++ b/packages/solid-signals/src/store/projection.ts
@@ -17,6 +17,7 @@ import {
   STORE_WRAP,
   storeSetter,
   storeTraps,
+  type NoFn,
   type ProjectionOptions,
   type Store
 } from "./store.js";
@@ -107,7 +108,7 @@ export function createProjectionInternal<T extends object = {}>(
  */
 export function createProjection<T extends object = {}>(
   fn: (draft: T) => void | T | Promise<void | T> | AsyncIterable<void | T>,
-  seed: Partial<T>,
+  seed: NoFn<T> | Store<NoFn<T>>,
   options?: ProjectionOptions
 ): Refreshable<Store<T>> {
   return createProjectionInternal(fn, seed, options).store;

--- a/packages/solid-signals/tests/store/store.type-tests.ts
+++ b/packages/solid-signals/tests/store/store.type-tests.ts
@@ -98,6 +98,21 @@ import {
   store[0].name satisfies string;
 }
 
+// ── createProjection — store as seed ──────────────────────────────────
+
+{
+  const [todos] = createStore([] as { id: number; done: boolean }[]);
+  const proj = createProjection(() => todos.filter(t => !t.done), todos);
+  proj[0].id satisfies number;
+  proj[0].done satisfies boolean;
+}
+
+{
+  const [state] = createStore({ count: 0 });
+  const proj = createProjection(() => ({ count: 1 }), state);
+  proj.count satisfies number;
+}
+
 // ── createOptimisticStore (projection) — partial seed ─────────────────
 
 {

--- a/packages/solid/src/client/hydration.ts
+++ b/packages/solid/src/client/hydration.ts
@@ -1017,7 +1017,7 @@ export const createOptimistic: {
  */
 export const createProjection: <T extends object = {}>(
   fn: (draft: T) => void | T | Promise<void | T> | AsyncIterable<void | T>,
-  initialValue: T,
+  initialValue: NoFn<T> | Store<NoFn<T>>,
   options?: ProjectionOptions
 ) => Refreshable<Store<T>> = ((...args: any[]) =>
   (_createProjection || coreProjection)(...args)) as any;

--- a/packages/solid/src/client/hydration.ts
+++ b/packages/solid/src/client/hydration.ts
@@ -1017,7 +1017,7 @@ export const createOptimistic: {
  */
 export const createProjection: <T extends object = {}>(
   fn: (draft: T) => void | T | Promise<void | T> | AsyncIterable<void | T>,
-  initialValue: NoFn<T> | Store<NoFn<T>>,
+  initialValue: Partial<T> | Store<NoFn<T>>,
   options?: ProjectionOptions
 ) => Refreshable<Store<T>> = ((...args: any[]) =>
   (_createProjection || coreProjection)(...args)) as any;

--- a/packages/solid/src/server/signals.ts
+++ b/packages/solid/src/server/signals.ts
@@ -1056,7 +1056,7 @@ function createPendingProxy<T extends object>(
 
 export function createProjection<T extends object>(
   fn: (draft: T) => void | T | Promise<void | T> | AsyncIterable<void | T>,
-  initialValue: Partial<T>,
+  initialValue: Partial<T> | Store<T>,
   options?: ServerSsrOptions
 ): Store<T> {
   const ctx = sharedConfig.context;


### PR DESCRIPTION
## Summary
- type createProjection seeds like createStore's projection seed
- keep the solid-js hydration wrapper signature aligned with @solidjs/signals
- add a patch changeset

## Testing
- pnpm --filter @solidjs/signals types
- pnpm --filter solid-js types