### PR TITLE
fix(reconcile): force replacement when nested value type changes between array and object

### DIFF
--- a/.changeset/fix-reconcile-array-object-type-mismatch.md
+++ b/.changeset/fix-reconcile-array-object-type-mismatch.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+reconcile: force wholesale replacement when nested value type changes between array and object

--- a/packages/solid-signals/src/store/reconcile.ts
+++ b/packages/solid-signals/src/store/reconcile.ts
@@ -170,6 +170,7 @@ function applyStateFast(next: any, target: any, keyFn: (item: NonNullable<any>) 
         !previousValue ||
         !isWrappable(previousValue) ||
         !isWrappable(nextValue) ||
+        Array.isArray(previousValue) !== Array.isArray(nextValue) ||
         (keyFn(previousValue) != null && keyFn(previousValue) !== keyFn(nextValue))
       ) {
         tracked && setSignal(tracked, void 0);
@@ -314,6 +315,7 @@ function applyStateSlow(next: any, target: any, keyFn: (item: NonNullable<any>) 
         !previousValue ||
         !isWrappable(previousValue) ||
         !isWrappable(nextValue) ||
+        Array.isArray(previousValue) !== Array.isArray(nextValue) ||
         (keyFn(previousValue) != null && keyFn(previousValue) !== keyFn(nextValue))
       ) {
         tracked && setSignal(tracked, void 0);

--- a/packages/solid-signals/tests/store/reconcile.test.ts
+++ b/packages/solid-signals/tests/store/reconcile.test.ts
@@ -179,6 +179,23 @@ describe("setState with reconcile", () => {
     flush();
     expect(effectRunCount).toBeGreaterThan(runsBefore);
   });
+
+  test("Reconcile overwrite tracked array with object updates the signal node", () => {
+    const [store, setStore] = createStore<{ value: any }>({ value: [1, 2] });
+    let derived: any;
+
+    // Establish a tracking subscription on store.value so a signal node is created for it
+    createRoot(() => {
+      derived = createMemo(() => store.value);
+    });
+    expect(Array.isArray(derived())).toBe(true);
+
+    setStore(reconcile({ value: { a: 1 } }, "id"));
+    flush();
+
+    expect(Array.isArray(derived())).toBe(false);
+    expect((derived() as any).a).toBe(1);
+  });
 });
 // type tests
 


### PR DESCRIPTION
When a tracked store property holds an array and `reconcile` replaces it with a plain object (or vice versa), the previous code entered the object-merge loop and called `applyState` recursively on the existing array-shaped proxy. The in-place patch swapped `STORE_VALUE` but left the signal node pointing at the old wrapper, so a memo or effect reading that property continued to see `Array.isArray() === true` even after the value became a plain object.

The guard that already handles non-wrappable values, missing values, and key identity mismatches now also catches `Array.isArray(previousValue) !== Array.isArray(nextValue)`. When the structural type differs, the signal node is rewritten with a fresh `wrap(nextValue, target)` call rather than delegating to `applyState`, which correctly replaces the proxy for downstream subscribers.

The same one-line guard is added to both `applyStateFast` and `applyStateSlow`.

Fixes #2774