### PR TITLE
fix(solid): exclude keys shared across splitProps groups on the proxy path

### DIFF
--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -293,17 +293,20 @@ export function splitProps<
 
   if (SUPPORTS_PROXY && $PROXY in props) {
     const blocked = len > 1 ? keys.flat() : keys[0];
+    const claimed = new Set<PropertyKey>();
     const res = keys.map(k => {
+      // a key belongs to the first group that lists it (matches non-proxy path)
+      const owned = k.filter(property => !claimed.has(property) && (claimed.add(property), true));
       return new Proxy(
         {
           get(property) {
-            return k.includes(property) ? props[property as any] : undefined;
+            return owned.includes(property) ? props[property as any] : undefined;
           },
           has(property) {
-            return k.includes(property) && property in props;
+            return owned.includes(property) && property in props;
           },
           keys() {
-            return k.filter(property => property in props);
+            return owned.filter(property => property in props);
           }
         },
         propTraps

--- a/packages/solid/test/component.spec.ts
+++ b/packages/solid/test/component.spec.ts
@@ -417,6 +417,31 @@ describe("SplitProps Props", () => {
     expect(otherProps.id).toBe("input");
     expect(Object.keys(otherProps).length).toBe(1);
   });
+  test("SplitProps with keys shared across groups assigns to first group only", () => {
+    // A key listed in more than one group must belong to the first group that
+    // lists it, for both plain-object and proxy (store/props) sources.
+    const check = (a: any, b: any, rest: any) => {
+      expect(a.b).toBe(2);
+      expect("b" in a).toBe(true);
+      expect(Object.keys(a).sort()).toEqual(["a", "b"]);
+
+      expect(b.b).toBeUndefined();
+      expect("b" in b).toBe(false);
+      expect(Object.keys(b)).toEqual(["c"]);
+      expect({ ...b }).toEqual({ c: 3 });
+
+      expect({ ...rest }).toEqual({});
+    };
+
+    const plain = splitProps({ a: 1, b: 2, c: 3 }, ["a", "b"], ["b", "c"]);
+    check(plain[0], plain[1], plain[2]);
+
+    createRoot(() => {
+      const [state] = createStore({ a: 1, b: 2, c: 3 });
+      const proxied = splitProps(state, ["a", "b"], ["b", "c"]);
+      check(proxied[0], proxied[1], proxied[2]);
+    });
+  });
   test("SplitProps returns same prop descriptors", () => {
     const inProps = {
       a: 1,


### PR DESCRIPTION
### Problem

`splitProps` proxy path duplicates a key that is shared across two groups, disagreeing with its own plain-object path and with the documented contract that a property belongs to a single group.

### Repro

```js
// plain object source
const [g1, g2, rest] = splitProps({ a: 1, b: 2, c: 3 }, ["a", "b"], ["b", "c"]);
// g2.b === undefined, "b" in g2 === false, Object.keys(g2) === ["c"], { ...g2 } === { c: 3 }   (correct)

// createStore proxy source (same as component props at runtime)
const [state] = createStore({ a: 1, b: 2, c: 3 });
const [p1, p2, prest] = splitProps(state, ["a", "b"], ["b", "c"]);
// ACTUAL:   p2.b === 2, "b" in p2 === true, Object.keys(p2) === ["b", "c"], { ...p2 } === { b: 2, c: 3 }
// EXPECTED: p2.b === undefined, "b" in p2 === false, Object.keys(p2) === ["c"], { ...p2 } === { c: 3 }
```

The key `b` is consumed by the first group but still leaks into the second group through get, has, enumeration, and spread.

### Root cause

`splitProps` has two implementations. The plain-object path walks each property once and assigns it to the first group that lists it (first-match `break`), so keys are exclusive. The proxy path instead builds one `Proxy` per group whose `get`/`has`/`keys` each test `k.includes(property)` against that group's own key list, with no cross-group exclusion. A key present in two groups is therefore reported by both proxied groups. Component props and stores are proxies at runtime, so the proxy path is the one that actually runs for components.

### Fix

In the proxy branch, track keys claimed by earlier groups and let each group own only its not-yet-claimed keys. `get`, `has`, and `keys` all read from that owned set, bringing the proxy path to parity with the plain-object first-match semantics. The `rest` proxy is unchanged, since it already excludes `keys.flat()`.

### Authority

Solid docs state `splitProps` partitions props and each property belongs to one group, and the plain-object implementation in the same function already enforces this with a first-match `break`.

### Tests

Added a case to `packages/solid/test/component.spec.ts` asserting first-group-only ownership for both a plain object and a `createStore` proxy across get, has, keys, and spread. It fails on the current proxy path (`expected 2 to be undefined`) and passes with the fix.

`packages/solid` suite: 482 passing plus the new test. The only failure is the unrelated pre-existing `web/test/transition.spec.tsx` "Transition memo stale read (#2046)" flake, which is nondeterministic and passes when run in isolation on the clean tree.
