### PR TITLE
ci: add CVE Lite dependency audit workflow

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,36 @@
+name: CVE Lite dependency audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for vulnerabilities
+        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        with:
+          fail-on: high
+          sarif: 'true'
+
+      - name: Upload SARIF to Code Scanning
+        if: always() && hashFiles('*.sarif') != ''
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: cve-lite-*.sarif
+          category: cve-lite

--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -29,8 +29,9 @@ jobs:
           sarif: 'true'
 
       - name: Upload SARIF to Code Scanning
-        if: always() && hashFiles('*.sarif') != ''
+        if: always()
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
         with:
-          sarif_file: cve-lite-*.sarif
+          sarif_file: .
           category: cve-lite

--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Scan for vulnerabilities
-        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        uses: OWASP/cve-lite-cli@99b7b0dcd4c687116890515dbfa8f955871776cc # v1
         with:
           fail-on: high
           sarif: 'true'

--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Scan for vulnerabilities
-        uses: OWASP/cve-lite-cli@99b7b0dcd4c687116890515dbfa8f955871776cc # v1
+        uses: OWASP/cve-lite-cli@fd481fff75f492f94de36dcaf020674af0eca9ef # v1.29.0
         with:
           fail-on: high
           sarif: 'true'


### PR DESCRIPTION
This PR adds a CVE Lite dependency audit workflow to help catch vulnerable dependencies before they land in main.

CVE Lite CLI is an OWASP Lab Project that scans lockfiles locally without installing packages. It reads the pnpm lockfile directly, queries the OSV vulnerability database, and classifies findings as direct or transitive so you know exactly what you control. A scan of the current main branch found 34 findings total - 3 critical, 16 high, 14 medium, and 1 low.

The workflow runs on every push to main, every pull request targeting main, and on a weekly schedule every Monday morning. When vulnerabilities at high severity or above are found, the job fails so they do not go unnoticed in CI. Results are also exported as a SARIF file and uploaded to GitHub Code Scanning, which surfaces findings directly on the Security tab with file and line context.

All Actions are pinned to immutable commit SHAs rather than mutable version tags, so the supply chain for the workflow itself is locked down.

A companion PR with direct dependency upgrades is coming separately once this is reviewed.

Full documentation and the OWASP project page are at https://owasp.org/cve-lite-cli
