### PR TITLE
fix(store): reconcile() notifies symbol-keyed properties (closes #2851)

### DIFF
--- a/.changeset/reconcile-symbol-keyed-nodes.md
+++ b/.changeset/reconcile-symbol-keyed-nodes.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Fix `reconcile()` updates for symbol-keyed store properties so tracked reads and `in` checks are notified like string-keyed properties.

--- a/packages/solid-signals/src/store/reconcile.ts
+++ b/packages/solid-signals/src/store/reconcile.ts
@@ -1,9 +1,9 @@
 import { setSignal } from "../core/index.js";
 import {
+  $DELETED,
   $PROXY,
   $TARGET,
   $TRACK,
-  getKeys,
   isWrappable,
   STORE_HAS,
   STORE_LOOKUP,
@@ -13,22 +13,56 @@ import {
   STORE_VALUE,
   notifySelf,
   storeLookup,
+  symbolKeyedRecords,
   wrap
 } from "./store.js";
+
+function nodeKeys(nodes: Record<PropertyKey, any>): PropertyKey[] {
+  const keys: PropertyKey[] = Object.keys(nodes);
+  // Keep the common string-key path cheap; only symbol-tracked records pay for
+  // symbol enumeration. `$TRACK` is handled separately by callers.
+  if (symbolKeyedRecords.has(nodes)) {
+    const syms = Object.getOwnPropertySymbols(nodes);
+    for (let i = 0, len = syms.length; i < len; i++) {
+      if (syms[i] !== $TRACK) keys.push(syms[i]);
+    }
+  }
+  return keys;
+}
 
 function unwrap(value: any) {
   return value?.[$TARGET]?.[STORE_VALUE] ?? value;
 }
 
-function getOverrideValue(value: any, override: any, key: string, optOverride?: any) {
+function getOverrideValue(value: any, override: any, key: PropertyKey, optOverride?: any) {
   if (optOverride && key in optOverride) return optOverride[key];
   return override && key in override ? override[key] : value[key];
 }
 
+// Append a value's *enumerable* own symbol keys. Symbol-free objects (the
+// common case) pay only an empty `getOwnPropertySymbols` call — no per-key
+// predicate — so the string fast path stays on `Object.keys`.
+function addEnumSymbols(o: any, keys: Set<PropertyKey>) {
+  const syms = Object.getOwnPropertySymbols(o);
+  for (let i = 0, len = syms.length; i < len; i++) {
+    if (Object.prototype.propertyIsEnumerable.call(o, syms[i])) keys.add(syms[i]);
+  }
+}
+
 function getAllKeys(value, override, next) {
-  const keys = getKeys(value, override) as string[];
+  // Reconcile must diff enumerable symbol keys the same way it diffs strings,
+  // but keep the string keys on the `Object.keys` fast path — symbols are
+  // appended only when the object actually has them.
+  const keys = new Set<PropertyKey>(Object.keys(value));
+  addEnumSymbols(value, keys);
+  if (override) {
+    for (const key of Reflect.ownKeys(override))
+      override[key] === $DELETED ? keys.delete(key) : keys.add(key);
+  }
   const nextKeys = Object.keys(next);
-  return Array.from(new Set([...keys, ...nextKeys]));
+  for (let i = 0, len = nextKeys.length; i < len; i++) keys.add(nextKeys[i]);
+  addEnumSymbols(next, keys);
+  return Array.from(keys);
 }
 
 // Array entries can be `null`/`undefined`/primitives, not just keyed objects.
@@ -54,14 +88,14 @@ function keyedMatch(a: any, b: any, keyFn: (item: NonNullable<any>) => any) {
 function syncArrayNodeMembership(target: any, next: any) {
   let nodes = target[STORE_NODE];
   if (nodes) {
-    const keys = Object.keys(nodes);
+    const keys = nodeKeys(nodes);
     for (let i = 0, len = keys.length; i < len; i++) {
       const key = keys[i];
       key in next || setSignal(nodes[key], undefined);
     }
   }
   if ((nodes = target[STORE_HAS])) {
-    const keys = Object.keys(nodes);
+    const keys = nodeKeys(nodes);
     for (let i = 0, len = keys.length; i < len; i++) {
       const key = keys[i];
       setSignal(nodes[key], key in next);
@@ -212,7 +246,7 @@ function applyStateFast(next: any, target: any, keyFn: (item: NonNullable<any>) 
   let nodes = target[STORE_NODE];
   if (nodes) {
     const tracked = nodes[$TRACK];
-    const keys = tracked ? getAllKeys(previous, undefined, next) : Object.keys(nodes);
+    const keys = tracked ? getAllKeys(previous, undefined, next) : nodeKeys(nodes);
     for (let i = 0, len = keys.length; i < len; i++) {
       const key = keys[i];
       const node = nodes[key];
@@ -234,7 +268,7 @@ function applyStateFast(next: any, target: any, keyFn: (item: NonNullable<any>) 
 
   // has
   if ((nodes = target[STORE_HAS])) {
-    const keys = Object.keys(nodes);
+    const keys = nodeKeys(nodes);
     for (let i = 0, len = keys.length; i < len; i++) {
       const key = keys[i];
       setSignal(nodes[key], key in next);
@@ -364,7 +398,7 @@ function applyStateSlow(next: any, target: any, keyFn: (item: NonNullable<any>) 
   // values
   if (nodes) {
     const tracked = nodes[$TRACK];
-    const keys = tracked ? getAllKeys(previous, override, next) : Object.keys(nodes);
+    const keys = tracked ? getAllKeys(previous, override, next) : nodeKeys(nodes);
     for (let i = 0, len = keys.length; i < len; i++) {
       const key = keys[i];
       const node = nodes[key];
@@ -386,7 +420,7 @@ function applyStateSlow(next: any, target: any, keyFn: (item: NonNullable<any>) 
 
   // has
   if ((nodes = target[STORE_HAS])) {
-    const keys = Object.keys(nodes);
+    const keys = nodeKeys(nodes);
     for (let i = 0, len = keys.length; i < len; i++) {
       const key = keys[i];
       setSignal(nodes[key], key in next);

--- a/packages/solid-signals/src/store/store.ts
+++ b/packages/solid-signals/src/store/store.ts
@@ -138,6 +138,8 @@ export function createStoreProxy<T extends object>(
 }
 
 export const storeLookup = new WeakMap();
+// Node records that hold at least one user symbol-keyed node.
+export const symbolKeyedRecords = new WeakSet<object>();
 export function wrap<T extends Record<PropertyKey, any>>(value: T, target?: StoreNode): T {
   if (target?.[STORE_WRAP]) return target[STORE_WRAP](value, target);
   let p = value[$PROXY] || storeLookup.get(value);
@@ -242,7 +244,22 @@ function getNode<T>(
     {
       equals: equals,
       unobserved() {
-        if (nodes[property] === s) delete nodes[property];
+        if (nodes[property] === s) {
+          delete nodes[property];
+          // Drop the symbol-record mark once the last user symbol node is
+          // gone, so reconcile's fast path stops probing a now string-only
+          // record. Runs only on symbol-node cleanup (cold), never on reconcile.
+          if (typeof property === "symbol" && property !== $TRACK && symbolKeyedRecords.has(nodes)) {
+            const syms = Object.getOwnPropertySymbols(nodes);
+            let hasUserSymbol = false;
+            for (let i = 0, len = syms.length; i < len; i++)
+              if (syms[i] !== $TRACK) {
+                hasUserSymbol = true;
+                break;
+              }
+            if (!hasUserSymbol) symbolKeyedRecords.delete(nodes);
+          }
+        }
       }
     },
     firewall
@@ -255,6 +272,8 @@ function getNode<T>(
     s._snapshotValue = sv === undefined ? NO_SNAPSHOT : sv;
     snapshotSources?.add(s);
   }
+  // Lets reconcile enumerate symbols only for records that need it.
+  if (typeof property === "symbol" && property !== $TRACK) symbolKeyedRecords.add(nodes);
   return (nodes[property] = s);
 }
 

--- a/packages/solid-signals/src/store/store.ts
+++ b/packages/solid-signals/src/store/store.ts
@@ -249,7 +249,11 @@ function getNode<T>(
           // Drop the symbol-record mark once the last user symbol node is
           // gone, so reconcile's fast path stops probing a now string-only
           // record. Runs only on symbol-node cleanup (cold), never on reconcile.
-          if (typeof property === "symbol" && property !== $TRACK && symbolKeyedRecords.has(nodes)) {
+          if (
+            typeof property === "symbol" &&
+            property !== $TRACK &&
+            symbolKeyedRecords.has(nodes)
+          ) {
             const syms = Object.getOwnPropertySymbols(nodes);
             let hasUserSymbol = false;
             for (let i = 0, len = syms.length; i < len; i++)

--- a/packages/solid-signals/tests/store/reconcile.test.ts
+++ b/packages/solid-signals/tests/store/reconcile.test.ts
@@ -537,6 +537,153 @@ describe("setState with reconcile", () => {
     expect(selectedName).toBe("b");
   });
 });
+
+describe("reconcile with symbol-keyed properties", () => {
+  const META = Symbol("meta");
+
+  test("notifies an effect tracking a symbol-keyed property", () => {
+    const [state, setState] = createStore<Record<PropertyKey, any>>({ id: 1, [META]: "old" });
+    let seen: any;
+    createRoot(() => {
+      createEffect(
+        () => state[META],
+        v => {
+          seen = v;
+        }
+      );
+    });
+    flush();
+    expect(seen).toBe("old");
+
+    setState(reconcile({ id: 1, [META]: "new" }, "id"));
+    flush();
+    expect(state[META]).toBe("new"); // value reachable, not shadowed by a stale node
+    expect(seen).toBe("new"); // subscriber notified
+  });
+
+  test("string control updates through the identical path", () => {
+    const [state, setState] = createStore<Record<PropertyKey, any>>({ id: 1, meta: "old" });
+    let seen: any;
+    createRoot(() => {
+      createEffect(
+        () => state.meta,
+        v => {
+          seen = v;
+        }
+      );
+    });
+    flush();
+
+    setState(reconcile({ id: 1, meta: "new" }, "id"));
+    flush();
+    expect(state.meta).toBe("new");
+    expect(seen).toBe("new");
+  });
+
+  test("string and symbol keys on the same store both update", () => {
+    const [state, setState] = createStore<Record<PropertyKey, any>>({ id: 1, label: "old", [META]: "old" });
+    let sawLabel: any, sawMeta: any;
+    createRoot(() => {
+      createEffect(
+        () => state.label,
+        v => {
+          sawLabel = v;
+        }
+      );
+      createEffect(
+        () => state[META],
+        v => {
+          sawMeta = v;
+        }
+      );
+    });
+    flush();
+
+    setState(reconcile({ id: 1, label: "new", [META]: "new" }, "id"));
+    flush();
+    expect(sawLabel).toBe("new");
+    expect(sawMeta).toBe("new");
+  });
+
+  test("a symbol key removed by reconcile notifies as undefined", () => {
+    const [state, setState] = createStore<Record<PropertyKey, any>>({ id: 1, [META]: "old" });
+    let seen: any = "unset";
+    createRoot(() => {
+      createEffect(
+        () => state[META],
+        v => {
+          seen = v;
+        }
+      );
+    });
+    flush();
+
+    setState(reconcile({ id: 1 }, "id"));
+    flush();
+    expect(state[META]).toBeUndefined();
+    expect(seen).toBeUndefined();
+  });
+
+  test("a symbol `in` check updates when reconcile adds the key", () => {
+    const [state, setState] = createStore<Record<PropertyKey, any>>({ id: 1 });
+    let has: boolean | undefined;
+    createRoot(() => {
+      createEffect(
+        () => META in state,
+        v => {
+          has = v;
+        }
+      );
+    });
+    flush();
+    expect(has).toBe(false);
+
+    setState(reconcile({ id: 1, [META]: "added" }, "id"));
+    flush();
+    expect(has).toBe(true);
+  });
+
+  test("perf invariant: symbol-record mark is set while tracked and cleared once unobserved", async () => {
+    // Guards the fast-path optimization: only records that currently hold a
+    // user symbol node are enumerated for symbols on reconcile. Asserts the
+    // internal mark rather than behavior (the mark is invisible to behavior).
+    const { symbolKeyedRecords, $TARGET, STORE_NODE } = await import("../../src/store/store.js");
+    const [store] = createStore<Record<PropertyKey, any>>({ id: 1, [META]: "x" });
+    let dispose!: () => void;
+    createRoot(d => {
+      dispose = d;
+      createEffect(
+        () => store[META],
+        () => {}
+      );
+    });
+    flush();
+    const nodes = (store as any)[$TARGET][STORE_NODE];
+    expect(symbolKeyedRecords.has(nodes)).toBe(true);
+    dispose();
+    flush();
+    expect(symbolKeyedRecords.has(nodes)).toBe(false); // no monotonic leak
+  });
+
+  test("nested symbol-keyed value reconciles", () => {
+    const [state, setState] = createStore<Record<PropertyKey, any>>({ id: 1, inner: { [META]: "old" } });
+    let seen: any;
+    createRoot(() => {
+      createEffect(
+        () => state.inner[META],
+        v => {
+          seen = v;
+        }
+      );
+    });
+    flush();
+
+    setState(reconcile({ id: 1, inner: { [META]: "new" } }, "id"));
+    flush();
+    expect(state.inner[META]).toBe("new");
+    expect(seen).toBe("new");
+  });
+});
 // type tests
 
 // reconcile

--- a/packages/solid-signals/tests/store/reconcile.test.ts
+++ b/packages/solid-signals/tests/store/reconcile.test.ts
@@ -581,7 +581,11 @@ describe("reconcile with symbol-keyed properties", () => {
   });
 
   test("string and symbol keys on the same store both update", () => {
-    const [state, setState] = createStore<Record<PropertyKey, any>>({ id: 1, label: "old", [META]: "old" });
+    const [state, setState] = createStore<Record<PropertyKey, any>>({
+      id: 1,
+      label: "old",
+      [META]: "old"
+    });
     let sawLabel: any, sawMeta: any;
     createRoot(() => {
       createEffect(
@@ -666,7 +670,10 @@ describe("reconcile with symbol-keyed properties", () => {
   });
 
   test("nested symbol-keyed value reconciles", () => {
-    const [state, setState] = createStore<Record<PropertyKey, any>>({ id: 1, inner: { [META]: "old" } });
+    const [state, setState] = createStore<Record<PropertyKey, any>>({
+      id: 1,
+      inner: { [META]: "old" }
+    });
     let seen: any;
     createRoot(() => {
       createEffect(


### PR DESCRIPTION
Closes #2851

## Summary

`reconcile()` never notifies subscribers of **symbol-keyed** store properties. An effect or binding tracking `state[SYM]` doesn't re-run when `reconcile()` changes that property, and because the stale node then shadows the value, even a plain `state[SYM]` read keeps returning the old value — the reconciled value is unreachable. String-keyed properties on the same store update fine through the identical path, so the only difference is the key type.

https://stackblitz.com/edit/solidjs-templates-krnhumcg?file=src%2FApp.tsx

This is the remaining variant of #2769: that fix (`bc92d002`) covered symbol keys in the set trap, `storeSetter`, `storePath`, and `merge`/`omit` via the `ownEnumerableKeys` helper — but `reconcile()`'s own diff loops still enumerated with `Object.keys`, which drops symbols.

## Root cause

Every key enumeration in reconcile's diff dropped symbols:

- `getAllKeys` (the `$TRACK`-tracked path) built from `getKeys` (string-only) + `Object.keys(next)`.
- The untracked value loops and the `STORE_HAS` (`in`-dependency) loops iterated `Object.keys(nodes)`.

So `setSignal` was never called for symbol-keyed nodes, while `applyState*` had already swapped `STORE_VALUE` to the new value — leaving the stale node shadowing it for direct reads too.

## Fix

Enumerate symbol keys everywhere reconcile enumerates string keys, while keeping the common symbol-free path on the exact `Object.keys` fast path:

- **`getAllKeys`** builds string keys via `Object.keys` (unchanged) and appends *enumerable* symbol keys via `getOwnPropertySymbols` — symbol-free objects pay only an empty call, no per-key predicate.
- **`nodeKeys`** (new) enumerates a node record's keys: `Object.keys` always, plus symbol nodes only for records flagged in a `symbolKeyedRecords` WeakSet. `getNode` marks a record when it creates a user (non-`$TRACK`) symbol node, and its `unobserved` cleanup drops the mark once the last such node goes — so the flag means exactly "this record currently holds a user symbol node", and the reconcile hot path stays on `Object.keys` gated by a free `WeakSet.has`.
- `$TRACK` (the internal self-node, the only internal symbol a node record can hold — the get/has traps early-return the others) is filtered out of symbol enumeration; callers handle it separately.

Semantics are identical to the old code for string keys, and match `ownEnumerableKeys` (enumerable strings + enumerable symbols) for the extended set; key order is irrelevant since each key is diffed independently.

## Tests

Seven tests in `tests/store/reconcile.test.ts` (`reconcile with symbol-keyed properties`), the symbol cases confirmed failing red-first on the unfixed source:

- effect tracking a symbol-keyed property is notified; the value is reachable, not shadowed
- string control updates through the identical path
- string and symbol keys on one store both update
- a symbol key removed by reconcile notifies `undefined`
- a symbol `in` check updates when reconcile adds the key
- a nested symbol-keyed value reconciles
- perf invariant: the `symbolKeyedRecords` mark is set while tracked and cleared once unobserved (guards the fast-path optimization against a monotonic leak)

Full solid-signals suite: the diff versus pristine is exactly the intended flips, nothing else; solid and @solidjs/web rebuilt against the fixed package and re-run at their baselines; source and test files pass the tests-inclusive typecheck.

## Solid 1.x note

Exists in 1.x too, in a worse form: 1.x `reconcile` doesn't even *merge* symbol-keyed values (the value stays stale; no notification question arises). 2.0 half-fixed this — the value merges — but subscribers of the symbol-keyed node are still never notified. Not a regression, but 2.0 already handles symbols in its other store paths (set trap, `getAllKeys`, `merge`/`omit` after #2769), so finishing the job in reconcile's diff loops is consistent.

Full disclosure: I wrote this with the help of an AI assistant (Claude Fable 5) and reviewed every line before pushing. All new tests were written first and confirmed failing on the unfixed code