### PR TITLE
fix(store): non-configurable property descriptor and stale indices after array truncation

### DIFF
--- a/.changeset/fix-store-proxy-invariants.md
+++ b/.changeset/fix-store-proxy-invariants.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+store: fix two proxy invariant bugs — non-configurable property descriptor and stale indices after array truncation

--- a/packages/solid-signals/src/store/store.ts
+++ b/packages/solid-signals/src/store/store.ts
@@ -578,6 +578,21 @@ export const storeTraps: ProxyHandler<StoreNode> = {
           override[property] = value;
           if (nextLength !== undefined) override.length = nextLength;
         }
+        // When shrinking an array's length, mark truncated indices as deleted in the
+        // override so that `has`, `ownKeys`, and index reads correctly reflect the
+        // shorter array rather than leaking stale entries from the underlying value.
+        if (
+          Array.isArray(state) &&
+          property === "length" &&
+          typeof value === "number" &&
+          typeof prev === "number" &&
+          value < prev
+        ) {
+          const override = target[overrideKey] || (target[overrideKey] = Object.create(null));
+          for (let i = value; i < prev; i++) {
+            if (i in state) override[i] = $DELETED;
+          }
+        }
         notifyStoreProperty(target, property, "set", value, prev, prevHas);
         // notify length change
         if (Array.isArray(state) && property !== "length" && nextLength !== undefined) {
@@ -690,7 +705,9 @@ export const storeTraps: ProxyHandler<StoreNode> = {
       // Get base descriptor structure, override just the value
       const baseDesc = getPropertyDescriptor(target[STORE_VALUE], target[STORE_OVERRIDE], property);
       if (baseDesc) {
-        return { ...baseDesc, value: target[STORE_OPTIMISTIC_OVERRIDE][property] };
+        const targetDesc = Reflect.getOwnPropertyDescriptor(target, property);
+        const configurable = !targetDesc || targetDesc.configurable ? true : baseDesc.configurable;
+        return { ...baseDesc, configurable, value: target[STORE_OPTIMISTIC_OVERRIDE][property] };
       }
       return {
         value: target[STORE_OPTIMISTIC_OVERRIDE][property],
@@ -699,7 +716,17 @@ export const storeTraps: ProxyHandler<StoreNode> = {
         configurable: true
       };
     }
-    return getPropertyDescriptor(target[STORE_VALUE], target[STORE_OVERRIDE], property);
+    const desc = getPropertyDescriptor(target[STORE_VALUE], target[STORE_OVERRIDE], property);
+    // The proxy target is an internal node object, not the original source. When the
+    // source has a non-configurable property that does not also exist as non-configurable
+    // on the proxy target, the proxy invariant is violated: the engine requires that a
+    // property reported as non-configurable must actually be non-configurable on the
+    // target object. Override configurable to true only in that case.
+    if (desc && !desc.configurable) {
+      const targetDesc = Reflect.getOwnPropertyDescriptor(target, property);
+      if (!targetDesc || targetDesc.configurable) return { ...desc, configurable: true };
+    }
+    return desc;
   },
 
   getPrototypeOf(target) {

--- a/packages/solid-signals/tests/store/createStore.test.ts
+++ b/packages/solid-signals/tests/store/createStore.test.ts
@@ -1319,3 +1319,35 @@ describe("derived store manual writes", () => {
     expect(store.count).toBe(2);
   });
 });
+
+describe("Proxy invariant correctness", () => {
+  test("Object.keys does not throw for stores wrapping objects with non-configurable own properties", () => {
+    // A non-configurable property on the source must not cause the getOwnPropertyDescriptor
+    // proxy trap to violate the proxy invariant when the store proxy target is a plain object
+    // that does not have the property as non-configurable.
+    const source: any = {};
+    Object.defineProperty(source, "id", {
+      value: 1,
+      enumerable: true,
+      writable: true,
+      configurable: false
+    });
+    const [store] = createStore(source);
+    expect(() => Object.keys(store)).not.toThrow();
+    expect(store.id).toBe(1);
+  });
+
+  test("Truncating array length clears stale indices from the store proxy", () => {
+    // Writing store.length = N must mark indices >= N as deleted so that `has`,
+    // index reads, and Object.keys all reflect the shorter array.
+    const [list, setList] = createStore([1, 2, 3]);
+    setList(s => {
+      s.length = 2;
+    });
+    flush();
+    expect(list.length).toBe(2);
+    expect(list[2]).toBeUndefined();
+    expect(2 in list).toBe(false);
+    expect(Object.keys(list).filter(k => k !== "length")).not.toContain("2");
+  });
+});


### PR DESCRIPTION
Two proxy invariant bugs in the store proxy, each with a regression test.

**Non-configurable property descriptor (fixes #2770)**

When the underlying source object has a non-configurable own property (created with `Object.defineProperty(..., { configurable: false })`), the `getOwnPropertyDescriptor` trap forwarded that descriptor verbatim. JavaScript proxy invariants require that if a property is reported as non-configurable, it must actually exist as non-configurable on the proxy target. Because the proxy target is an internal node object (not the original source), the invariant was violated, and `Object.keys` — which calls the trap internally — threw a `TypeError`.

The fix checks whether the property already exists as non-configurable on the proxy target before forwarding the source descriptor. If the target does not carry the property as non-configurable, the returned descriptor has `configurable: true`. The same guard is applied in the optimistic-override fast path, where a previous unconditional spread of `configurable: true` could have the opposite problem for array `length` (whose proxy target carries it as non-configurable).

**Stale indices after array truncation (fixes #2768)**

Writing `store.length = N` on an array store updated the length signal but left indices `>= N` visible through the proxy. The `has` trap, `ownKeys`, and index reads all consulted the underlying source array, which still held the removed entries.

The fix marks each truncated index as `$DELETED` in the override whenever a `length` write shrinks the array. The existing override layer already interprets `$DELETED` values as absent in `has`, `ownKeys`, and `getKeys`, so no further changes are needed downstream.