### PR TITLE
fix(signals): repeat() handles disjoint window jumps (closes #2853)

### DIFF
--- a/.changeset/repeat-disjoint-window.md
+++ b/.changeset/repeat-disjoint-window.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Fix `repeat()` / `<Repeat>` leaking live row scopes and crashing on disjoint window jumps. When a reactive `from` moves the window to indices that don't overlap the previous window, the shift-and-fill update walked `_nodes` at negative local indices: a forward jump larger than the window created every gap row and left them alive (owners, effects, and `onCleanup`s never disposed), and a backward disjoint jump threw `Cannot read properties of undefined (reading 'dispose')` and froze the list. The first render with a nonzero `from` mapped the whole `0..from+count` prefix for the same reason. Disjoint windows are now detected and replaced wholesale; overlapping slides (the #2784 fix) are unchanged.

--- a/packages/solid-signals/src/map.ts
+++ b/packages/solid-signals/src/map.ts
@@ -346,6 +346,20 @@ function updateRepeat<MappedItem>(this: RepeatData<MappedItem>): any[] {
     // remove fallback
     if (this._len === 0 && this._nodes[0]) this._nodes[0].dispose();
 
+    // Disjoint windows have no rows to retain; replace them wholesale.
+    if (from >= prevTo || to <= this._offset) {
+      for (let i = 0; i < this._len; i++) this._nodes[i].dispose();
+      this._nodes = new Array(newLen);
+      this._mappings = new Array(newLen);
+      for (let i = 0; i < newLen; i++)
+        this._mappings[i] = runWithOwner<MappedItem>((this._nodes[i] = createOwner()), () =>
+          this._map(from + i)
+        );
+      this._offset = from;
+      this._len = newLen;
+      return;
+    }
+
     // clear the end
     for (let i = to; i < prevTo; i++) this._nodes[i - this._offset].dispose();
 

--- a/packages/solid-signals/tests/repeat.test.ts
+++ b/packages/solid-signals/tests/repeat.test.ts
@@ -346,3 +346,76 @@ it("slides the window backwards: disposes departing rows and retains the overlap
   // only the departing rows were disposed
   expect(disposed.sort()).toEqual([4, 5]);
 });
+
+describe("disjoint window jumps", () => {
+  function windowed() {
+    const [from, setFrom] = createSignal(0);
+    let created = 0;
+    let cleaned = 0;
+    let view!: () => number[];
+    createRoot(() => {
+      view = repeat(
+        () => 3,
+        i => {
+          created++;
+          onCleanup(() => cleaned++);
+          return i;
+        },
+        { from }
+      );
+    });
+    flush();
+    return {
+      view,
+      jump: (n: number) => {
+        setFrom(n);
+        flush();
+      },
+      live: () => created - cleaned
+    };
+  }
+
+  it("a forward jump larger than the window creates only the window's rows", () => {
+    const w = windowed();
+    expect(w.view()).toEqual([0, 1, 2]);
+    expect(w.live()).toBe(3);
+    w.jump(10);
+    expect(w.view()).toEqual([10, 11, 12]);
+    expect(w.live()).toBe(3);
+  });
+
+  it("repeated disjoint jumps do not accumulate live scopes", () => {
+    const w = windowed();
+    w.jump(10);
+    w.jump(20);
+    expect(w.view()).toEqual([20, 21, 22]);
+    expect(w.live()).toBe(3);
+  });
+
+  it("a backward disjoint jump maps the new window without crashing", () => {
+    const w = windowed();
+    w.jump(20);
+    expect(() => w.jump(0)).not.toThrow();
+    expect(w.view()).toEqual([0, 1, 2]);
+    expect(w.live()).toBe(3);
+  });
+
+  it("initial render with a nonzero `from` maps only the window", () => {
+    const [from] = createSignal(10);
+    let created = 0;
+    let view!: () => number[];
+    createRoot(() => {
+      view = repeat(
+        () => 3,
+        i => {
+          created++;
+          return i;
+        },
+        { from }
+      );
+    });
+    flush();
+    expect(view()).toEqual([10, 11, 12]);
+    expect(created).toBe(3);
+  });
+});


### PR DESCRIPTION
Closes #2853

## Summary

`repeat()` / `<Repeat>` with a reactive `from` only handled window moves that **overlap** the previous window. Any disjoint jump — the everyday shape of a virtualized list, where dragging the scrollbar or jumping to an index moves `from` by more than `count` — broke three ways:

1. **Initial render with a nonzero `from` maps the whole prefix** — `from: 10, count: 3` creates rows `0..12` (13 rows for a 3-row window).
2. **A forward jump larger than the window leaks every gap row** — jumping `0 → 10` maps `3..12` and stores the gap rows (`3..9`) at *negative* `_nodes` indices, so nothing ever disposes them; their owners, effects and `onCleanup`s stay live until the whole list is torn down. Each disjoint jump adds more (`0 → 10 → 20` ⇒ 17 live scopes for a 3-row window).
3. **A backward disjoint jump crashes** — `20 → 0` throws `Cannot read properties of undefined (reading 'dispose')`, the update aborts, and the list freezes on the old rows.

The rendered list always *looks* right (leaked rows never enter the DOM), so the leak is invisible without watching live scope counts. Repro: https://stackblitz.com/edit/solidjs-templates-de3jtq5s?file=src%2FApp.tsx

Distinct from #2767 (fixed by #2784 / `d8921ac1`): that covered the empty-window reset and *overlapping* backward slides, which still work. The disjoint geometries were never handled.

## Root cause

`updateRepeat` (`packages/solid-signals/src/map.ts`) models every window move as "clear the end, shift the front, fill the difference" — valid only when `old ∩ new ≠ ∅`. The fill loop `for (i = prevTo; i < to; i++) this._nodes[i - from] = …` writes negative local indices for every `i < from` (symptoms 1–2), and the end-clear loop `this._nodes[i - this._offset].dispose()` reads `this._nodes[negative]` (`undefined`) on a backward disjoint jump (symptom 3).

## Fix

Detect the disjoint case up front and replace the window wholesale:

```ts
if (from >= prevTo || to <= this._offset) {
  for (let i = 0; i < this._len; i++) this._nodes[i].dispose();
  this._nodes = new Array(newLen);
  this._mappings = new Array(newLen);
  for (let i = 0; i < newLen; i++)
    this._mappings[i] = runWithOwner(this._nodes[i] = createOwner(), () => this._map(from + i));
  this._offset = from;
  this._len = newLen;
  return;
}
```

That condition is the exact boolean complement of "the windows overlap" (`from < prevTo && to > offset`), so:

- **partial-overlap slides still take the existing preserving path** and keep shared rows' identity/state — verified: `[5,8) → [3,6)` creates only rows `3,4` and preserves row `5`;
- **only truly disjoint moves are replaced wholesale**, which is unavoidable work (no shared rows to preserve);
- it also subsumes the nonzero-first-render case (`prevTo` is 0 on first render).

The existing overlapping-slide branches (the #2784 fix) are untouched, and no loop-clamping is added — the guard makes the negative-index accesses unreachable rather than merely clamped.

## Tests

`tests/repeat.test.ts` gains a "disjoint window jumps" block, all confirmed red-first on the unfixed source:

- a forward jump larger than the window creates only the window's rows (`live === 3`, not 10)
- repeated disjoint jumps do not accumulate live scopes (`live === 3`, not 17)
- a backward disjoint jump maps the new window without crashing
- initial render with a nonzero `from` maps only the window (3 created, not 13)

## Solid 1.x note

Not applicable — `repeat()` / `<Repeat>` is a new 2.0 API with no 1.x counterpart (the closest 1.x pattern, `<Index>` over a sliced range, has no windowing bookkeeping and no equivalent failure mode).

Full disclosure: I wrote this with the help of an AI assistant (Claude Fable 5) and reviewed every line before pushing. All new tests were written first and confirmed failing on the unfixed code