### PR TITLE
fix(store): snapshot() and deep() preserve array length when trailing indices were deleted (closes #2846)

### DIFF
--- a/.changeset/snapshot-trailing-holes.md
+++ b/.changeset/snapshot-trailing-holes.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Fix `snapshot()` and `deep()` silently shrinking an array's length when trailing indices were deleted. `delete arr[i]` on a store leaves a hole without changing `length` — plain JS semantics, and every proxy-side read agrees — but the copy loop skipped `$DELETED` slots without restoring the result's length afterwards, so trailing holes truncated the copy (at any nesting depth, for either API). The array branch of `snapshotImpl` now restores the length after the loop, mirroring `unwrapStoreValue`, so deleted slots stay holes (`i in copy === false`, serialized as `null`).

--- a/packages/solid-signals/src/store/utils.ts
+++ b/packages/solid-signals/src/store/utils.ts
@@ -56,6 +56,8 @@ function snapshotImpl<T>(
         result[i] = unwrapped;
       }
     }
+    // Deleted trailing slots are skipped above, so restore length to preserve holes.
+    if (result) result.length = len;
   } else {
     const keys = getKeys(item, override);
     for (let i = 0, l = keys.length; i < l; i++) {

--- a/packages/solid-signals/tests/store/utilities.test.ts
+++ b/packages/solid-signals/tests/store/utilities.test.ts
@@ -651,6 +651,66 @@ describe("deep", () => {
 });
 
 describe("snapshot", () => {
+  test("preserves array length when a trailing index was deleted", () => {
+    const [state, setState] = createStore<(string | undefined)[]>(["a", "b", "c"]);
+    setState(s => {
+      delete s[2];
+    });
+    flush();
+    expect(state.length).toBe(3); // proxy: plain-JS delete semantics
+
+    const copy = snapshot(state);
+    expect(copy.length).toBe(3); // the copy must agree with the store
+    expect(2 in copy).toBe(false); // and keep the hole a hole, not undefined
+    expect(JSON.stringify(copy)).toBe('["a","b",null]');
+  });
+
+  test("deep() preserves array length for trailing holes too", () => {
+    const [state, setState] = createStore<(string | undefined)[]>(["a", "b", "c"]);
+    setState(s => {
+      delete s[2];
+    });
+    flush();
+    createRoot(dispose => {
+      const copy = deep(state);
+      expect(copy.length).toBe(3);
+      expect(2 in copy).toBe(false);
+      dispose();
+    });
+  });
+
+  test("preserves length for nested arrays and multi-hole runs", () => {
+    const [state, setState] = createStore<{ list: (string | undefined)[] }>({
+      list: ["a", "b", "c", "d"]
+    });
+    setState(s => {
+      delete s.list[2];
+      delete s.list[3];
+    });
+    flush();
+    const copy = snapshot(state);
+    expect(copy.list.length).toBe(4);
+    expect(JSON.stringify(copy.list)).toBe('["a","b",null,null]');
+  });
+
+  test("middle holes and length truncation keep working (controls)", () => {
+    const [mid, setMid] = createStore<(string | undefined)[]>(["a", "b", "c"]);
+    setMid(s => {
+      delete s[1];
+    });
+    flush();
+    expect(JSON.stringify(snapshot(mid))).toBe('["a",null,"c"]');
+    expect(snapshot(mid).length).toBe(3);
+
+    const [cut, setCut] = createStore<string[]>(["a", "b", "c"]);
+    setCut(s => {
+      s.length = 2;
+    });
+    flush();
+    expect(snapshot(cut).length).toBe(2);
+    expect(JSON.stringify(snapshot(cut))).toBe('["a","b"]');
+  });
+
   test("returns same object if unchanged", () => {
     const ref = { a: 1, b: 2 };
     const [state, setState] = createStore(ref);


### PR DESCRIPTION
Closes #2846

## Summary

`delete arr[i]` on an array store leaves a hole without changing `length` — plain JavaScript semantics, and every proxy-side path agrees (`store.length`, `JSON.stringify(store)`, `[...store]`, `store.map`, `Array.from` all yield `["a","b",null]`). But both copy APIs return an array whose length has silently shrunk: `snapshot(store)` and `deep(store)` drop trailing holes entirely, at any nesting depth, and multi-hole runs shrink by the full run. The store disagrees only with its own materialized copies — any consumer that serializes, diffs, or `reconcile()`s the copy sees silently lost slots.

https://stackblitz.com/edit/solidjs-templates-dvf3msqv?file=src%2FApp.tsx

## Root cause

The array branch of `snapshotImpl` (`packages/solid-signals/src/store/utils.ts`) skips `$DELETED` slots but never restores the result's length afterwards, so a copy ends at the last written index:

```ts
for (let i = 0; i < len; i++) {
  v = override && i in override ? override[i] : item[i];
  if (v === $DELETED) continue;   // ← skipped; result never reaches index i
  ...
  result[i] = unwrapped;
}
```

The sibling path `unwrapStoreValue` (used by the set trap) handles the identical situation correctly by restoring the length after its loop (`store.ts`: `result.length = override.length ?? source.length`). This is the one divergent site.

## Fix

One line, mirroring `unwrapStoreValue`: after the array loop, `if (result) result.length = len;`. Deleted slots stay true holes (`i in copy === false`, serialized as `null`), matching plain-JS `delete` and the proxy's own view. By construction it can't overreach: the loop only writes indices `< len` so the restoration never truncates written data, the `if (result)` guard leaves the identity/no-copy path untouched, and `len` already honors `override.length` so length-truncation writes keep working. One change covers every affected variant, since `snapshot()` and `deep()` share the implementation and nesting recurses through it.

## Tests

Four tests added to the existing `snapshot` describe in `tests/store/utilities.test.ts`, three confirmed failing red-first on the unfixed source:

- trailing hole: copy keeps `length 3`, the hole stays a *hole* (`2 in copy === false`), serializes as `["a","b",null]`
- `deep()` with the same shape
- nested array + multi-hole run (`{ list: ["a","b",<hole>,<hole>] }` keeps `length 4`)
- controls (passing before and after): middle holes preserved, `length`-truncation writes still truncate

Edge shapes probed additionally: deleting the only element (`[null]`, length 1, index still a hole), `length`-extension with a delete in the extended region, mixed middle+trailing holes. Full solid-signals suite: the diff versus pristine is exactly the intended flips; solid and @solidjs/web rebuilt and re-run at their baselines; test files pass the tests-inclusive typecheck.

## Solid 1.x note

Regression from 1.x, verified on 1.9.14 with the 1.x equivalents (`setState(2, undefined)` to delete; `unwrap` as the copy): both `state.length` and `unwrap(state).length` remain `3` after deleting the trailing index — a hole, matching plain-JS `delete` semantics. 2.0's copies shrink instead.

Full disclosure: I wrote this with the help of an AI assistant (Claude Fable 5) and reviewed every line before pushing. The tests were written first and confirmed failing on the unfixed code, and the affected/unaffected variant boundary was established by probing each shape individually.