### PR TITLE
fix(repo): patch npm-run-all to detect cjs npm exec paths

### DIFF
--- a/patches/npm-run-all@4.1.5.patch
+++ b/patches/npm-run-all@4.1.5.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/run-task.js b/lib/run-task.js
+index 8cabc03c7ef64f5ca57378009618222fc97ac9b7..53166e6a81a1fb5dfcf0c489ef5815f864f80a13 100644
+--- a/lib/run-task.js
++++ b/lib/run-task.js
+@@ -155,7 +155,7 @@ module.exports = function runTask(task, options) {
+ 
+         // Execute.
+         const npmPath = options.npmPath || process.env.npm_execpath //eslint-disable-line no-process-env
+-        const npmPathIsJs = typeof npmPath === "string" && /\.m?js/.test(path.extname(npmPath))
++        const npmPathIsJs = typeof npmPath === "string" && /^\.[cm]?js$/.test(path.extname(npmPath))
+         const execPath = (npmPathIsJs ? process.execPath : npmPath || "npm")
+         const isYarn = path.basename(npmPath || "npm").startsWith("yarn")
+         const spawnArgs = ["run"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ overrides:
   solid-js: workspace:*
   '@solidjs/web': workspace:*
 
+patchedDependencies:
+  npm-run-all@4.1.5: d951d94a1c5ee49d8f3178bf1010d3f25d2903417c114791c51458b6b636929f
+
 importers:
 
   .:
@@ -79,7 +82,7 @@ importers:
         version: 2.0.0
       npm-run-all:
         specifier: ^4.1.5
-        version: 4.1.5
+        version: 4.1.5(patch_hash=d951d94a1c5ee49d8f3178bf1010d3f25d2903417c114791c51458b6b636929f)
       prettier:
         specifier: ^3.6.2
         version: 3.8.1
@@ -6635,7 +6638,7 @@ snapshots:
   normalize-path@3.0.0:
     optional: true
 
-  npm-run-all@4.1.5:
+  npm-run-all@4.1.5(patch_hash=d951d94a1c5ee49d8f3178bf1010d3f25d2903417c114791c51458b6b636929f):
     dependencies:
       ansi-styles: 3.2.1
       chalk: 2.4.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,9 @@ allowBuilds:
   esbuild: true
   simple-git-hooks: true
 
+patchedDependencies:
+  npm-run-all@4.1.5: patches/npm-run-all@4.1.5.patch
+
 minimumReleaseAgeExclude:
   - babel-plugin-jsx-dom-expressions
   - dom-expressions


### PR DESCRIPTION
## Summary

`pnpm` managed by `vite-plus` causes this error:

```
ERROR: spawn /Users/name/.vite-plus/package_manager/pnpm/11.1.1/pnpm/bin/pnpm.cjs EACCES
```

In this particular setup `pnpm 11` exposes `npm_execpath` as `pnpm.cjs`. But `npm-run-all` only treated `.js/.mjs` paths as Node shims. It tried to execute `pnpm.cjs` directly and hit `EACCES`, so the patch treats `.cjs` as a JS shim and runs it through `node`.

Updating `pnpm` to 11.9.0 did not help.

## How did you test this change?

`pnpm build` now works. The patch is minimal and sufficient.
