### PR TITLE
fix(reconcile): notify ownKeys subscribers on pure keyed trailing removal

### DIFF
--- a/.changeset/fix-reconcile-trailing-removal-notify.md
+++ b/.changeset/fix-reconcile-trailing-removal-notify.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+reconcile: notify ownKeys subscribers on pure keyed trailing removal

--- a/packages/solid-signals/src/store/reconcile.ts
+++ b/packages/solid-signals/src/store/reconcile.ts
@@ -99,7 +99,7 @@ function applyStateFast(next: any, target: any, keyFn: (item: NonNullable<any>) 
           applyState(next[j], wrapped, keyFn);
         }
 
-        changed && notifySelf(target);
+        (changed || prevLength !== next.length) && notifySelf(target);
         prevLength !== next.length &&
           arrayNodes?.length &&
           setSignal(arrayNodes.length, next.length);
@@ -244,7 +244,7 @@ function applyStateSlow(next: any, target: any, keyFn: (item: NonNullable<any>) 
         }
 
         const nextLength = next.length;
-        changed && notifySelf(target);
+        (changed || prevLength !== nextLength) && notifySelf(target);
         prevLength !== nextLength && nodes?.length && setSignal(nodes.length, nextLength);
         return;
       }

--- a/packages/solid-signals/tests/store/reconcile.test.ts
+++ b/packages/solid-signals/tests/store/reconcile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { createStore, reconcile, snapshot } from "../../src/index.js";
+import { createStore, reconcile, snapshot, $TRACK, createMemo, createRoot, createEffect, createRenderEffect, flush } from "../../src/index.js";
 
 describe("setState with reconcile", () => {
   test("Reconcile a simple object", () => {
@@ -157,6 +157,27 @@ describe("setState with reconcile", () => {
     expect(store.value).toEqual([1, 2, 3]);
     setStore(reconcile({ value: { q: "aa" } }, "id"));
     expect(store.value).toEqual({ q: "aa" });
+  });
+  test("Reconcile keyed trailing removal notifies $TRACK subscribers", () => {
+    let effectRunCount = 0;
+    const [state, setState] = createStore({ arr: [{ id: 1 }, { id: 2 }, { id: 3 }] });
+    createRoot(() => {
+      createRenderEffect(() => {
+        effectRunCount++;
+        // accessing $TRACK subscribes to ownKeys notifications on arr
+        (state.arr as any)[$TRACK];
+        return undefined;
+      }, () => undefined);
+    });
+    // flush to run the effect initially
+    flush();
+    const runsBefore = effectRunCount;
+    setState(s => {
+      reconcile([{ id: 1 }, { id: 2 }], "id")(s.arr);
+    });
+    // flush to propagate invalidation and re-run the effect
+    flush();
+    expect(effectRunCount).toBeGreaterThan(runsBefore);
   });
 });
 // type tests


### PR DESCRIPTION
When keyed `reconcile` removes only trailing items from an array (for example `[{id:1},{id:2},{id:3}]` shrinks to `[{id:1},{id:2}]`), the common-prefix loop advances `start` past all matching items, which causes `start > newEnd` to be true and the early-exit branch to execute

Inside that branch, the two inner loops only run when there are *new or updated* items to write — there are none in a pure removal — so `changed` stays `false`, `notifySelf(target)` is skipped, and any memo that subscribed to the array's `ownKeys` via `$TRACK` is never invalidated

The length signal fires correctly, but that is a separate signal; `ownKeys` subscribers (which `createSelector`, spread patterns, and anything using `$TRACK` depend on) are silently stale

The same path exists in both `applyStateFast` and `applyStateSlow`

**Fix**: widen the `notifySelf` guard to also fire when the array length changed, regardless of whether any element was rewritten in this pass

Fixes #2773