### PR TITLE
fix: align nested Reveal readiness across client and SSR

### DIFF
--- a/.changeset/steady-reveal-composites.md
+++ b/.changeset/steady-reveal-composites.md
@@ -1,0 +1,14 @@
+---
+"solid-js": patch
+"@solidjs/signals": patch
+---
+
+Fix nested `Reveal` readiness across the client and streaming SSR.
+
+Empty or synchronously resolved composites now count as minimally ready, so an
+enclosing `order="together"` group cannot deadlock. Nested `order="natural"`
+groups also report readiness as soon as one direct child is minimally ready,
+and nested client `order="together"` groups propagate the same direct-slot
+readiness they use for their own release. Readiness and completion on the server
+are held until all synchronous child slots have registered, preventing an early
+child from making a partially constructed group release prematurely.

--- a/documentation/solid-2.0/03-control-flow.md
+++ b/documentation/solid-2.0/03-control-flow.md
@@ -219,7 +219,7 @@ Each order defines when it has "first visible content" under its own policy. Thi
 
 - `sequential` — frontier-0 (the first registered slot) has reached its own minimally-ready state.
 - `together` — every direct slot has reached its own minimally-ready state.
-- `natural` — any direct slot has produced visible content (leaves on resolve; nested composites when their whole subtree is ready, since natural treats a composite as one atomic slot).
+- `natural` — any direct slot has reached its own minimally-ready state (leaves on resolve; nested composites according to their own order).
 
 For a leaf `<Loading>`, "minimally ready" and "fully ready" are the same thing: its data resolved. For a nested `<Reveal>`, the two differ — e.g. a nested `sequential` is minimally ready once its first child resolves, even though later children are still pending.
 
@@ -231,13 +231,13 @@ For a leaf `<Loading>`, "minimally ready" and "fully ready" are the same thing: 
 |---|---|---|---|
 | `sequential` | `sequential` | Outer frontier reaches the inner slot. | Inner reveals in registration order; outer frontier waits for the inner group to finish before advancing past it. |
 | `sequential` | `together` | Outer frontier reaches the inner slot. | Inner reveals atomically once every inner child is ready. |
-| `sequential` | `natural` | Outer frontier reaches the inner slot. | Inner reveals per-slot: each leaf on resolve, each grandchild composite when fully ready. |
+| `sequential` | `natural` | Outer frontier reaches the inner slot. | Inner reveals per-slot: each leaf on resolve, while each grandchild composite runs its own order locally. |
 | `together` | `sequential` | Every direct child of the outer `together` is minimally ready; that means the inner's frontier-0 has resolved. | Inner reveals its frontier-0 immediately with the group release, then continues its own sequential order for the tail. |
 | `together` | `together` | Every direct child of the outer is minimally ready; that means the inner `together` has all its own children ready. | Inner reveals atomically as part of the same group release. |
 | `together` | `natural` | Every direct child of the outer is minimally ready; that means at least one inner child is ready. | Already-resolved inner children flush with the group release; later inner resolutions stream independently under natural. |
-| `natural` | `sequential` | The inner composite is fully ready (i.e. every inner child has resolved). | Inner group is fully ready at release; all inner children flush together. |
-| `natural` | `together` | The inner composite is fully ready. | Same as above. |
-| `natural` | `natural` | The inner composite is fully ready. | Same as above. |
+| `natural` | `sequential` | Immediately; outer `natural` does not hold the inner composite. | Inner reveals in registration order. |
+| `natural` | `together` | Immediately; outer `natural` does not hold the inner composite. | Inner reveals atomically once every direct child is minimally ready. |
+| `natural` | `natural` | Immediately; outer `natural` does not hold the inner composite. | Inner children reveal independently. |
 
 `order="natural"` is primarily useful when you have a group whose children don't need to coordinate with each other. Nesting a natural group under an outer ordering lets the natural group participate as one unit in the outer order while each child reveals on its own data once the outer releases the slot.
 

