### PR TITLE
fix(signals): don't route an already-caught error past its Errored through a Loading

### DIFF
--- a/.changeset/loading-errored-composition-escape.md
+++ b/.changeset/loading-errored-composition-escape.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Fixed an error-routing escape in `Errored > Loading > Errored > content` composition: a sync error thrown by the content was routed past the inner `Errored` to the boundary above the `Loading` — both when the content threw during the same flush the boundaries mounted (e.g. navigating to a route that renders already-errored) and when it threw reactively after a healthy commit. The inner `Errored` consumed the ERROR dimension from the notification mask when it caught, but the `Loading` queue's notify-through remap keyed off the node's raw status flags and resurrected the already-caught error past its handler. The remap now only fires while the ERROR dimension is still live in the mask. Errors surfaced through DOM insertion effects were unaffected. Restores the beta.15 (and Solid 1.x) contract that `Loading > Errored > content` reliably catches at the inner boundary.

--- a/packages/solid-signals/src/boundaries.ts
+++ b/packages/solid-signals/src/boundaries.ts
@@ -304,12 +304,18 @@ export class CollectionQueue extends Queue {
     // Notify-through: a real error inside a `Loading` is not this boundary's to
     // handle — remap it to ERROR and forward toward the `Errored` that catches it.
     // This must run before the initialized passthrough below so the error still
-    // reaches its catcher after this boundary has committed. The mirror case
-    // (pending inside an `Errored`) needs no explicit rule: the PENDING dimension
-    // survives `type &= ~collectionType` below and reaches the outer `Loading`
-    // natively, while a pending already caught by an inner `Loading` arrives here
-    // as a bare ERROR-dimension remainder and is correctly swallowed.
-    if (this._collectionType & STATUS_PENDING && flags & STATUS_ERROR) {
+    // reaches its catcher after this boundary has committed. Guarded on the ERROR
+    // dimension still being live in `type`: an `Errored` nested below this
+    // `Loading` consumes ERROR from the mask when it catches, and remapping off
+    // the node's raw `flags` alone would resurrect that consumed error and route
+    // it past the boundary that already handled it (the Loading > Errored >
+    // content composition escape).
+    // The mirror case (pending inside an `Errored`) needs no explicit rule: the
+    // PENDING dimension survives `type &= ~collectionType` below and reaches the
+    // outer `Loading` natively, while a pending already caught by an inner
+    // `Loading` arrives here as a bare ERROR-dimension remainder and is correctly
+    // swallowed.
+    if (this._collectionType & STATUS_PENDING && type & STATUS_ERROR && flags & STATUS_ERROR) {
       return super.notify(node, STATUS_ERROR, flags, error);
     }
 

--- a/packages/solid-signals/tests/createErrorBoundary.test.ts
+++ b/packages/solid-signals/tests/createErrorBoundary.test.ts
@@ -829,6 +829,101 @@ it("does not loop when an async memo is read inside Loading > Errored (#2809)", 
 });
 
 /**
+ * #2809 fallout — the `Errored > Loading > Errored > content` composition
+ * escape: a sync error from the content must be caught by the INNER `Errored`,
+ * the boundary between the `Loading` and the throwing content. When the inner
+ * boundary catches, it consumes the ERROR dimension from the notification mask
+ * and forwards only the PENDING remainder up the queue chain — but the
+ * `Loading` queue's notify-through remap keyed off the node's raw status flags
+ * instead of the mask, resurrecting the already-caught error and routing it to
+ * the OUTER boundary, whose fallback then replaced the whole subtree (and with
+ * no outer boundary, reactivity halted). This broke the React-style
+ * `Suspense > ErrorBoundary > content` nesting that TanStack Router mirrors.
+ * The remap now fires only while the ERROR dimension is still live in the mask.
+ */
+function mountNestedComposition(content: () => string) {
+  let rendered: unknown;
+  const dispose = createRoot(dispose => {
+    const outer = createErrorBoundary(
+      () =>
+        createLoadingBoundary(
+          () => createErrorBoundary(content, () => "inner caught")(),
+          () => "loading"
+        )(),
+      () => "outer caught"
+    );
+    createRenderEffect(
+      () => (rendered = outer()),
+      () => {}
+    );
+    return dispose;
+  });
+  return { rendered: () => rendered, dispose };
+}
+
+it("catches at the inner Errored when content throws in the mounting flush (Errored > Loading > Errored)", () => {
+  const { rendered, dispose } = mountNestedComposition(() => {
+    throw new Error("boom on mount");
+  });
+  flush();
+  expect(rendered()).toBe("inner caught");
+  dispose();
+});
+
+it("catches at the inner Errored when content throws reactively after a healthy commit (Errored > Loading > Errored)", () => {
+  const [$boom, setBoom] = createSignal(false);
+  const { rendered, dispose } = mountNestedComposition(() => {
+    if ($boom()) throw new Error("boom");
+    return "ok";
+  });
+  flush();
+  expect(rendered()).toBe("ok");
+
+  setBoom(true);
+  flush();
+  expect(rendered()).toBe("inner caught");
+  dispose();
+});
+
+it("catches an async rejection at the inner Errored (Errored > Loading > Errored)", async () => {
+  const rejected = Promise.reject(new Error("boom async"));
+  rejected.catch(() => {});
+
+  let rendered: unknown;
+  const dispose = createRoot(dispose => {
+    // The memo lives outside the boundary computes (component-body shape); a
+    // memo created inside the inner boundary's fn would be recreated on every
+    // re-run and refetch forever.
+    const data = createMemo(() => rejected);
+    const outer = createErrorBoundary(
+      () =>
+        createLoadingBoundary(
+          () =>
+            createErrorBoundary(
+              () => `value: ${data()}`,
+              () => "inner caught"
+            )(),
+          () => "loading"
+        )(),
+      () => "outer caught"
+    );
+    createRenderEffect(
+      () => (rendered = outer()),
+      () => {}
+    );
+    return dispose;
+  });
+  flush();
+  expect(rendered).toBe("loading");
+
+  await Promise.resolve();
+  await Promise.resolve();
+  flush();
+  expect(rendered).toBe("inner caught");
+  dispose();
+});
+
+/**
  * #2809 hydration interaction: with snapshot capture active (as during
  * `hydrate()`), boundary computeds must not become snapshot sources. The tree no
  * longer carries the foreign PENDING flag (see above), so capture can't rely on


### PR DESCRIPTION
## Summary

In the `Errored > Loading > Errored > content` composition, a sync error thrown by the content was routed past the inner `Errored` to the boundary above the `Loading` — the outer fallback replaced the whole subtree, and with no outer boundary the error escaped entirely and (new in beta.16) permanently halted reactivity. This broke the React-style `Suspense > ErrorBoundary > content` nesting that TanStack Router mirrors; it worked on 2.0.0-beta.15 and regressed in beta.16 with the #2809 boundary notify-through work.

It reproduced both when the content threw during the same flush the boundaries mounted (e.g. navigating to a route that renders already-errored) and when it threw reactively after a healthy commit.

## Root cause

When the inner `Errored` catches, `CollectionQueue#notify` consumes the ERROR dimension from the notification **mask** (`type`) and forwards only the PENDING remainder up the queue chain. But the `Loading` queue's notify-through remap keyed off the node's raw **status flags** instead of the mask — it saw "this node has an error", remapped the PENDING-only remainder back into an ERROR notification, and forwarded the already-caught error past its handler.

## Fix

The remap now additionally requires the ERROR dimension to still be live in the mask (`type & STATUS_ERROR`), i.e. it only fires while the error is still unhandled — which is exactly the `Errored > Loading > erroring content` case the rule was written for (#2821).

## Testing

- Three new regression tests in `createErrorBoundary.test.ts` pinning the composition: throw in the mounting flush, reactive throw after a healthy commit, and an async rejection — all must catch at the inner boundary.
- Full solid-signals, solid, and solid-web (client/SSR/hydration) suites pass, including the #2821 `errored-async-nesting` pins that motivated the notify-through rule.
- Verified against the published packages that `@solidjs/signals` 2.0.0-beta.15 catches at the inner boundary and 2.0.0-beta.16 routes to the outer boundary in the same scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)