### PR TITLE
fix: handle runtime edge case regressions

### DIFF
--- a/packages/solid-signals/src/core/action.ts
+++ b/packages/solid-signals/src/core/action.ts
@@ -89,13 +89,13 @@ export function action<Args extends any[], Y, R>(
       let ctx = activeTransition!;
       ctx._actions.push(it);
 
-      const done = (v?: R, e?: any) => {
+      const done = (v?: R, e?: any, failed = false) => {
         ctx = currentTransition(ctx);
         const i = ctx._actions.indexOf(it);
         if (i >= 0) ctx._actions.splice(i, 1);
         setActiveTransition(ctx);
         schedule();
-        e ? reject(e) : resolve(v!);
+        failed ? reject(e) : resolve(v!);
       };
 
       const step = (v?: any, err?: boolean): void => {
@@ -103,12 +103,12 @@ export function action<Args extends any[], Y, R>(
         try {
           r = err ? it.throw!(v) : it.next(v);
         } catch (e) {
-          return done(undefined, e);
+          return done(undefined, e, true);
         }
         // A rejected iterator result (async generators) means the error already
         // escaped the generator body — it is completed, and throwing back in
         // would just reject again forever. Settle instead.
-        if (isThenable(r)) return void r.then(run, e => done(undefined, e));
+        if (isThenable(r)) return void r.then(run, e => done(undefined, e, true));
         run(r);
       };
 

--- a/packages/solid-signals/src/core/async.ts
+++ b/packages/solid-signals/src/core/async.ts
@@ -318,6 +318,7 @@ export function handleAsync<T>(
   if (iterator) {
     const it = (result as AsyncIterable<T>)[Symbol.asyncIterator]();
     let hadSyncValue = false;
+    let hadValue = false;
     let completed = false;
 
     cleanup(() => {
@@ -341,11 +342,17 @@ export function handleAsync<T>(
             if (r.done) completed = true;
           } else if (el._inFlight !== result) {
             return;
-          } else if (!r.done) asyncWrite(r.value, iterate);
-          else {
+          } else if (!r.done) {
+            hadValue = true;
+            asyncWrite(r.value, iterate);
+          } else {
             completed = true;
-            schedule();
-            flush();
+            if (!hadValue) asyncWrite(undefined as T);
+            if (el._inFlight === result) el._inFlight = null;
+            if (hadValue) {
+              schedule();
+              flush();
+            }
           }
         },
         e => {
@@ -359,6 +366,7 @@ export function handleAsync<T>(
       if (resolved && !syncResult!.done) {
         syncValue = syncResult!.value;
         hadSyncValue = true;
+        hadValue = true;
         return iterate();
       }
       return resolved && syncResult!.done;

--- a/packages/solid-signals/src/store/reconcile.ts
+++ b/packages/solid-signals/src/store/reconcile.ts
@@ -108,6 +108,13 @@ function keyedMatch(a: any, b: any, keyFn: (item: NonNullable<any>) => any) {
   return a === b || (isWrappable(a) && isWrappable(b) && keyFn(a) === keyFn(b));
 }
 
+function hasKeyedItem(items: any[], keyFn: (item: NonNullable<any>) => any) {
+  for (let i = 0, len = items.length; i < len; i++) {
+    if (isWrappable(items[i]) && keyFn(items[i]) != null) return true;
+  }
+  return false;
+}
+
 // Array reconciliation updates the slots it visits, then swaps STORE_VALUE.
 // Previously tracked keys that are absent from `next` still need invalidating,
 // and `in` dependencies should follow the new value's membership. Use
@@ -178,7 +185,7 @@ function applyStateFast(next: any, target: any, keyFn: (item: NonNullable<any>) 
   if (Array.isArray(previous)) {
     let changed = false;
     const prevLength = (previous as any).length;
-    if (next.length && prevLength && isWrappable(next[0]) && keyFn(next[0]) != null) {
+    if (next.length && prevLength && hasKeyedItem(next, keyFn)) {
       let i, j, start, end, newEnd, item, newIndicesNext, keyVal;
 
       for (
@@ -319,7 +326,7 @@ function applyStateSlow(next: any, target: any, keyFn: (item: NonNullable<any>) 
   if (Array.isArray(previous)) {
     let changed = false;
     const prevLength = getOverrideValue(previous, override, "length", optOverride);
-    if (next.length && prevLength && isWrappable(next[0]) && keyFn(next[0]) != null) {
+    if (next.length && prevLength && hasKeyedItem(next, keyFn)) {
       let i, j, start, end, newEnd, item, newIndicesNext, keyVal;
 
       for (

--- a/packages/solid-signals/src/store/store.ts
+++ b/packages/solid-signals/src/store/store.ts
@@ -645,9 +645,14 @@ export const storeTraps: ProxyHandler<StoreNode> = {
         // Symbol-keyed writes on arrays are metadata, not index writes — never run
         // them through the numeric index/length machinery (`parseInt` on a symbol
         // throws). #2769
+        const index = typeof property === "string" ? Number(property) : -1;
         const isArrayIndexWrite =
-          Array.isArray(state) && property !== "length" && typeof property !== "symbol";
-        const nextIndex = isArrayIndexWrite ? parseInt(property as string) + 1 : 0;
+          Array.isArray(state) &&
+          Number.isInteger(index) &&
+          index >= 0 &&
+          index < 4294967295 &&
+          String(index) === property;
+        const nextIndex = isArrayIndexWrite ? index + 1 : 0;
         const len = isArrayIndexWrite && (getOverlayLayer(target, "length") ?? state).length;
         const nextLength = isArrayIndexWrite && nextIndex > len ? nextIndex : undefined;
 

--- a/packages/solid-signals/tests/action.test.ts
+++ b/packages/solid-signals/tests/action.test.ts
@@ -885,6 +885,14 @@ describe("action", () => {
       await expect(myAction()).rejects.toThrow("sync error");
     });
 
+    it("should reject the promise when generator throws a falsy value", async () => {
+      const myAction = action(function* () {
+        throw undefined;
+      });
+
+      await expect(myAction()).rejects.toBeUndefined();
+    });
+
     it("should reject the promise when generator throws after yield", async () => {
       const myAction = action(function* () {
         yield Promise.resolve();

--- a/packages/solid-signals/tests/store/createStore.test.ts
+++ b/packages/solid-signals/tests/store/createStore.test.ts
@@ -1512,6 +1512,18 @@ describe("Store key handling and tracked truncation", () => {
     expect((store.getValue as () => number)()).toBe(42);
   });
 
+  test("Non-index string properties on arrays do not change length", () => {
+    const [list, setList] = createStore<Record<PropertyKey, unknown>>([] as any);
+
+    setList(current => {
+      current["01"] = "metadata";
+    });
+    flush();
+
+    expect(list["01"]).toBe("metadata");
+    expect((list as unknown as unknown[]).length).toBe(0);
+  });
+
   describe("symbol-keyed properties (#2769)", () => {
     const meta = Symbol("meta");
 

--- a/packages/solid-signals/tests/store/reconcile.test.ts
+++ b/packages/solid-signals/tests/store/reconcile.test.ts
@@ -220,6 +220,21 @@ describe("setState with reconcile", () => {
     expect(snapshot(state)).toEqual([{ id: 1 }, null, { id: 2, value: "updated" }]);
   });
 
+  test("Keyed reconcile preserves object identity when the first entry is null", () => {
+    const [state, setState] = createStore<Array<{ id: number } | null>>([
+      null,
+      { id: 1 },
+      { id: 2 }
+    ]);
+    const first = state[1];
+    const second = state[2];
+
+    setState(reconcile([null, { id: 2 }, { id: 1 }], "id"));
+
+    expect(state[1]).toBe(second);
+    expect(state[2]).toBe(first);
+  });
+
   test("Keyed reconcile replaces a keyed object with a primitive (#2772)", () => {
     const [state, setState] = createStore<Array<{ id: number; value: string } | number>>([
       { id: 1, value: "object" }

--- a/packages/solid-signals/tests/syncThenable.test.ts
+++ b/packages/solid-signals/tests/syncThenable.test.ts
@@ -177,6 +177,32 @@ describe("sync async iterator support", () => {
     expect(value()).toBe(undefined);
   });
 
+  it("should settle consumers when an async iterator is immediately done", async () => {
+    const values: unknown[] = [];
+    const asyncIterator = {
+      next() {
+        return Promise.resolve({ value: undefined, done: true as const });
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      }
+    } as AsyncIterable<unknown>;
+
+    createRoot(() => {
+      const value = createMemo(() => asyncIterator);
+      createRenderEffect(value, next => {
+        values.push(next);
+      });
+    });
+    flush();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    flush();
+
+    expect(values).toEqual([undefined]);
+  });
+
   it("should handle mixed sync/async iterator", async () => {
     let asyncResolve: (r: IteratorResult<number>) => void;
     let callCount = 0;

--- a/packages/solid/src/server/signals.ts
+++ b/packages/solid/src/server/signals.ts
@@ -270,6 +270,19 @@ export function setContext<T>(
   };
 }
 
+function unlinkOwner(node: SSROwner): void {
+  const parent = node._parent;
+  if (!parent) return;
+  if (parent._firstChild === node) parent._firstChild = node._nextSibling;
+  else {
+    let sibling = parent._firstChild;
+    while (sibling && sibling._nextSibling !== node) sibling = sibling._nextSibling;
+    if (sibling) sibling._nextSibling = node._nextSibling;
+  }
+  node._parent = null;
+  node._nextSibling = null;
+}
+
 /**
  * Tears down `owner` (optionally) and all of its descendants. Walks the
  * forward-only `_firstChild` -> `_nextSibling` chain, recursively disposing
@@ -293,10 +306,9 @@ export function disposeOwner(owner: Owner, self: boolean = true): void {
   if (!node._firstChild && !node._disposal) {
     if (self) {
       node._disposed = true;
+      unlinkOwner(node);
       if (ownerPool.length < OWNER_POOL_MAX) {
         node.id = undefined;
-        node._parent = null;
-        node._nextSibling = null;
         ownerPool.push(node);
       }
     }
@@ -320,13 +332,12 @@ export function disposeOwner(owner: Owner, self: boolean = true): void {
     }
     node._disposal = null;
   }
+  if (self) unlinkOwner(node);
   // Recycle the disposed owner. Skip the root case (`self=false`) and the
   // already-pooled case so we don't double-add. The next `createOwner` will
   // overwrite all fields, so we only need to drop heavy references here.
   if (self && ownerPool.length < OWNER_POOL_MAX) {
     node.id = undefined;
-    node._parent = null;
-    node._nextSibling = null;
     ownerPool.push(node);
   }
 }
@@ -819,10 +830,7 @@ function processResult<T>(
 
   // Async-iterable takes precedence over thenable, mirroring the client
   // runtime's detection order (`handleAsync` in @solidjs/signals core/async.ts).
-  if (
-    typeof (result as any)?.[Symbol.asyncIterator] !== "function" &&
-    isThenable<T>(result)
-  ) {
+  if (typeof (result as any)?.[Symbol.asyncIterator] !== "function" && isThenable<T>(result)) {
     if ((result as any).s === 1) {
       comp.value = (result as any).v;
       comp.error = undefined;

--- a/packages/solid/test/server/signals.spec.ts
+++ b/packages/solid/test/server/signals.spec.ts
@@ -22,6 +22,7 @@ import {
   runWithOwner,
   untrack,
   flush,
+  isDisposed,
   isPending,
   latest,
   refresh,
@@ -37,7 +38,8 @@ import {
 import {
   createErrorBoundary,
   createLoadingBoundary,
-  NotReadyError as NotReadyErrorClass
+  NotReadyError as NotReadyErrorClass,
+  type Owner
 } from "../../src/server/signals.js";
 
 // === createSignal ===
@@ -571,5 +573,26 @@ describe("Server owner tree", () => {
       },
       { id: "test" }
     );
+  });
+
+  test("disposing a parent does not dispose an owner recycled into another root", () => {
+    let disposeParent!: () => void;
+    let disposeChild!: () => void;
+    let recycledOwner!: Owner;
+
+    createRoot(dispose => {
+      disposeParent = dispose;
+      createRoot(childDispose => {
+        disposeChild = childDispose;
+      });
+    });
+    disposeChild();
+
+    createRoot(() => {
+      recycledOwner = getOwner()!;
+    });
+    disposeParent();
+
+    expect(isDisposed(recycledOwner)).toBe(false);
   });
 });


### PR DESCRIPTION
Used the new GPT 5.6 Sol model to hunt bugs and this what it came up with. 

Feel free to take as many or as little as you want

## Summary

- reject actions correctly when generators throw falsy values and settle consumers of asynchronously empty iterables
- preserve native array index semantics and keyed store identity with leading null entries
- unlink disposed SSR owners before pooling so reused owners cannot be disposed through stale parent links
- add regression coverage for each corrected path

## Testing

- `pnpm test` in `packages/solid-signals` (900 tests)
- `pnpm test` in `packages/solid` (432 tests)
- `pnpm types` in `packages/solid-signals`
- `pnpm types` in `packages/solid`
- `pnpm test-types` in `packages/solid`