### PR TITLE
fix(web): remove Portal's end marker on cleanup

### DIFF
--- a/.changeset/portal-marker-cleanup.md
+++ b/.changeset/portal-marker-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/web": patch
+---
+
+Fix `Portal` stranding one empty text node in its mount target per unmount: the cleanup removed the nodes in `[startMarker, endMarker)` but never `endMarker` itself, which the same effect run had appended. Toggling a Portal (the modal open/close pattern) accumulated one node per cycle, unbounded — invisible to `innerHTML` checks but breaking `:empty` selectors and `childNodes` counts on the mount target. The removal range is now inclusive of `endMarker`.

--- a/packages/solid-web/src/index.ts
+++ b/packages/solid-web/src/index.ts
@@ -236,10 +236,13 @@ export function Portal<T extends boolean = false, S extends boolean = false>(pro
       );
       return () => {
         dispose!();
+        // remove [startMarker, endMarker] inclusive — endMarker was appended
+        // by this same effect run and must not survive the cleanup
         let c: Node | null = startMarker;
-        while (c && c !== endMarker) {
+        while (c) {
           const n: Node | null = c.nextSibling;
           m.removeChild(c);
+          if (c === endMarker) break;
           c = n;
         }
       };

--- a/packages/solid-web/test/portal.spec.tsx
+++ b/packages/solid-web/test/portal.spec.tsx
@@ -457,6 +457,80 @@ describe("Testing Portal insert effect ownership (#2758)", () => {
   });
 });
 
+describe("Testing Portal marker cleanup", () => {
+  // empty text markers don't serialize, so these assert on childNodes.length —
+  // innerHTML checks stay green even when markers are stranded
+  test("disposing a Portal removes its markers from the mount", () => {
+    const div = document.createElement("div");
+    const mount = document.createElement("div");
+
+    const disposer = render(
+      () => (
+        <Portal mount={mount}>
+          <span>content</span>
+        </Portal>
+      ),
+      div
+    );
+    expect(mount.querySelector("span")).toBeTruthy();
+
+    disposer();
+    expect(mount.childNodes.length).toBe(0);
+  });
+
+  test("toggling a Portal does not accumulate markers in the mount", () => {
+    const div = document.createElement("div");
+    const mount = document.createElement("div");
+    const [open, setOpen] = createSignal(false);
+
+    const disposer = render(
+      () => (
+        <Show when={open()}>
+          <Portal mount={mount}>
+            <span>modal</span>
+          </Portal>
+        </Show>
+      ),
+      div
+    );
+
+    for (let i = 0; i < 5; i++) {
+      setOpen(true);
+      flush();
+      expect(mount.querySelector("span")).toBeTruthy();
+      setOpen(false);
+      flush();
+      expect(mount.childNodes.length).toBe(0);
+    }
+    disposer();
+  });
+
+  test("switching mounts leaves no markers behind in either mount", () => {
+    const div = document.createElement("div");
+    const mountA = document.createElement("div");
+    const mountB = document.createElement("div");
+    const [mount, setMount] = createSignal(mountA);
+
+    const disposer = render(
+      () => (
+        <Portal mount={mount()}>
+          <span>content</span>
+        </Portal>
+      ),
+      div
+    );
+    expect(mountA.querySelector("span")).toBeTruthy();
+
+    setMount(mountB);
+    flush();
+    expect(mountA.childNodes.length).toBe(0);
+    expect(mountB.querySelector("span")).toBeTruthy();
+
+    disposer();
+    expect(mountB.childNodes.length).toBe(0);
+  });
+});
+
 describe("Testing a Portal with direct reactive children", () => {
   let div = document.createElement("div"),
     disposer: () => void,


### PR DESCRIPTION
Closes #2833

## Summary

Every `Portal` unmount strands one empty text node in its mount target. Toggling a Portal inside `<Show>` — the standard modal open/close pattern, typically mounting into `document.body` — accumulates one node per cycle, unbounded. The leak is invisible to `innerHTML`-based checks (empty text nodes don't serialize) but shows up in `childNodes.length` and breaks `:empty` CSS selectors on the mount target. Regression from 1.x, where the mount returns to 0 child nodes after every close.

Repro: https://stackblitz.com/edit/solidjs-templates-kwwlzkir?file=src%2FApp.tsx

## Root cause

Portal's render-effect cleanup removes the half-open range `[startMarker, endMarker)` and stops — but `endMarker` was appended to the mount by that same effect run (`m.appendChild(endMarker)`) and nothing else ever removes it:

```ts
let c: Node | null = startMarker;
while (c && c !== endMarker) {   // ← endMarker itself survives every cleanup
  const n: Node | null = c.nextSibling;
  m.removeChild(c);
  c = n;
}
```

Switching `props.mount` does *not* leak into the previous mount — the next run's `appendChild(endMarker)` moves the surviving marker into the new mount — so the stranding materializes exactly once per unmount.

## Fix

Make the removal range inclusive: the loop now removes through `endMarker` and stops there. Four lines, no behavior change beyond the mount target being left truly empty.

## Solid 1.x note

Verified on `solid-js@1.9.14` with the identical toggle sequence: the mount target holds 0 child nodes after every close and after final disposal. Clean regression, no caveats.

## Tests

Three red-first tests in `test/portal.spec.tsx` ("Testing Portal marker cleanup"), all asserting on `childNodes.length` since `innerHTML` checks stay green even with stranded markers — which is exactly why the existing disposal tests never caught this:

- disposing a Portal leaves the mount at 0 child nodes
- 5× `<Show>` toggle cycles accumulate nothing
- switching mounts leaves no markers behind in either mount

All three confirmed failing against the unfixed build. Full solid-web client suite, the separately-configured hydration suite, and the server suite all pass at their existing baselines.

Full disclosure: I wrote this with the help of an AI assistant (Claude Fable 5) and reviewed every line before pushing. All new tests were written first and confirmed failing on the unfixed code, and the leak and the fix were verified in both jsdom and the [StackBlitz repro app](https://stackblitz.com/edit/solidjs-templates-kt1gg3uf?file=src%2FApp.tsx).