### PR TITLE
fix(server): Show/Switch should ignore zero-arg function children

### DIFF
--- a/.changeset/fix-ssr-show-switch-zero-arg-children.md
+++ b/.changeset/fix-ssr-show-switch-zero-arg-children.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Fix server `Show`/`Switch` to ignore zero-arg function children, matching client behavior per #1508.

--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -302,9 +302,9 @@ export function Show<T>(props: {
 }): string {
   let c: string | ((item: NonNullable<T> | Accessor<NonNullable<T>>) => string);
   return props.when
-    ? typeof (c = props.children) === "function"
+    ? typeof (c = props.children) === "function" && c.length > 0
       ? c(props.keyed ? props.when! : () => props.when as any)
-      : c
+      : (c as string)
     : props.fallback || "";
 }
 
@@ -319,7 +319,9 @@ export function Switch(props: {
     const w = conditions[i].when;
     if (w) {
       const c = conditions[i].children;
-      return typeof c === "function" ? c(conditions[i].keyed ? w : () => w) : c;
+      return typeof c === "function" && c.length > 0
+        ? c(conditions[i].keyed ? w : () => w)
+        : (c as string);
     }
   }
   return props.fallback || "";

--- a/packages/solid/test/rendering.spec.ts
+++ b/packages/solid/test/rendering.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { createResource } from "../src/index.js";
-import { mergeProps } from "../src/server/rendering.js";
+import { mergeProps, Show, Switch, Match } from "../src/server/rendering.js";
 import { resolveSSRNode } from "dom-expressions/src/server.js";
 
 describe("resolveSSRNode", () => {
@@ -51,6 +51,7 @@ describe("createResource", () => {
     expect(data.loading).toBe(false);
   });
 });
+
 describe("server mergeProps", () => {
   test("preserves properties that shadow Object.prototype methods (toString, valueOf)", () => {
     expect(mergeProps({ toString: 1 }).toString).toBe(1);
@@ -76,5 +77,55 @@ describe("server mergeProps", () => {
     const props = mergeProps({ a: 1 }, { a: 2, b: 3 });
     expect(props.a).toBe(2);
     expect(props.b).toBe(3);
+  });
+});
+
+// A zero-arg function child is treated as a static value rather than a render-prop
+// (see solidjs/solid#1508), since there's nothing for it to receive as an argument.
+// The client (packages/solid/src/render/flow.ts) gates on `child.length > 0` before
+// invoking it as a render-prop; the server implementation needs to agree, or markup
+// rendered with renderToString can diverge from what hydration on the client produces.
+describe("Show with a zero-arg function child", () => {
+  test("is treated like a plain value, same as ErrorBoundary's fallback", () => {
+    function staticChild() {
+      return "static content";
+    }
+    expect(Show({ when: true, children: staticChild as any })).toBe(staticChild as any);
+  });
+
+  test("a render-prop (arity > 0) is still invoked with the value", () => {
+    expect(Show({ when: "hello", keyed: true, children: (item: any) => `got ${item}` })).toBe(
+      "got hello"
+    );
+    // non-keyed: the render-prop receives an accessor, not the raw value
+    expect(Show({ when: "hello", children: (item: any) => `got ${item()}` })).toBe("got hello");
+  });
+});
+
+describe("Switch/Match with a zero-arg function child", () => {
+  test("is treated like a plain value, same as ErrorBoundary's fallback", () => {
+    function staticChild() {
+      return "static content";
+    }
+    const result = Switch({
+      children: Match<unknown>({ when: true, children: staticChild as any })
+    });
+    expect(result).toBe(staticChild as any);
+  });
+
+  test("a render-prop (arity > 0) is still invoked with the value", () => {
+    const keyedResult = Switch({
+      children: Match<unknown>({
+        when: "hello",
+        keyed: true,
+        children: (item: any) => `got ${item}`
+      })
+    });
+    expect(keyedResult).toBe("got hello");
+    // non-keyed: the render-prop receives an accessor, not the raw value
+    const result = Switch({
+      children: Match<unknown>({ when: "hello", children: (item: any) => `got ${item()}` })
+    });
+    expect(result).toBe("got hello");
   });
 });


### PR DESCRIPTION
On the client, `Show`/`Switch` only treat a function child as a render-prop if it actually takes an argument (`child.length > 0`) -- a zero-arg function is just a static value, not re-invoked when the keyed `when` changes. This is intentional per #1508. The server implementation in `rendering.ts` never had that gate, so it calls any function unconditionally, which means SSR output can diverge from what the client would do with the same JSX. `ErrorBoundary` right next to it already does this correctly (`f.length` check), so it's just an inconsistency rather than deliberate.

Fixed by mirroring the same `.length > 0` check client-side uses (also matches how the 2.0 rewrite already does it in `next`, it just never got backported). Added tests in `rendering.spec.ts` covering both the zero-arg case and that real render-props still work for keyed/non-keyed.
