### PR TITLE
fix(portal): guard removeChild against externally cleared mount

### DIFF
--- a/packages/solid/web/src/index.ts
+++ b/packages/solid/web/src/index.ts
@@ -101,7 +101,7 @@ export function Portal<T extends boolean = false, S extends boolean = false>(pro
         insert(renderRoot, content);
         el.appendChild(container);
         props.ref && (props as any).ref(container);
-        onCleanup(() => el.removeChild(container));
+        onCleanup(() => el.contains(container) && el.removeChild(container));
       }
     },
     undefined,

--- a/packages/solid/web/test/portal.spec.tsx
+++ b/packages/solid/web/test/portal.spec.tsx
@@ -115,6 +115,24 @@ describe("Testing a Portal with Synthetic Events", () => {
   test("dispose", () => disposer());
 });
 
+describe("Testing a Portal whose mount is externally cleared before disposal", () => {
+  let div = document.createElement("div"),
+    disposer: () => void;
+  const testMount = document.createElement("div");
+  const Component = () => <Portal mount={testMount}>Hi</Portal>;
+
+  test("Create portal", () => {
+    disposer = render(Component, div);
+    expect((testMount.firstChild as HTMLDivElement).innerHTML).toBe("Hi");
+  });
+
+  test("dispose does not throw when mount has been externally emptied", () => {
+    // Simulate an external actor clearing the mount node (e.g. innerHTML = "")
+    testMount.innerHTML = "";
+    expect(() => disposer()).not.toThrow();
+  });
+});
+
 describe("Testing a Portal with direct reactive children", () => {
   let div = document.createElement("div"),
     disposer: () => void,


### PR DESCRIPTION
Fixes #2775

Disposing a Portal throws NotFoundError if the mount node is externally cleared before Solid's cleanup callbacks run. el.removeChild(container) fails because container is no longer a child of el.

The fix guards the call with el.contains(container) so cleanup is a no-op when the container has already been detached. Regression test added to portal.spec.tsx.