### PR TITLE
fix(signals): settle async-generator actions on uncaught errors instead of freezing

### DIFF
--- a/packages/solid-signals/src/core/action.ts
+++ b/packages/solid-signals/src/core/action.ts
@@ -76,8 +76,10 @@ export function action<Args extends any[], Y, R>(
         } catch (e) {
           return done(undefined, e);
         }
-        if (isThenable(r))
-          return void r.then(run, e => restoreTransition(ctx, () => step(e, true)));
+        // A rejected iterator result (async generators) means the error already
+        // escaped the generator body — it is completed, and throwing back in
+        // would just reject again forever. Settle instead.
+        if (isThenable(r)) return void r.then(run, e => done(undefined, e));
         run(r);
       };
 

--- a/packages/solid-signals/tests/action.test.ts
+++ b/packages/solid-signals/tests/action.test.ts
@@ -886,6 +886,73 @@ describe("action", () => {
       await expect(myAction()).rejects.toThrow("error after yield");
     });
 
+    it("should reject the promise when an async generator throws immediately", async () => {
+      const myAction = action(async function* () {
+        throw new Error("boom");
+      });
+
+      await expect(myAction()).rejects.toThrow("boom");
+
+      // The event loop must not be starved — a macrotask still runs
+      await new Promise<void>(r => setTimeout(r, 0));
+    });
+
+    it("should reject the promise when an async generator throws after an await", async () => {
+      const myAction = action(async function* () {
+        await Promise.resolve();
+        yield undefined;
+        throw new Error("async error after yield");
+      });
+
+      await expect(myAction()).rejects.toThrow("async error after yield");
+    });
+
+    it("should allow try/catch inside async generator for awaited rejections", async () => {
+      const steps: string[] = [];
+
+      const myAction = action(async function* () {
+        steps.push("start");
+        try {
+          yield Promise.reject(new Error("test error"));
+          steps.push("unreachable");
+        } catch (e: any) {
+          steps.push("caught: " + e.message);
+        }
+        steps.push("end");
+      });
+
+      await myAction();
+      expect(steps).toEqual(["start", "caught: test error", "end"]);
+    });
+
+    it("should complete the transition when an async generator throws", async () => {
+      const [$x, setX] = createSignal(0);
+
+      const errorAction = action(async function* () {
+        setX(1);
+        yield undefined;
+        throw new Error("async boom");
+      });
+
+      const successAction = action(function* () {
+        setX(v => v + 10);
+        yield Promise.resolve();
+        yield Promise.resolve();
+        setX(v => v + 100);
+      });
+
+      const errorPromise = errorAction();
+      successAction();
+      flush();
+      expect($x()).toBe(0); // Held
+
+      await expect(errorPromise).rejects.toThrow("async boom");
+
+      // Error action was removed from the transition, so it can still commit
+      await new Promise<void>(r => setTimeout(r, 0));
+      expect($x()).toBe(111); // 1 + 10 + 100
+    });
+
     it("should remove action from transition on error but let transition continue", async () => {
       const [$x, setX] = createSignal(0);
 


### PR DESCRIPTION
## Summary

Fixes #2841 — an uncaught error inside an async-generator `action()` froze the JS thread: the returned promise never settled, the event loop was starved by an infinite microtask loop, and the transition never completed because the iterator was never removed from `_actions`.

## Root cause

When an async generator's body throws, `it.next()` returns a **rejected promise** with the generator already in the completed state. The action runner responded to that rejection by calling `it.throw(e)` — but `throw()` on a completed async generator just returns another rejected promise, whose rejection handler called `it.throw(e)` again, forever. Each iteration is a microtask, so the loop starves the event loop (frozen tab / hung process). Sync generators were unaffected because their `it.next()` throws synchronously, which was already handled.

## Fix

A rejected iterator-result promise is terminal: async generators run user `try`/`catch`/`finally` internally before the rejection ever reaches the runner. So the rejection handler now settles the action via `done(undefined, e)` — mirroring how the fulfilled path handles `done: true`. The returned promise rejects, the iterator is removed from the transition's `_actions`, and the transition can complete.

`try/catch` around `yield`/`await` inside async generators still works (handled by the generator machinery itself), and the sync-generator `it.throw` path for yielded promise rejections is unchanged.

## Tests

Four regression tests in `action.test.ts`:
- immediate throw in an async generator rejects and does not starve the event loop (the issue's repro — this test hangs without the fix)
- throw after an `await`/`yield` rejects
- `try/catch` inside an async generator around an awaited rejection recovers and continues
- a failing async-generator action is removed from the transition so a concurrent action still commits

Full solid-signals suite passes (818 tests, 49 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)