### PR TITLE
fix(web): re-export core merge as SSR mergeProps so function-source spreads render (closes #2815)

### DIFF
--- a/packages/solid-web/server/index.ts
+++ b/packages/solid-web/server/index.ts
@@ -1,6 +1,7 @@
 import { ssrElement } from "./server.js";
 import {
   createComponent,
+  merge,
   omit,
   getOwner,
   getNextChildId,
@@ -12,6 +13,17 @@ import type { JSX } from "../src/jsx.js";
 
 export * from "./server.js";
 export type { JSX } from "../src/jsx.js";
+
+/**
+ * Compiler-emitted prop-spread helper. The JSX transform (in
+ * `dom-expressions`) emits `mergeProps(...)` calls when compiling prop
+ * spreads — it is *not* a user-facing API. Re-exported here as core `merge`
+ * (shadowing the `dom-expressions/src/server.js` star export) so SSR resolves
+ * function sources exactly like the client entry does.
+ *
+ * @internal
+ */
+export const mergeProps = merge;
 
 export {
   For,

--- a/packages/solid-web/test/server/spread-function-source.spec.tsx
+++ b/packages/solid-web/test/server/spread-function-source.spec.tsx
@@ -1,0 +1,46 @@
+/**
+ * @jsxImportSource @solidjs/web
+ */
+import { describe, expect, test } from "vitest";
+import { renderToString, Dynamic, mergeProps, ssrElement } from "@solidjs/web";
+
+// Regression: SSR mergeProps dropped props whose source is a function.
+// The compiler passes spread sources lazily (`mergeProps({...static}, fn)`);
+// the old SSR merger resolved the function for key enumeration only, so the
+// per-key getter read `fn[key]` (undefined) and the attribute vanished from
+// the HTML. Client rendering and 1.x were unaffected.
+describe("SSR spread with function source", () => {
+  test("mergeProps resolves function sources for values, not just keys", () => {
+    const fn = () => ({ "data-x": "1" });
+    const html = renderToString(() => ssrElement("div", mergeProps({ id: "y" }, fn), "x", false));
+    expect(html).toContain('data-x="1"');
+    expect(html).toContain('id="y"');
+  });
+
+  test("object spread source still renders (no regression)", () => {
+    const obj = { "data-x": "1" };
+    const html = renderToString(() => ssrElement("div", mergeProps({ id: "y" }, obj), "x", false));
+    expect(html).toContain('data-x="1"');
+    expect(html).toContain('id="y"');
+  });
+
+  test("JSX spread of a function call result alongside a static attribute", () => {
+    const html = renderToString(() => <div id="y" {...(() => ({ "data-x": "1" }))()} />);
+    expect(html).toContain('data-x="1"');
+    expect(html).toContain('id="y"');
+  });
+
+  test("Dynamic routes spreads through mergeProps", () => {
+    const props = { "data-x": "1", id: "y" };
+    const html = renderToString(() => <Dynamic component="div" {...props} />);
+    expect(html).toContain('data-x="1"');
+    expect(html).toContain('id="y"');
+  });
+
+  test("later function source overrides earlier static prop", () => {
+    const fn = () => ({ id: "override" });
+    const html = renderToString(() => ssrElement("div", mergeProps({ id: "y" }, fn), "x", false));
+    expect(html).toContain('id="override"');
+    expect(html).not.toContain('id="y"');
+  });
+});


### PR DESCRIPTION
Closes #2815

## Summary

`renderToString` drops JSX spread props whose source is a function — `<div id="y" {...fn()}>` renders `<div id="y" >`, and anything routed through `<Dynamic {...props}>` is affected too. Object spreads and client rendering are fine. This is a 1.x → 2.0 regression.

Repro: https://stackblitz.com/edit/solidjs-templates-z23yxd2s?file=server.js

## Root cause

The compiler intentionally passes spread sources lazily (`mergeProps({...static}, fn)`). The server build's `mergeProps` comes from `dom-expressions/src/server.js` (via `server/server.ts`'s star export), which resolves a function source for **key enumeration only** — the per-key value getter still reads the raw, un-invoked function, so `fn[key]` is `undefined` and the prop vanishes from the HTML.

It regressed in the 2.0 entry split: 1.x `solid-js/web` re-exported the **core** prop merger on the server, so SSR and client shared one correct implementation. The 2.0 client entry still does this (`src/index.ts`: `export const mergeProps = merge`), but the server entry ships dom-expressions' broken one without the core override.

## Fix

Re-export core `merge` as `mergeProps` from `packages/solid-web/server/index.ts`, shadowing the `dom-expressions` star export — restoring the 1.x invariant that server and client use the same merger. Besides fixing the bug, this keeps SSR and hydration semantics identical in edge cases: core `merge` picks the winning source with `key in source`, while the dom-expressions version uses `value !== undefined`, which diverges for explicitly-`undefined` props.

## Tests

New `test/server/spread-function-source.spec.tsx` covers:

- raw `mergeProps` with a function source (the compiler-emitted shape)
- JSX `<div id="y" {...(() => ({...}))()} />`
- `<Dynamic {...props}>`
- object-source no-regression case
- override precedence (later function source beats earlier static prop)

Verified the function-source tests fail without the fix and pass with it. Full solid-web suite (client + server + hydrate) passes.

## Upstream note

`dom-expressions`' own SSR `mergeProps` should also be fixed for consumers that use it without `@solidjs/web`. One line — resolve the function source in place so the getters read the resolved object:

```diff
   for (let i = 0; i < sources.length; i++) {
     let source = sources[i];
-    if (typeof source === "function") source = source();
+    if (typeof source === "function") sources[i] = source = source();
```