--- a/packages/solid-signals/src/boundaries.ts
+++ b/packages/solid-signals/src/boundaries.ts
@@ -147,13 +147,13 @@ export class RevealController {
   /**
    * "Minimally ready" = this group has something visible to show under its own policy.
    * Used by an enclosing `together` group to decide when it can release.
-   * - `together`: fully ready (atomic).
+   * - `together`: every direct slot is minimally ready.
    * - `sequential`: the first owned slot is minimally ready (frontier can advance).
    * - `natural`: any owned slot is minimally ready.
    */
   isMinimallyReady(): boolean {
     const order = untrack(this._orderAccessor);
-    if (order === "together") return this.isReady();
+    if (order === "together") return this._forEachOwnedSlot(isSlotMinimallyReady);
     if (order === "natural") {
       let hasSlot = false;
       let anyReady = false;
@@ -524,7 +524,7 @@ export function createErrorBoundary<T, U>(
  *   own minimal signal).
  * - `together` — every direct slot is minimally ready.
  * - `natural` — any direct slot has visible content (leaves on resolve; nested
- *   composites when fully ready, since natural treats composites as atomic).
+ *   composites via their own minimal signal).
  *
  * @example
  * ```ts

--- a/packages/solid-signals/tests/createRevealOrder.test.ts
+++ b/packages/solid-signals/tests/createRevealOrder.test.ts
@@ -1749,6 +1749,95 @@ describe("createRevealOrder", () => {
     expect(result).toEqual([["N1", "N2"]]);
   });
 
+  const orders: RevealOrder[] = ["sequential", "together", "natural"];
+  const threeLevelCases = orders.flatMap(middleOrder =>
+    orders.map(innerOrder => ({ middleOrder, innerOrder }))
+  );
+
+  it.each(threeLevelCases)(
+    "three-level minimal readiness: $middleOrder middle forwards $innerOrder inner",
+    async ({ middleOrder, innerOrder }) => {
+      let result: any[] = [];
+      const gate = deferred<number>();
+      const first = deferred<number>();
+      const second = deferred<number>();
+
+      createRoot(() => {
+        const gateMemo = createMemo(async () => {
+          await gate.promise;
+          return "G";
+        });
+        const firstMemo = createMemo(async () => {
+          await first.promise;
+          return "F";
+        });
+        const secondMemo = createMemo(async () => {
+          await second.promise;
+          return "S";
+        });
+
+        const ordered = baseCreateRevealOrder(
+          () => [
+            createLoadingBoundary(
+              () => gateMemo(),
+              () => "lg"
+            ),
+            baseCreateRevealOrder(
+              () => [
+                baseCreateRevealOrder(
+                  () => [
+                    createLoadingBoundary(
+                      () => firstMemo(),
+                      () => "lf"
+                    ),
+                    createLoadingBoundary(
+                      () => secondMemo(),
+                      () => "ls"
+                    )
+                  ],
+                  { order: () => innerOrder, collapsed: () => false }
+                )
+              ],
+              { order: () => middleOrder, collapsed: () => false }
+            )
+          ],
+          { order: () => "together", collapsed: () => false }
+        );
+
+        createRenderEffect(
+          () => (result = materialize(ordered)),
+          () => {}
+        );
+      });
+
+      flush();
+      gate.resolve(1);
+
+      if (innerOrder === "sequential") first.resolve(1);
+      else if (innerOrder === "natural") second.resolve(1);
+      else {
+        first.resolve(1);
+        await settle();
+        expect(result).toEqual(["lg", [["lf", "ls"]]]);
+        second.resolve(1);
+      }
+
+      await settle();
+      if (innerOrder === "sequential") {
+        expect(result).toEqual(["G", [["F", "ls"]]]);
+        second.resolve(1);
+      } else if (innerOrder === "natural") {
+        expect(result).toEqual(["G", [["lf", "S"]]]);
+        first.resolve(1);
+      } else {
+        expect(result).toEqual(["G", [["F", "S"]]]);
+      }
+
+      await settle();
+      expect(result).toEqual(["G", [["F", "S"]]]);
+    }
+  );
+
   it("outer natural + inner sequential: inner composite runs its own frontier locally", async () => {
     // Outer natural releases composite slots to run their own order locally, so
     // an inner sequential reveals its children per its own frontier-gating,

--- a/packages/solid-web/test/server/ssr-stream.spec.tsx
+++ b/packages/solid-web/test/server/ssr-stream.spec.tsx
@@ -2491,6 +2491,157 @@ describe("SSR Streaming — Reveal", () => {
     expect(full).toContain("$dfj");
   });
 
+  test.each(["sequential", "together", "natural"] as const)(
+    "together mode activates with an empty nested %s Reveal",
+    async order => {
+      const { promise, resolve } = deferred<string>();
+
+      function AsyncContent() {
+        const data = createMemo(async () => promise);
+        return <div>{data()}</div>;
+      }
+      function App() {
+        return (
+          <Reveal order="together">
+            <Loading fallback={<div>loading</div>}>
+              <AsyncContent />
+            </Loading>
+            <Reveal order={order}>
+              <aside>static content</aside>
+            </Reveal>
+          </Reveal>
+        );
+      }
+
+      const chunksPromise = collectChunks(() => <App />);
+      await delay(10);
+      resolve("async content");
+
+      const { chunks } = await chunksPromise;
+      const full = chunks.join("");
+      const key = full.match(/<template id="(\d+)"><div[^>]*>async content/)?.[1];
+      const templateIndex = full.indexOf(`<template id="${key}">`);
+      const activationIndex = full.indexOf(`$dfj(["${key}"])`);
+
+      expect(full).toContain("static content");
+      expect(key).toBeDefined();
+      expect(activationIndex).toBeGreaterThan(templateIndex);
+    }
+  );
+
+  test("empty composite does not make a together group ready before later slots register", async () => {
+    const { promise: profile, resolve: resolveProfile } = deferred<string>();
+    const { promise: slowCard, resolve: resolveSlowCard } = deferred<string>();
+
+    function Profile() {
+      const data = createMemo(async () => profile);
+      return <h1>{data()}</h1>;
+    }
+    function SlowCard() {
+      const data = createMemo(async () => slowCard);
+      return <p>{data()}</p>;
+    }
+    function App() {
+      return (
+        <Reveal order="together">
+          <Loading fallback={<b>loading profile</b>}>
+            <Profile />
+          </Loading>
+          <Reveal order="together">
+            <Reveal order="natural">
+              <aside>static content</aside>
+            </Reveal>
+            <Loading fallback={<i>loading slow card</i>}>
+              <SlowCard />
+            </Loading>
+          </Reveal>
+        </Reveal>
+      );
+    }
+
+    const chunksPromise = collectChunks(() => <App />);
+    await delay(10);
+    resolveProfile("profile");
+    await delay(10);
+    resolveSlowCard("slow card");
+
+    const { chunks } = await chunksPromise;
+    const full = chunks.join("");
+    const profileKey = full.match(/<template id="(\d+)"><h1[^>]*>profile/)?.[1];
+    const profileActivationIndex = full.indexOf(`$dfj(["${profileKey}"])`);
+    const slowTemplateIndex = full.indexOf(">slow card</p></template>");
+
+    expect(profileKey).toBeDefined();
+    expect(slowTemplateIndex).toBeGreaterThan(-1);
+    expect(profileActivationIndex).toBeGreaterThan(slowTemplateIndex);
+  });
+
+  test("together mode releases when a nested natural composite is minimally ready", async () => {
+    const { promise: profile, resolve: resolveProfile } = deferred<string>();
+    const { promise: fastCard, resolve: resolveFastCard } = deferred<string>();
+    const { promise: slowCard, resolve: resolveSlowCard } = deferred<string>();
+
+    function Profile() {
+      const data = createMemo(async () => profile);
+      return <h1>{data()}</h1>;
+    }
+    function FastCard() {
+      const data = createMemo(async () => fastCard);
+      return <p>{data()}</p>;
+    }
+    function SlowCard() {
+      const data = createMemo(async () => slowCard);
+      return <p>{data()}</p>;
+    }
+    function App() {
+      return (
+        <Reveal order="together">
+          <Loading fallback={<b>loading profile</b>}>
+            <Profile />
+          </Loading>
+          <Reveal order="natural">
+            <Reveal order="natural">
+              <Loading fallback={<i>loading fast card</i>}>
+                <FastCard />
+              </Loading>
+              <Loading fallback={<i>loading slow card</i>}>
+                <SlowCard />
+              </Loading>
+            </Reveal>
+          </Reveal>
+        </Reveal>
+      );
+    }
+
+    const chunksPromise = collectChunks(() => <App />);
+    await delay(10);
+    resolveFastCard("fast card");
+    await delay(10);
+    resolveProfile("profile");
+    await delay(10);
+    resolveSlowCard("slow card");
+
+    const { chunks } = await chunksPromise;
+    const full = chunks.join("");
+    const profileTemplate = full.match(/<template id="(\d+)"><h1[^>]*>profile/)?.[1];
+    const fastTemplate = full.match(/<template id="(\d+)"><p[^>]*>fast card/)?.[1];
+    const slowTemplate = full.match(/<template id="(\d+)"><p[^>]*>slow card/)?.[1];
+    const profileTemplateIndex = full.indexOf(`<template id="${profileTemplate}">`);
+    const profileActivationIndex = full.indexOf(`$dfj(["${profileTemplate}"])`);
+    const fastActivationIndex = full.indexOf(`$dfj(["${fastTemplate}"])`);
+    const slowTemplateIndex = full.indexOf(`<template id="${slowTemplate}">`);
+    const slowActivationIndex = full.indexOf(`$dfj(["${slowTemplate}"])`);
+
+    expect(profileTemplate).toBeDefined();
+    expect(fastTemplate).toBeDefined();
+    expect(slowTemplate).toBeDefined();
+    expect(profileActivationIndex).toBeGreaterThan(profileTemplateIndex);
+    expect(profileActivationIndex).toBeLessThan(slowTemplateIndex);
+    expect(fastActivationIndex).toBeGreaterThan(profileTemplateIndex);
+    expect(fastActivationIndex).toBeLessThan(slowTemplateIndex);
+    expect(slowActivationIndex).toBeGreaterThan(slowTemplateIndex);
+  });
+
   test("nested Reveal: outer sequential controls inner group", async () => {
     function Outer1() {
       const data = createMemo(async () => asyncValue("outer-1", 20));

--- a/packages/solid/src/server/flow.ts
+++ b/packages/solid/src/server/flow.ts
@@ -357,6 +357,9 @@ export function Reveal(props: RevealProps): SolidElement {
   let collapsedByParent = false;
   let selfMinimallyResolved = false;
   let notifiedParentDone = false;
+  // Child getters can keep registering slots after `props.children` returns.
+  // Do not publish readiness from a partial key set to an enclosing group.
+  let registering = true;
 
   const parent = getOwner();
   const parentGroup = parent ? runWithOwner(parent, () => getContext(RevealGroupContext)) : null;
@@ -387,7 +390,7 @@ export function Reveal(props: RevealProps): SolidElement {
   }
 
   function notifyParentIfDone() {
-    if (notifiedParentDone) return;
+    if (registering || notifiedParentDone) return;
     if (parentGroup && resolved.size === keys.length) {
       notifiedParentDone = true;
       parentGroup.onResolved(id);
@@ -401,14 +404,13 @@ export function Reveal(props: RevealProps): SolidElement {
   }
 
   function updateSelfMinimallyResolved() {
-    if (selfMinimallyResolved) return;
+    if (registering || selfMinimallyResolved) return;
     if (keys.length === 0) selfMinimallyResolved = true;
     else if (order === "together") selfMinimallyResolved = minimallyResolved.size === keys.length;
     else if (order === "sequential") selfMinimallyResolved = minimallyResolved.has(keys[0]);
-    // natural: any child being visible counts. Leaves: resolved == minimally ready;
-    // composites: natural holds them until fully ready, so `resolved` is the right
-    // signal for both.
-    else selfMinimallyResolved = resolved.size > 0;
+    // natural: any child being minimally ready counts. For composites this can
+    // precede full resolution when their own order has visible content to show.
+    else selfMinimallyResolved = minimallyResolved.size > 0;
     if (selfMinimallyResolved) parentGroup?.onMinimallyResolved?.(id);
   }
 
@@ -431,7 +433,7 @@ export function Reveal(props: RevealProps): SolidElement {
   }
 
   function checkTogetherRelease() {
-    if (order !== "together" || heldByParent) return;
+    if (registering || order !== "together" || heldByParent) return;
     if (minimallyResolved.size < keys.length) return;
     // All direct slots minimally ready: drain stashed leaf swaps and cascade
     // into every inner composite (they're minimally ready too, so this releases
@@ -508,6 +510,7 @@ export function Reveal(props: RevealProps): SolidElement {
           if (order === "natural") updateSelfMinimallyResolved();
         } else {
           // Composite fully resolved.
+          markMinimallyResolved(key);
           if (!heldByParent) {
             if (order === "sequential") advanceFrontier();
             else if (order === "natural") activateComposite(key);
@@ -523,9 +526,10 @@ export function Reveal(props: RevealProps): SolidElement {
       }
     });
     const result = props.children;
-    if (parentGroup && keys.length === 0) {
-      parentGroup.onResolved(id);
-    }
+    registering = false;
+    updateSelfMinimallyResolved();
+    checkTogetherRelease();
+    notifyParentIfDone();
     return result;
   }) as unknown as SolidElement;
 

--- a/packages/solid/src/server/signals.ts
+++ b/packages/solid/src/server/signals.ts
@@ -1625,7 +1625,7 @@ export type ServerRevealGroup = {
     key: string,
     options?: { onActivate?: () => void }
   ): { collapseFallback: boolean; held: boolean };
-  /** Called by a child when its subtree is fully resolved. */
+  /** Called by a child when its subtree is fully resolved, which also implies minimal readiness. */
   onResolved(key: string): void;
   /**
    * Called by a nested Reveal when it becomes "minimally resolved" under its own

--- a/packages/solid/test/server/reveal-ssr.spec.ts
+++ b/packages/solid/test/server/reveal-ssr.spec.ts
@@ -1560,6 +1560,103 @@ describe("Reveal SSR component", () => {
     revealed = mock.revealFragmentsCalls.flatMap(c => (Array.isArray(c) ? c : [c]));
     expect(revealed).toContain(keys[1]);
   });
+
+  const orders = ["sequential", "together", "natural"] as const;
+  const threeLevelCases = orders.flatMap(middleOrder =>
+    orders.map(innerOrder => ({ middleOrder, innerOrder }))
+  );
+
+  test.each(threeLevelCases)(
+    "three-level minimal readiness: $middleOrder middle forwards $innerOrder inner",
+    async ({ middleOrder, innerOrder }) => {
+      const mock = createMockSSRContext({ async: true });
+      sharedConfig.context = mock.context;
+
+      const gate = deferred<string>();
+      const first = deferred<string>();
+      const second = deferred<string>();
+
+      createRoot(
+        () => {
+          Reveal({
+            order: "together",
+            get children() {
+              return [
+                Loading({
+                  fallback: "gate-fb",
+                  get children() {
+                    const data = createMemo(() => gate.promise);
+                    return ssr(["<span>", "</span>"], () => data()) as any;
+                  }
+                }),
+                Reveal({
+                  order: middleOrder,
+                  get children() {
+                    return Reveal({
+                      order: innerOrder,
+                      get children() {
+                        return [
+                          Loading({
+                            fallback: "first-fb",
+                            get children() {
+                              const data = createMemo(() => first.promise);
+                              return ssr(["<span>", "</span>"], () => data()) as any;
+                            }
+                          }),
+                          Loading({
+                            fallback: "second-fb",
+                            get children() {
+                              const data = createMemo(() => second.promise);
+                              return ssr(["<span>", "</span>"], () => data()) as any;
+                            }
+                          })
+                        ] as any;
+                      }
+                    } as any);
+                  }
+                } as any)
+              ] as any;
+            }
+          } as any);
+        },
+        { id: "t" }
+      );
+
+      await tick();
+      const [gateKey, firstKey, secondKey] = [...mock.registeredFragments.keys()];
+      gate.resolve("gate");
+
+      if (innerOrder === "sequential") first.resolve("first");
+      else if (innerOrder === "natural") second.resolve("second");
+      else {
+        first.resolve("first");
+        await tick();
+        expect(mock.revealFragmentsCalls.length).toBe(0);
+        second.resolve("second");
+      }
+
+      await tick();
+      let revealed = mock.revealFragmentsCalls.flatMap(c => (Array.isArray(c) ? c : [c]));
+      expect(revealed).toContain(gateKey);
+
+      if (innerOrder === "sequential") {
+        expect(revealed).toContain(firstKey);
+        expect(revealed).not.toContain(secondKey);
+        second.resolve("second");
+      } else if (innerOrder === "natural") {
+        expect(revealed).not.toContain(firstKey);
+        expect(revealed).toContain(secondKey);
+        first.resolve("first");
+      } else {
+        expect(revealed).toContain(firstKey);
+        expect(revealed).toContain(secondKey);
+      }
+
+      await tick();
+      revealed = mock.revealFragmentsCalls.flatMap(c => (Array.isArray(c) ? c : [c]));
+      expect(revealed).toEqual(expect.arrayContaining([gateKey, firstKey, secondKey]));
+    }
+  );
 });
 
 describe("boundaries sever reveal-group membership (#2871, #2872)", () => {


### PR DESCRIPTION
Closes #2879
Closes #2880

## Summary

Fix three related readiness gaps in nested `<Reveal>` coordination:

1. **Empty composites deadlock SSR (#2879):** a nested `<Reveal>` with only static or synchronously resolved content reports full resolution but not minimal readiness. An enclosing `order="together"` therefore waits forever, leaving resolved HTML inside an inert streamed template.
2. **Nested `natural` groups release too late on SSR (#2880):** the server waits for a nested composite's entire subtree, while the client reports it minimally ready as soon as one direct child reaches its own minimally-ready state. A slow grandchild can therefore hold unrelated, already-resolved content on hard refresh but not client navigation.
3. **Nested client `together` groups propagate readiness too late:** the client releases a `together` group using direct-slot minimal readiness, but reports that group upward only after full descendant resolution. This produces the complementary asymmetry in deeper nesting.

Repros: https://stackblitz.com/edit/6mtf1sak-aa7xi7cl?file=src%2Froutes%2Findex.tsx (#2879), https://stackblitz.com/edit/6mtf1sak-cyxmot1c?file=src%2Froutes%2Findex.tsx (#2880)

## Root cause

The server tracks full resolution and minimal readiness separately:

- an empty composite called `onResolved` without ever reporting minimal readiness;
- the parent composite branch did not treat full resolution as also implying minimal readiness;
- `order="natural"` checked the fully-resolved set instead of the minimally-ready set.

There was also a registration-order hazard: an empty first composite could report completion while its parent was still registering later sibling slots, making a partially constructed `together` group appear ready.

On the client, `RevealController.evaluate()` already releases `together` using `isSlotMinimallyReady`, but `RevealController.isMinimallyReady()` used `isReady()`. The same group therefore used two different readiness rules depending on whether it was releasing itself or reporting to its parent.

## Fix

Use one recursive minimal-readiness contract across client and streaming SSR:

- full composite resolution also records minimal readiness;
- `natural` becomes minimally ready when any direct slot reaches its own minimally-ready state;
- `together` becomes minimally ready when every direct slot reaches its own minimally-ready state;
- server groups suppress readiness/completion notifications while `props.children` is registering direct slots, then finalize synchronously against the complete slot set.

A composite's minimal readiness is determined by its own order:

- `sequential`: frontier-0 is minimally ready;
- `together`: every direct slot is minimally ready;
- `natural`: any direct slot is minimally ready.

This does not make `together` non-atomic: it still releases its direct slots together. It only avoids requiring every descendant of a nested composite to fully resolve before readiness can propagate upward.

The RFC and public JSDoc now describe the same recursive rule.

## Tests

Added matching three-level 3×3 matrices to the client and server controller suites, covering every middle/inner combination of `sequential`, `together`, and `natural`.

Added streaming regressions for:

- empty nested composites under all three orders;
- an empty first composite not completing a partially registered group;
- a nested `natural` composite releasing an outer `together` before its slow grandchild resolves.

The regressions were confirmed red-first:

- #2879 emitted no activation for the resolved outer slot;
- #2880 withheld activation until the slow grandchild resolved;
- without the registration guard, the outer group released before a later sibling registered;
- the old client `together` rule failed the nested `sequential` and `natural` propagation cases.

Verification:

- `@solidjs/signals` Reveal controller: 38/38
- `solid-js` server Reveal controller: 39/39
- public `<Reveal>` wrapper: 11/11
- streaming SSR Reveal suite: 108/108
- `@solidjs/signals` build/types and `solid-js` build/types pass

## Solid 1.x note

Not applicable — `<Reveal>` and recursive reveal-order composition are new Solid 2.0 APIs with no Solid 1.x counterpart.

Full disclosure: I wrote this with the help of an AI assistant (OpenAI Codex) and reviewed every line before pushing. All regressions were confirmed against the unfixed implementation, including the client/server symmetry cases.