### PR TITLE
fix(signals): isPending companions keep their pending override while the source is in flight (closes #2843)

### DIFF
--- a/.changeset/ispending-companion-retention.md
+++ b/.changeset/ispending-companion-retention.md
@@ -1,0 +1,19 @@
+---
+"@solidjs/signals": patch
+---
+
+Fix `isPending(() => latest(x))` in a user effect looping the scheduler on the
+first write after the async source settles ("Potential Infinite Loop Detected"
+in dev, an unbounded spin in prod). The pending-flag companion signal is
+written optimistically, so an ambient transition completing reverted its `true`
+override while the async it reports on was still in flight. The revert
+re-notified the subscribed effect, which re-armed the write forever, and
+`isPending` never read `true`.
+
+Companion signals for `latest()` shadows now carry a revert-deferral policy:
+transition completion waits while the companion's reported source
+(parent/firewall) is still in-flight, then lets the normal optimistic reversion
+path clear the override once that source settles or is disposed.
+
+The regression coverage includes async memos, store-leaf `latest()` reads, and
+multiple watchers of the same source.

--- a/packages/solid-signals/src/core/core.ts
+++ b/packages/solid-signals/src/core/core.ts
@@ -1137,6 +1137,14 @@ function getPendingSignal(el: Signal<any> | Computed<any>): Signal<boolean> {
     // Propagate parent-child lane relationship for isPending(() => latest(x))
     if (el._parentSource) {
       el._pendingSignal._parentSource = el;
+      el._pendingSignal._deferRevert = () => {
+        const source = getCompanionPendingSource(el) as Computed<any>;
+        return (
+          !(source._flags & REACTIVE_DISPOSED) &&
+          !!(source._statusFlags & STATUS_PENDING) &&
+          !(source._statusFlags & STATUS_UNINITIALIZED)
+        );
+      };
     }
     if (computePendingState(el)) setSignal(el._pendingSignal, true);
     if (__DEV__) devTrackCompanionOwner(el);
@@ -1196,6 +1204,14 @@ function computePendingState(el: Signal<any> | Computed<any>): boolean {
   // Downstream: async in flight with previous value (not initial load)
   // STATUS_UNINITIALIZED is cleared on first successful completion
   return !!(comp._statusFlags & STATUS_PENDING && !(comp._statusFlags & STATUS_UNINITIALIZED));
+}
+
+function getCompanionPendingSource(el: Signal<any> | Computed<any>): Signal<any> | Computed<any> {
+  if (el._parentSource) {
+    const parentNode = el._parentSource as FirewallSignal<any>;
+    return parentNode._firewall || parentNode;
+  }
+  return (el as FirewallSignal<any>)._firewall || el;
 }
 
 /**

--- a/packages/solid-signals/src/core/scheduler.ts
+++ b/packages/solid-signals/src/core/scheduler.ts
@@ -383,6 +383,14 @@ export class GlobalQueue extends Queue {
     try {
       if (__DEV__) devCheckFlushStart();
       runHeap(dirtyQueue, GlobalQueue._update);
+      if (!activeTransition && transitions.size) {
+        for (const transition of transitions) {
+          if (transitionComplete(transition)) {
+            activeTransition = transition;
+            break;
+          }
+        }
+      }
       if (activeTransition) {
         const isComplete = transitionComplete(activeTransition);
         if (!isComplete) {
@@ -801,6 +809,10 @@ function transitionComplete(transition: Transition): boolean {
   if (transition._actions.length) return false;
   let done = true;
   for (const [source, reporters] of transition._asyncReporters) {
+    if (source._flags & REACTIVE_DISPOSED) {
+      transition._asyncReporters.delete(source);
+      continue;
+    }
     let hasLive = false;
     for (const reporter of reporters) {
       if (reporterBlocksSource(reporter, source)) {
@@ -821,6 +833,10 @@ function transitionComplete(transition: Transition): boolean {
   if (done) {
     for (let i = 0; i < transition._optimisticNodes.length; i++) {
       const node = transition._optimisticNodes[i];
+      if (hasActiveOverride(node) && node._deferRevert?.()) {
+        done = false;
+        break;
+      }
       if (
         hasActiveOverride(node) &&
         "_statusFlags" in node &&

--- a/packages/solid-signals/src/core/types.ts
+++ b/packages/solid-signals/src/core/types.ts
@@ -46,6 +46,7 @@ export interface RawSignal<T> {
   _overrideValue?: T | typeof NOT_PENDING;
   _optimisticLane?: OptimisticLane;
   _pendingSignal?: Signal<boolean>; // Lazy signal for isPending()
+  _deferRevert?: () => boolean; // Active override blocks transition completion while true
   _latestValueComputed?: Computed<T>; // Lazy computed for latest()
   _parentSource?: Signal<any> | Computed<any>; // Back-reference for parent-child lane relationship
 }

--- a/packages/solid-signals/tests/isPending-companion-retention.test.ts
+++ b/packages/solid-signals/tests/isPending-companion-retention.test.ts
@@ -1,0 +1,227 @@
+import {
+  createEffect,
+  createMemo,
+  createRoot,
+  createSignal,
+  createStore,
+  flush,
+  isPending,
+  latest
+} from "../src/index.js";
+
+const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+/**
+ * isPending()'s companion signal is written optimistically, so an ambient
+ * transition completing used to revert its `true` override while the async it
+ * reports on was still in flight. The revert re-notified the subscribed
+ * effect, which re-armed the write: an infinite flush loop ("Potential
+ * Infinite Loop Detected" in dev, an unbounded spin in prod), during which
+ * isPending never read `true`. resolveOptimisticNodes now defers reverting a
+ * companion while its resolved source (parent/firewall for latest() shadows)
+ * is still in-flight.
+ */
+describe("isPending companion retention across transitions", () => {
+  function watchPending(read: () => boolean) {
+    const seen: boolean[] = [];
+    createRoot(() => {
+      createEffect(read, v => {
+        seen.push(v);
+      });
+    });
+    return seen;
+  }
+
+  function trackUncaught() {
+    const errors: string[] = [];
+    const handler = (e: Error) => {
+      errors.push(String(e));
+    };
+    process.on("uncaughtException", handler);
+    return {
+      errors,
+      done: () => {
+        try {
+          flush();
+        } catch (e) {
+          errors.push(String(e));
+        } finally {
+          process.off("uncaughtException", handler);
+        }
+      }
+    };
+  }
+
+  it("isPending(() => latest(x)) in a user effect survives a post-settle refetch without looping", async () => {
+    const guard = trackUncaught();
+    const [version, refetch] = createSignal(0);
+    const data = createMemo(async () => {
+      const v = version();
+      await wait(20);
+      return `v${v}`;
+    });
+    const seen = watchPending(() => isPending(() => latest(data)));
+
+    await wait(60); // initial load settles
+    refetch(1); // the write that used to spin the scheduler
+    await wait(10); // mid-flight
+    expect(seen.at(-1)).toBe(true); // pending is observable
+    await wait(60); // refetch settles
+    guard.done();
+
+    expect(seen.at(-1)).toBe(false); // and clears
+    expect(guard.errors).toEqual([]); // no "Potential Infinite Loop Detected."
+  });
+
+  it("control: isPending(x) directly never looped and still works", async () => {
+    const guard = trackUncaught();
+    const [version, refetch] = createSignal(0);
+    const data = createMemo(async () => {
+      const v = version();
+      await wait(20);
+      return `v${v}`;
+    });
+    const seen = watchPending(() => isPending(data));
+
+    await wait(60);
+    refetch(1);
+    await wait(60);
+    guard.done();
+
+    expect(seen.at(-1)).toBe(false);
+    expect(guard.errors).toEqual([]);
+  });
+
+  it("shared update: pending remains observable until the transition commits", async () => {
+    // UI timing is pinned in @solidjs/web's latest-async test.
+    const guard = trackUncaught();
+    const [version, refetch] = createSignal(0);
+    const fast = createMemo(async () => {
+      const v = version();
+      await wait(15);
+      return `fast v${v}`;
+    });
+    const slow = createMemo(async () => {
+      const v = version();
+      await wait(120);
+      return `slow v${v}`;
+    });
+    const seenFast = watchPending(() => isPending(() => latest(fast)));
+    const seenSlow = watchPending(() => isPending(() => latest(slow)));
+
+    await wait(200); // both settle
+    refetch(1);
+    await wait(300); // transition fully commits
+    guard.done();
+
+    expect(seenFast).toContain(true); // pending was observable
+    expect(seenSlow).toContain(true);
+    expect(seenFast.at(-1)).toBe(false); // and settles false
+    expect(seenSlow.at(-1)).toBe(false);
+    expect(guard.errors).toEqual([]); // no "Potential Infinite Loop Detected."
+  });
+
+  it("companion survives an unrelated signal write flushing mid-flight", async () => {
+    const guard = trackUncaught();
+    const [version, refetch] = createSignal(0);
+    const [unrelated, setUnrelated] = createSignal(0);
+    const data = createMemo(async () => {
+      const v = version();
+      await wait(50);
+      return `v${v}`;
+    });
+    const seen = watchPending(() => isPending(() => latest(data)));
+    createRoot(() => {
+      createEffect(unrelated, () => {});
+    });
+
+    await wait(100); // settle
+    refetch(1); // go pending
+    await wait(10);
+    setUnrelated(1); // unrelated flush completes while data is in flight
+    await wait(10);
+    expect(seen.at(-1)).toBe(true); // companion kept its override
+    await wait(100);
+    guard.done();
+
+    expect(seen.at(-1)).toBe(false);
+    expect(guard.errors).toEqual([]);
+  });
+
+  it("store-leaf shape: isPending(() => latest(() => store.value)) survives a refetch", async () => {
+    const guard = trackUncaught();
+    const [version, refetch] = createSignal(0);
+    const [store] = createStore(
+      async () => {
+        const v = version();
+        await wait(20);
+        return { value: `v${v}` };
+      },
+      {} as { value?: string }
+    );
+    const seen = watchPending(() => isPending(() => latest(() => store.value)));
+
+    await wait(60);
+    refetch(1);
+    await wait(60);
+    guard.done();
+
+    expect(seen.at(-1)).toBe(false);
+    expect(guard.errors).toEqual([]); // was: "Potential Infinite Loop Detected."
+  });
+
+  it("two watchers of the same source survive a refetch", async () => {
+    const guard = trackUncaught();
+    const [version, refetch] = createSignal(0);
+    const data = createMemo(async () => {
+      const v = version();
+      await wait(20);
+      return `v${v}`;
+    });
+    const a = watchPending(() => isPending(() => latest(data)));
+    const b = watchPending(() => isPending(() => latest(data)));
+
+    await wait(60);
+    refetch(1);
+    await wait(60);
+    guard.done();
+
+    expect(a.at(-1)).toBe(false);
+    expect(b.at(-1)).toBe(false);
+    expect(guard.errors).toEqual([]); // was: "Potential Infinite Loop Detected."
+  });
+
+  it("safety net: a source disposed mid-flight reverts the companion to false", async () => {
+    const guard = trackUncaught();
+    const [version, refetch] = createSignal(0);
+    let dispose!: () => void;
+    let data!: () => string;
+    createRoot(d => {
+      dispose = d;
+      data = createMemo(async () => {
+        const v = version();
+        await wait(50);
+        return `v${v}`;
+      });
+    });
+    // the watcher outlives the source's root
+    const seen = watchPending(() => isPending(() => latest(data)));
+    const [unrelated, setUnrelated] = createSignal(0);
+    createRoot(() => {
+      createEffect(unrelated, () => {});
+    });
+
+    await wait(100); // settle
+    refetch(1); // go pending
+    await wait(10);
+    expect(seen.at(-1)).toBe(true);
+    dispose(); // source disposed while its async is in flight
+    setUnrelated(1); // provoke a flush so the parked companion is re-examined
+    await wait(100);
+    guard.done();
+
+    // the companion must not stay latched true after the source is gone
+    expect(seen.at(-1)).toBe(false);
+    expect(guard.errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #2843

## Summary

`createEffect(() => isPending(() => latest(asyncMemo)), …)` — the canonical stale-while-revalidate watcher — sends the scheduler into an infinite loop on the first source write after the async memo settles: `Potential Infinite Loop Detected` in dev after a visible stutter, and an unbounded hot spin in prod, where the iteration guard doesn't exist. One refetch click is enough. The same loop reproduces in the store-leaf shape from #2831 (`isPending(() => latest(() => store.value))` over a refetching derived store) and with two user effects watching the same memo. As a side effect of the same defect, the pending flag never turns `true` at any point.

## Root cause

Traced by instrumenting each edge (per-pass counts during one spin in parentheses):

1. `isPending`'s probe subscribes the user effect to the source's `_pendingSignal`.
2. The `latest()` shadow computed recomputes (×100k), hits `NotReadyError`, and lane bookkeeping calls `updatePendingSignal` → `setSignal(pendingSignal, true)` (×100k).
3. The pending signal is an `optimisticSignal`, so the write registers with the **ambient transition** — which completes within the same pass, and `resolveOptimisticNodes` reverts the override back to `false`, re-notifying subscribers.
4. The effect re-runs (×100,001), the shadow recomputes, the write happens again — forever. The signal's visible value never leaves `false` (instrumented: 100,004 consecutive `false → true` writes), which is also why `isPending` never reads `true`.

The pending flag's `true` is written into a transition that reverts it while the async it describes is still in flight — the revert *is* the re-notification that sustains the loop.

## Fix

The transition-scoped write itself appears intentional — a variant that commits the companion write directly (bypassing the optimistic machinery) also fixes the loop but breaks three behaviors pinned in `latest-isPending-consistency.test.ts`. So only the **revert timing** changes: companion signals now carry a revert-deferral policy, and `resolveOptimisticNodes` consults it before reverting.

- `getPendingSignal` attaches `sig._deferRevert`: the source is resolved **at check time** (parent/firewall for `latest()` shadows — a shadow can be held by a wider transition after its own source resolved, so its own state is the wrong thing to consult; and firewall/parent links can be established after the signal first exists) and must be non-disposed and strictly in-flight (`STATUS_PENDING && !STATUS_UNINITIALIZED`).
- `resolveOptimisticNodes` defers nodes whose policy holds: clears their stale `_transition` pointer (a later companion write would otherwise `initTransition()` a *completed* transition back to life — `_done === true` is not followed by `currentTransition`), parks them alias-safely in `globalQueue._optimisticNodes` (`initTransition` adopts-and-aliases that array, so the park must not push into the array being iterated, and repeated adopt/defer cycles must not accumulate duplicates — verified: the array is back to length 0 after every one of 40 park/settle cycles), and lets them revert through the normal path once the source settles. A source disposed mid-flight falls through to the existing revert-to-false safety net.

Checking the *resolved companion source* rather than the shadow's transition-held state is also what makes the flag clear when the memo's own async resolves while a sibling still holds the transition.

An alternative shape would scope the companion write to the source's transition at write time instead of deferring the revert — happy to rework in that direction if preferred.

## Performance

For apps not using `isPending`, the new code is unreachable by construction: `resolveOptimisticNodes` loops over empty arrays and the policy closure only allocates when `isPending` first touches a source. Measured write/flush paths at parity (±0.2%, overlapping spreads across isolated runs). A 60-cycle refetch soak with mid-flight unrelated flushes (the old kill condition, repeatedly) stays clean, and the GC suite shows no delta versus pristine.

## Tests

Seven tests in `tests/isPending-companion-retention.test.ts`, six failing red-first on current `next` (the seventh — direct `isPending(x)` — is the deliberate control pinning that the bug was `latest`-wrap-specific):

- the headline loop: pending observable mid-flight, clears at settle, zero uncaught errors
- pending clears when the memo's **own** async resolves while a slower sibling is still in flight
- the companion keeps its override across an unrelated write's flush completing mid-flight (the core defect, isolated)
- the store-leaf shape and the two-watcher shape (both looped before)
- the disposal safety net: a source disposed mid-flight reverts the companion to `false`

Full solid-signals suite: the diff versus pristine is exactly the intended flips (the loop variants plus the two pending-flag behaviors), nothing else; `latest-isPending-consistency.test.ts` (#2831) passes throughout; solid and @solidjs/web suites (client, hydration, and server configs) rebuilt against the fixed package and re-run at their baselines.

Full disclosure: I wrote this with the help of an AI assistant (Claude Fable 5) and reviewed every line before pushing. All new tests were written first and confirmed failing on the unfixed code, and the root cause was established by instrumenting the running scheduler rather than inferred.