### PR TITLE
fix(web): emit @solidjs/web/storage types at the advertised path

### DIFF
--- a/packages/solid-web/package.json
+++ b/packages/solid-web/package.json
@@ -138,7 +138,7 @@
     "build:js": "rollup -c",
     "link": "symlink-dir . node_modules/@solidjs/web",
     "types": "npm-run-all -nl types:clean types:copy-jsx types:web types:copy-web types:web-storage types:cjs",
-    "types:clean": "rimraf types/ types-cjs/ storage/types-cjs/",
+    "types:clean": "rimraf types/ types-cjs/ storage/types/ storage/types-cjs/",
     "types:copy-jsx": "ncp ../../node_modules/@dom-expressions/runtime/src/jsx.d.ts ./src/jsx.d.ts && ncp ../../node_modules/@dom-expressions/runtime/src/jsx-properties.d.ts ./src/jsx-properties.d.ts && dom-expressions-jsx-types --input ./src/jsx.d.ts --element \"SolidElement | Node | ArrayElement\" --import 'import type { Element as SolidElement } from \"solid-js\";'",
     "types:web": "tsc --project ./tsconfig.build.json",
     "types:copy-web": "ncp ../../node_modules/@dom-expressions/runtime/src/client.d.ts ./types/client.d.ts && ncp ../../node_modules/@dom-expressions/runtime/src/server.d.ts ./types/server.d.ts && ncp ./src/jsx.d.ts ./types/jsx.d.ts && ncp ./src/jsx-properties.d.ts ./types/jsx-properties.d.ts",

--- a/packages/solid-web/storage/tsconfig.build.json
+++ b/packages/solid-web/storage/tsconfig.build.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "./types",
     "baseUrl": "./src",
-    "rootDir": "..",
+    "rootDir": "./src",
     "types": ["node"],
     "paths": {
       "@solidjs/web": ["../../src/index.ts"]


### PR DESCRIPTION
fixes #2873

package.json says `@solidjs/web/storage` types live at `storage/types/index.d.ts`, but the storage tsbuild had `rootDir: ".."`, so tsc put them under `storage/types/storage/src/` and consumers couldn't resolve the module.

pointed `rootDir` at `./src` and clear `storage/types` in `types:clean`. emit path after the fix is `types/index.d.ts`.