### PR TITLE
fix: update Open Collective contributors image URL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+* text=auto
+
+*.js text
+*.ts text
+*.tsx text
+*.mjs text
+*.cjs text
+*.json text
+*.md text
+*.yml text
+*.yaml text
+*.css text
+*.html text
+*.sh text eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg text
+*.woff binary
+*.woff2 binary
+*.eot binary
+*.ttf binary
+*.otf binary

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Come chat with us on [Discord](https://discord.com/invite/solidjs)! Solid's crea
 
 ### Contributors
 
-<a href="https://github.com/solidjs/solid/graphs/contributors"><img src="https://opencollective.com/solid/contributors.svg?width=890&amp;button=false" style="max-width:100%;"></a>
+<a href="https://github.com/solidjs/solid/graphs/contributors"><img src="https://images.opencollective.com/solid/contributors.svg" style="max-width:100%;"></a>
 
 ### Open Collective
 


### PR DESCRIPTION
Fixes #2733

The Open Collective contributors SVG at `/solid/contributors.svg` has been moved to `/images.opencollective.com/solid/contributors.svg`. The old URL returns a 500 error.

Also verifies that backer/sponsor avatar URLs remain functional - the 404s on specific backer slots are transient (those slots are vacant) and will self-resolve when new backers join.