### PR TITLE
fix(signals): clear uninitialized optimistic async completion

### DIFF
--- a/.changeset/fix-optimistic-first-refresh-pending.md
+++ b/.changeset/fix-optimistic-first-refresh-pending.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Fix `isPending` staying false on the first `refresh()` of an async `createOptimistic` accessor when `isPending` is the only reactive consumer.

--- a/packages/solid-signals/src/core/async.ts
+++ b/packages/solid-signals/src/core/async.ts
@@ -211,6 +211,13 @@ export function handleAsync<T>(
         el._pendingValue = value;
       else {
         el._value = value;
+        // First successful completion of a *resting* optimistic node (no active
+        // override) must clear STATUS_UNINITIALIZED, same as the `setter` branch
+        // above. Otherwise a node whose only consumer is `isPending(() => x())`
+        // — which never drives the observed commit path — stays UNINITIALIZED
+        // forever, and every later refresh() is misread as an initial load, so
+        // `isPending` never reports `true` (#2799 follow-up).
+        if (wasUninitialized) clearStatus(el, true);
         insertSubs(el);
       }
       el._time = clock;

--- a/packages/solid-signals/tests/createOptimistic.test.ts
+++ b/packages/solid-signals/tests/createOptimistic.test.ts
@@ -939,6 +939,51 @@ describe("createOptimistic", () => {
       expect(isPending(() => $data())).toBe(false);
     });
 
+    it("isPending effect fires on the FIRST refresh when isPending is the only consumer (#2799 follow-up)", async () => {
+      // The #2799 test above keeps the node alive with
+      // `createRenderEffect(data, () => {})` — an eager value-observer that
+      // happens to clear STATUS_UNINITIALIZED on the initial load. When the only
+      // consumer is a reactive `isPending(() => data())` (the real JSX case),
+      // nothing cleared that flag on first completion, so the *first* refresh()
+      // was misread as an initial load: the effect never observed `true` until a
+      // second refresh.
+      let resolveFetch: ((v: number[]) => void) | null = null;
+      const makeFetch = () => new Promise<number[]>(r => (resolveFetch = r));
+
+      const seen: boolean[] = [];
+      let $data!: SourceAccessor<number[]>;
+      createRoot(() => {
+        const [data] = createOptimistic<number[]>(() => makeFetch());
+        $data = data;
+        // isPending is the sole consumer — no eager read of data().
+        createEffect(
+          () => isPending(() => data()),
+          p => {
+            seen.push(p);
+          }
+        );
+      });
+
+      // Initial load settles — no stale data yet, so isPending stays false.
+      flush();
+      resolveFetch!([1, 2, 3]);
+      await Promise.resolve();
+      flush();
+      expect(seen.at(-1)).toBe(false);
+
+      // The very FIRST refresh must drive the effect to `true`.
+      refresh($data);
+      flush();
+      expect(seen.at(-1)).toBe(true);
+
+      // Settling the refetch swaps in the new value and clears pending.
+      resolveFetch!([4, 5, 6]);
+      await Promise.resolve();
+      flush();
+      expect($data()).toEqual([4, 5, 6]);
+      expect(seen.at(-1)).toBe(false);
+    });
+
     it("plain optimistic stays true through refresh-of-unrelated-async (issue #2685)", async () => {
       // github.com/solidjs/solid/issues/2685 — the optimistic signal itself
       // is plain (no async source); the async work comes from refresh()ing


### PR DESCRIPTION
## Summary
- clear STATUS_UNINITIALIZED after the first successful completion of a resting async createOptimistic source
- add a regression test for the first refresh when isPending is the only consumer
- add a patch changeset for @solidjs/signals

## Testing
- pnpm --filter @solidjs/signals test -- tests/createOptimistic.test.ts