### PR TITLE
fix: use Object.prototype.hasOwnProperty.call for null-prototype store objects

### DIFF
--- a/.changeset/fix-null-proto-hasownproperty.md
+++ b/.changeset/fix-null-proto-hasownproperty.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Use Object.prototype.hasOwnProperty.call() to support null-prototype objects in store proxies

--- a/packages/solid/store/src/mutable.ts
+++ b/packages/solid/store/src/mutable.ts
@@ -50,7 +50,7 @@ const proxyTraps: ProxyHandler<StoreNode> = {
     if (!tracked) {
       const desc = Object.getOwnPropertyDescriptor(target, property);
       const isFunction = typeof value === "function";
-      if (getListener() && (!isFunction || target.hasOwnProperty(property)) && !(desc && desc.get))
+      if (getListener() && (!isFunction || Object.prototype.hasOwnProperty.call(target, property)) && !(desc && desc.get))
         value = getNode(nodes, property, value)();
       else if (value != null && isFunction && value === Array.prototype[property as any]) {
         return (...args: unknown[]) =>

--- a/packages/solid/store/src/store.ts
+++ b/packages/solid/store/src/store.ts
@@ -188,7 +188,7 @@ const proxyTraps: ProxyHandler<StoreNode> = {
       const desc = Object.getOwnPropertyDescriptor(target, property);
       if (
         getListener() &&
-        (typeof value !== "function" || target.hasOwnProperty(property)) &&
+        (typeof value !== "function" || Object.prototype.hasOwnProperty.call(target, property)) &&
         !(desc && desc.get)
       )
         value = getNode(nodes, property, value)();

--- a/packages/solid/store/test/mutable.spec.ts
+++ b/packages/solid/store/test/mutable.spec.ts
@@ -8,6 +8,16 @@ test("Object.create(null) is allowed", () => {
   expect(user.name).toBe("John");
 });
 
+test("Object.create(null) with function values in reactive reads", () => {
+  createRoot(() => {
+    const user = createMutable(Object.assign(Object.create(null), { fn: () => 42, name: "John" }));
+    const getValue = createMemo(() => user.fn());
+    expect(getValue()).toBe(42);
+    user.fn = () => 99;
+    expect(getValue()).toBe(99);
+  });
+});
+
 describe("State Mutability", () => {
   test("Setting a property", () => {
     const user = createMutable({ name: "John" });

--- a/packages/solid/store/test/store.spec.ts
+++ b/packages/solid/store/test/store.spec.ts
@@ -557,6 +557,18 @@ describe("Handling functions in state", () => {
       expect(getValue()).toBe(2);
     });
   });
+
+  test("Object.create(null) with function values in reactive reads", () => {
+    createRoot(() => {
+      const [state, setState] = createStore<{ fn: () => number; name: string }>(
+        Object.assign(Object.create(null), { fn: () => 1, name: "John" })
+      );
+      const getValue = createMemo(() => state.fn());
+      expect(getValue()).toBe(1);
+      setState({ fn: () => 2 });
+      expect(getValue()).toBe(2);
+    });
+  });
 });
 
 describe("Setting state from Effects", () => {


### PR DESCRIPTION
Null-prototype objects (created with `Object.create(null)`) are commonly used as dictionary-style maps because they avoid inherited properties like `constructor` and `__proto__`. When a store proxy wraps such an object and a function-valued property is accessed, the proxy calls `.hasOwnProperty()` directly on the target. Because null-prototype objects do not inherit from `Object.prototype`, this throws `TypeError: target.hasOwnProperty is not a function`.

This patch replaces the two direct `.hasOwnProperty()` calls in `store.ts` and `mutable.ts` with `Object.prototype.hasOwnProperty.call(target, property)`, which is safe regardless of the object's prototype chain.

Fixes #2771