### PR TITLE
fix(signals): settle resolve() when the async source rejects

### DIFF
--- a/packages/solid-signals/src/signals.ts
+++ b/packages/solid-signals/src/signals.ts
@@ -23,6 +23,7 @@ import {
   untrack
 } from "./core/index.js";
 import { emitDiagnostic, registerGraph } from "./core/dev.js";
+import { StatusError } from "./core/error.js";
 import { globalQueue } from "./core/scheduler.js";
 
 /**
@@ -588,7 +589,9 @@ export function createReaction(
  * Awaits a reactive expression and returns its first fully-settled value as a
  * `Promise`. Pending async reads (`createMemo` returning a promise, etc.) are
  * waited on; once the expression returns synchronously without `NotReadyError`
- * the promise resolves with that value.
+ * the promise resolves with that value. If the expression settles with an
+ * error instead — including an async source that rejects — the promise
+ * rejects with it.
  *
  * Must be called *outside* a tracking scope — it doesn't subscribe, it just
  * resolves the current value once.
@@ -611,15 +614,24 @@ export function resolve<T>(fn: () => T): Promise<T> {
   }
   return new Promise((res, rej) => {
     createRoot(dispose => {
-      computed(() => {
-        try {
-          res(fn());
-        } catch (err) {
-          if (err instanceof NotReadyError) throw err;
-          rej(err);
-        }
-        dispose();
-      });
+      // A user effect rather than a bare computed: computeds are pull-based and
+      // are only re-enqueued when a pending source *resolves* — a rejection just
+      // marks them errored, so nothing would re-run and the promise would never
+      // settle (#2842). The effect's error channel is notified on rejection.
+      effect(
+        fn,
+        value => {
+          res(value);
+          dispose();
+        },
+        err => {
+          // Compute-phase errors arrive wrapped for source tracking; reject
+          // with the user's original error like error boundaries do.
+          rej(err instanceof StatusError ? (err.cause ?? err) : err);
+          dispose();
+        },
+        { user: true }
+      );
     });
   });
 }

--- a/packages/solid-signals/tests/resolve.test.ts
+++ b/packages/solid-signals/tests/resolve.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Pins `resolve()`'s settlement contract (#2842).
+ *
+ * `resolve(fn)` must settle for every terminal state of the expression:
+ *   - resolves with the first fully-settled value (async or sync)
+ *   - rejects with the original error when the async source rejects after
+ *     having been pending
+ *   - rejects when the expression throws synchronously
+ * and it must dispose its internal root in all of those cases — a rejection
+ * that leaves the promise forever-pending also leaks the root (#2842).
+ */
+import { describe, expect, it, vi } from "vitest";
+import { createMemo, createRoot, createSignal, onCleanup, resolve } from "../src/index.js";
+
+const delay = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+describe("resolve settlement (#2842)", () => {
+  it("rejects with the original error when the async source rejects after pending", async () => {
+    const boom = new Error("boom");
+    await createRoot(async dispose => {
+      const m = createMemo(async () => {
+        await delay(5);
+        throw boom;
+      });
+
+      await expect(resolve(() => m())).rejects.toBe(boom);
+      dispose();
+    });
+  });
+
+  it("disposes its internal root when the source rejects", async () => {
+    const cleanupSpy = vi.fn();
+    await createRoot(async dispose => {
+      const m = createMemo(async () => {
+        await delay(5);
+        throw new Error("boom");
+      });
+
+      await resolve(() => {
+        onCleanup(cleanupSpy);
+        return m();
+      }).catch(() => {});
+
+      expect(cleanupSpy).toHaveBeenCalled();
+      dispose();
+    });
+  });
+
+  it("still resolves with the settled value when the source resolves", async () => {
+    await createRoot(async dispose => {
+      const [s] = createSignal(7);
+      const m = createMemo(async () => {
+        await delay(5);
+        return s() * 2;
+      });
+
+      await expect(resolve(() => m())).resolves.toBe(14);
+      dispose();
+    });
+  });
+
+  it("rejects when the expression throws synchronously", async () => {
+    const boom = new Error("sync-boom");
+    await createRoot(async dispose => {
+      await expect(
+        resolve(() => {
+          throw boom;
+        })
+      ).rejects.toBe(boom);
+      dispose();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2842 — `resolve(fn)` hung forever (never resolved, never rejected) and leaked its internal `createRoot` whenever the awaited async source **rejected** after having been pending. Resolution worked; rejection did not.

## Root cause

`resolve()` was built on a bare `computed` inside a root, and computeds are pull-based. The two settlement paths are asymmetric:

- When a pending source **resolves**, `settlePendingSource()` explicitly re-enqueues blocked dependents, so the computed re-ran, called `res(fn())`, and disposed the root.
- When a pending source **rejects**, `handleAsync`'s error path only propagates `STATUS_ERROR` through `notifyStatus()`, which *marks* subscribers errored for their next pull but never re-runs them. Nothing ever reads `resolve()`'s computed (it has no subscribers), so neither `res` nor `rej` fired and `dispose()` never ran.

## Fix

Rebuild `resolve()` on a **user effect** — the primitive that owns an error-notification channel (`_notifyStatus` → `_errorFn`) and is therefore actively told when a pending source rejects:

- effect callback → `res(value)` + dispose (same observable timing as before)
- error callback → `rej(err)` + dispose, unwrapping the internal `StatusError` wrapper so the promise rejects with the user's original error, matching what `createErrorBoundary` exposes

Also documents the rejection behavior in the JSDoc.

## Tests

New `tests/resolve.test.ts` pins the settlement contract:

- rejects with the original error when the async source rejects after pending *(hung before this fix)*
- disposes the internal root on rejection *(hung before this fix)*
- still resolves with the settled value on success
- rejects on a synchronous throw

Full `solid-signals` suite (814 tests) and `solid` suite (418 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)