### PR TITLE
fix(signals): affects() as an action's first statement never lights isPending

### DIFF
--- a/.changeset/fix-affects-first-statement-lane.md
+++ b/.changeset/fix-affects-first-statement-lane.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Fix `affects(store)` as an action's first statement never lighting tracked `isPending` probes (#2887). The mark pokes the node's verdict companion while the owner is still lane-less, so the companion's optimistic lane was born parentless and the action's first optimistic write merged it into the async-carrying lane, deferring every tracked reader of the verdict to settle. Owner lane creation now adopts a companion's own unmerged, parentless lane as a child, making the parent-child relation a property of the nodes rather than of write order.

--- a/packages/solid-signals/src/core/lanes.ts
+++ b/packages/solid-signals/src/core/lanes.ts
@@ -49,7 +49,28 @@ export function getOrCreateLane(signal: Signal<any>): OptimisticLane {
   };
   signalLanes.set(signal, lane);
   activeLanes.add(lane);
+  // A companion may have written before the owner's first optimistic write
+  // (affects() as an action's first statement pokes the verdict companion of a
+  // still lane-less node, #2887), leaving its lane parentless. Adopt it now:
+  // parent-child is a property of the nodes, not of write order — otherwise
+  // the owner's write merges the companion's subscribers into this lane and
+  // their effects wait on its async instead of flushing immediately.
+  adoptCompanionLane(signal._pendingSignal, lane);
+  adoptCompanionLane(signal._latestValueComputed, lane);
   return lane;
+}
+
+function adoptCompanionLane(
+  companion: Signal<any> | Computed<any> | undefined,
+  parent: OptimisticLane
+): void {
+  if (!companion) return;
+  const companionLane = signalLanes.get(companion);
+  if (!companionLane) return;
+  const root = findLane(companionLane);
+  // Only the companion's own unmerged root is safely re-parentable: a root
+  // that absorbed other lanes carries work that is not a child of this owner.
+  if (root !== parent && root._source === companion && !root._parentLane) root._parentLane = parent;
 }
 
 /**

--- a/packages/solid-signals/tests/affects-propagation.test.ts
+++ b/packages/solid-signals/tests/affects-propagation.test.ts
@@ -26,6 +26,7 @@ import {
   createStore,
   flush,
   isPending,
+  mapArray,
   refresh
 } from "../src/index.js";
 
@@ -274,6 +275,65 @@ describe("affects — propagation through derivation", () => {
     await done;
     flush();
     expect(isPending(() => statusView())).toBe(false);
+    dispose();
+  });
+
+  it("a mark declared before the action's first optimistic write still lights tracked badges (#2887)", async () => {
+    // affects(store) as an action's FIRST statement writes the isPending
+    // companion while its owner node is still lane-less; the optimistic write
+    // that follows must not absorb the companion's lane into the store's
+    // async-carrying lane, or the badge effect defers to settle.
+    type User = { name: string };
+    let serverUsers: User[] = [{ name: "a" }];
+    const getUsers = async () => serverUsers.map(u => ({ ...u }));
+    const [users, setUsers] = createOptimisticStore<User[]>(() => getUsers(), []);
+    const log: boolean[] = [];
+    let dispose!: () => void;
+    createRoot(d => {
+      dispose = d;
+      // <For each={users}> stand-in: keeps live subscribers on the array.
+      const rows = mapArray(
+        () => users,
+        u => u.name
+      );
+      createRenderEffect(
+        () => rows(),
+        () => {}
+      );
+      const badge = createMemo(() => isPending(() => users.length));
+      createRenderEffect(badge, v => {
+        log.push(v);
+      });
+    });
+    flush();
+    await Promise.resolve();
+    flush();
+    expect(users.length).toBe(1); // initial load settled
+    log.length = 0;
+
+    let resolveIt!: () => void;
+    const act = action(function* () {
+      affects(users); // declared first — before any write
+      setUsers(u => {
+        u.push({ name: "b" });
+      });
+      yield new Promise<void>(r => (resolveIt = r));
+      serverUsers = [{ name: "a" }, { name: "b" }];
+      refresh(users as any);
+    });
+    const done = act();
+    flush();
+    expect(log).toContain(true); // the badge lit DURING the action
+    expect(isPending(() => users.length)).toBe(true);
+
+    resolveIt();
+    await done;
+    await new Promise(r => setTimeout(r, 0));
+    flush();
+    await new Promise(r => setTimeout(r, 0));
+    flush();
+    expect(isPending(() => users.length)).toBe(false);
+    expect(log.at(-1)).toBe(false);
     dispose();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #2887 — `affects(store)` declared as the **first statement** of an action (before any optimistic write) never read as pending through tracked `isPending` probes for the duration of the action; the badge blipped `true` for a single tick at settle instead. Moving the same `affects` call after the first write worked, exactly as the issue describes.

## Root cause

`affects()` on a lane-less node writes `true` into the node's `isPending` companion signal, which (being the first optimistic write) creates a lane for the companion. Companion lanes must stay **children** of their owner's lane so their effects flush immediately instead of waiting on the transaction's async — but the parent link was captured only at lane creation from `parentSource._optimisticLane`. With `affects` first, the owner has no lane yet, so the companion lane was born parentless. The action's optimistic write then reached the shared subscriber (the badge memo), found no parent-child relation in `assignOrMergeLane`, and merged the companion's lane into the store's async-carrying lane. `runLaneEffects` skips lanes with pending async, so every tracked reader of the verdict deferred to settle.

The mark itself was held correctly the whole time (refcount, untracked probes read `true`) — only tracked/effect-driven readers were starved.

## Fix

When an owner's lane is created in `getOrCreateLane`, adopt any lane its companions (`_pendingSignal`, `_latestValueComputed`) already created as a child of the new lane — the parent-child relation becomes a property of the nodes rather than of write order. Adoption is guarded to the companion's own unmerged, still-parentless root, so a lane group that has absorbed unrelated work is never re-parented.

## Testing

- New regression test in `affects-propagation.test.ts` reproducing the issue's setup (derived optimistic store + live `mapArray` subscriber + tracked badge memo): fails without the fix (badge log stays empty during the action), passes with it.
- Full suites pass: solid-signals, solid, solid-web; package typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)