### PR TITLE
feat(signals,solid): pay-for-use tree-shaking phase 2 — optimistic engine + Loading hydration seam (#2883)

### DIFF
--- a/.changeset/pay-for-use-treeshaking-phase-2.md
+++ b/.changeset/pay-for-use-treeshaking-phase-2.md
@@ -1,0 +1,8 @@
+---
+"@solidjs/signals": patch
+"solid-js": patch
+---
+
+Pay-for-use tree-shaking, phase 2 (#2883). The optimistic write engine (override writes, lane routing/suspension, stashed-optimistic reads, transition-completion blockage, optimistic-node resolution) moves out of `core.ts`/`scheduler.ts`/`lanes.ts` into a new internal `optimistic` module behind fourteen nullable `GlobalQueue` hooks, installed by the verdict layer and at first `createOptimistic`/`createOptimisticStore` call. Every core call site is gated on state only the engine can create (an `_overrideValue` slot, a live lane, a non-empty optimistic batch), and the A17 override-is-the-value read path stays inline in core. On the `solid-js` side, `createLoadingBoundary`'s hydration-resume machinery (boundary triggers, resume scheduling, asset-failure reporting, snapshot capture) now installs through the existing `enableHydration()` seam, so client-only apps stop shipping it.
+
+Measured (esbuild, minify, `_`-prop mangling, gzip -9): core floor 8.2 → 7.7 KB gzip; plain-store subset 13.0 → 12.4 KB; minimal app from published dist 11.5 → 10.9 KB; a CSR app using `<Loading>` drops a further ~0.9 KB gzip; opting into `hydrate()` costs +43 min bytes. Cumulative with phase 1, the minimal-app floor is down ~14% and the signals floor ~13.5% with no behavioral change — differential smoke runs are byte-identical and the full Tier-A suite passes unchanged.

--- a/packages/solid-signals/src/core/core.ts
+++ b/packages/solid-signals/src/core/core.ts
@@ -42,22 +42,14 @@ import {
   markHeap,
   markNode
 } from "./heap.js";
-import {
-  findLane,
-  getOrCreateLane,
-  hasActiveOverride,
-  resolveLane,
-  resolveTransition,
-  type OptimisticLane
-} from "./lanes.js";
+import { type OptimisticLane } from "./lanes.js";
 import { clearSignals, DEV, emitDiagnostic } from "./dev.js";
-import { devTrackHeldPending, devTrackOptimistic } from "./invariants.js";
+import { devTrackHeldPending } from "./invariants.js";
 import { cleanup, disposeChildren, getNextChildId, markDisposal } from "./owner.js";
 import {
   activeAffectsMarks,
   activeTransition,
   armReaskClear,
-  assignOrMergeLane,
   clock,
   dirtyQueue,
   globalQueue,
@@ -67,7 +59,6 @@ import {
   queuePendingNode,
   runInTransition,
   schedule,
-  shouldReadStashedOptimisticValue,
   zombieQueue
 } from "./scheduler.js";
 import type { Computed, FirewallSignal, Link, NodeOptions, Owner, Root, Signal } from "./types.js";
@@ -220,25 +211,20 @@ export function recompute(el: Computed<any>, create: boolean = false): void {
     strictRead = false;
   }
   tracking = true;
+  // Lane posture lives with the engine: OPTIMISTIC_DIRTY is only ever set by
+  // engine-driven paths, and _optimisticNodes is only pushed by
+  // _optimisticWrite, so the hook is installed whenever either gate holds.
   if (isOptimisticDirty) {
-    const lane = resolveLane(el);
+    const lane = GlobalQueue._recomputeLane!(el, true);
     if (lane) currentOptimisticLane = lane;
   } else if (activeTransition && !create && activeTransition._optimisticNodes.length) {
     // Lane adoption: parent-deeper-than-owned-child can run before its OPT-dirty
     // child propagates. Walk deps once and inherit the OPT lane so this node
     // recomputes under the right posture and propagates correctly.
-    for (let d: Link | null = el._deps; d; d = d._nextDep) {
-      const dep = d._dep as Computed<any>;
-      if (dep._flags & REACTIVE_OPTIMISTIC_DIRTY) {
-        const depLane = resolveLane(dep);
-        if (depLane) {
-          isOptimisticDirty = true;
-          currentOptimisticLane = depLane;
-          el._flags |= REACTIVE_OPTIMISTIC_DIRTY;
-          assignOrMergeLane(el as any, depLane);
-          break;
-        }
-      }
+    const lane = GlobalQueue._recomputeLane!(el, false);
+    if (lane) {
+      isOptimisticDirty = true;
+      currentOptimisticLane = lane;
     }
   }
   const isStaleEffect = isEffect && isEffect !== EFFECT_USER;
@@ -262,25 +248,12 @@ export function recompute(el: Computed<any>, create: boolean = false): void {
       if (!inFlightChanged && !isAsyncResult) el._inFlight = null;
     }
     clearStatus(el, create);
-    if (el._optimisticLane) {
-      const resolvedLane = resolveLane(el);
-      if (resolvedLane) {
-        resolvedLane._pendingAsync.delete(el);
-        GlobalQueue._updatePendingSignal !== null &&
-          GlobalQueue._updatePendingSignal(resolvedLane._source);
-      }
-    }
+    // _optimisticLane is only ever assigned by engine paths.
+    if (el._optimisticLane) GlobalQueue._laneAsyncSettled!(el);
   } catch (e) {
     // Track pending async in the lane (not the lane's source — it creates the lane
     // but doesn't belong to it). Set lane BEFORE notifyStatus for downstream propagation.
-    if (e instanceof NotReadyError && currentOptimisticLane) {
-      const lane = findLane(currentOptimisticLane);
-      if (lane._source !== el) {
-        lane._pendingAsync.add(el);
-        el._optimisticLane = lane;
-        GlobalQueue._updatePendingSignal !== null && GlobalQueue._updatePendingSignal(lane._source);
-      }
-    }
+    if (e instanceof NotReadyError && currentOptimisticLane) GlobalQueue._laneAsyncPending!(el);
     let reaskChanged = false;
     if (e instanceof NotReadyError) {
       el._blocked = true;
@@ -838,17 +811,10 @@ export function read<T>(el: Signal<T> | Computed<T>): T {
         });
         console.warn(message);
       }
-      if (currentOptimisticLane) {
-        // Per-lane suspension: only throw if in same lane as pending async
-        // AND the node doesn't have an active override (overrides are the visible value,
-        // downstream in the lane should read the override, not throw)
-        const pendingLane = (owner as any)._optimisticLane;
-        const lane = findLane(currentOptimisticLane);
-        if (pendingLane && findLane(pendingLane) === lane && !hasActiveOverride(owner)) {
-          if (!tracking && el !== c) link(el, c as Computed<any>);
-          throw owner._error;
-        }
-      } else {
+      // Per-lane suspension lives with the engine (a non-null lane implies it
+      // is installed): under a lane, only same-lane pending async without an
+      // active override throws.
+      if (currentOptimisticLane === null || GlobalQueue._laneSuspends!(owner)) {
         if (!tracking && el !== c) link(el, c as Computed<any>);
         throw owner._error;
       }
@@ -898,7 +864,9 @@ export function read<T>(el: Signal<T> | Computed<T>): T {
   }
 
   if (el._overrideValue !== undefined && el._overrideValue !== NOT_PENDING) {
-    if (c && stale && shouldReadStashedOptimisticValue(el as Signal<any>)) return el._value as T;
+    // An active override means the engine is installed (A17: the override IS
+    // the value for every reader — that check itself stays right here).
+    if (c && stale && GlobalQueue._readStashed!(el as Signal<any>)) return el._value as T;
     return el._overrideValue as T;
   }
 
@@ -907,35 +875,25 @@ export function read<T>(el: Signal<T> | Computed<T>): T {
   // manual writes use the firewall's manual-write flag to opt into this path.
   // Async drivers are not under an optimistic lane and so bypass this, reading
   // _pendingValue for correct fetching. The sub is recorded for replay at commit
-  // so it re-runs with the new committed view.
+  // so it re-runs with the new committed view. (Gate details live with the
+  // engine — a non-null lane implies it is installed.)
   if (
-    activeTransition !== null &&
     currentOptimisticLane !== null &&
-    !latestReadActive &&
-    el._pendingValue !== NOT_PENDING &&
-    (owner === el || !!((owner as Computed<unknown>)._flags & REACTIVE_MANUAL_WRITE)) &&
-    !(el as Partial<Computed<unknown>>)._fn &&
-    c
+    activeTransition !== null &&
+    c !== null &&
+    GlobalQueue._gatedRead!(el as Signal<any>, owner, c as Computed<any>)
   ) {
-    activeTransition._gatedSubs.add(c as Computed<any>);
     return el._value as T;
   }
 
   // In optimistic lane context, return _value for optimistic/lane-assigned signals
   // and for regular signals in stale mode (render effects). Non-stale readers (user
   // effects) see _pendingValue so that latest() and direct reads stay consistent.
-  // Exception: resolved projection store properties (firewall, owner !== el) whose
-  // STATUS_PENDING has been cleared always return _pendingValue.
-  // The latest() shadow computed (`c._parentSource === el`) always wants the
-  // in-flight value: it may recompute under a stale/lane context inherited from
-  // whichever flush ran it, and must not cache the committed value there (#2829).
+  // (The lane-context clause lives with the engine.)
   const value =
     !c ||
     (currentOptimisticLane !== null &&
-      (el._overrideValue !== undefined ||
-        (el as any)._optimisticLane ||
-        (owner === el && stale && (c as Computed<any>)._parentSource !== el) ||
-        !!(owner._statusFlags & STATUS_PENDING))) ||
+      GlobalQueue._laneReadsCommitted!(el, owner, c as Computed<any>)) ||
     el._pendingValue === NOT_PENDING ||
     (stale && el._transition && activeTransition !== el._transition)
       ? el._value
@@ -980,15 +938,14 @@ export function setSignal<T>(el: Signal<T> | Computed<T>, v: T | ((prev: T) => T
   if (el._transition && activeTransition !== el._transition)
     globalQueue.initTransition(el._transition);
 
-  const isOptimistic = el._overrideValue !== undefined && !projectionWriteActive;
-  const hasOverride = el._overrideValue !== undefined && el._overrideValue !== NOT_PENDING;
-  const currentValue = isOptimistic
-    ? hasOverride
-      ? (el._overrideValue as T)
-      : el._value
-    : el._pendingValue === NOT_PENDING
-      ? el._value
-      : (el._pendingValue as T);
+  // The optimistic write path lives with the engine: only optimisticSignal /
+  // optimisticComputed callers and optimistic store nodes carry an
+  // _overrideValue slot, and every module that creates one installs the
+  // engine first.
+  if (el._overrideValue !== undefined && !projectionWriteActive)
+    return GlobalQueue._optimisticWrite!(el, v);
+
+  const currentValue = el._pendingValue === NOT_PENDING ? el._value : (el._pendingValue as T);
 
   if (typeof v === "function") v = (v as (prev: T) => T)(currentValue);
 
@@ -998,39 +955,16 @@ export function setSignal<T>(el: Signal<T> | Computed<T>, v: T | ((prev: T) => T
     !!((el as Computed<T>)._statusFlags & STATUS_UNINITIALIZED) ||
     !el._equals ||
     !el._equals(currentValue, v);
-  if (!valueChanged) {
-    // Same-value write with an active override still entangles the current
-    // action's transition — the hold must outlast all overlapping actions.
-    if (isOptimistic && hasOverride) {
-      const transition = resolveTransition(el as any);
-      if (transition && activeTransition !== transition) globalQueue.initTransition(transition);
-    }
-    return v;
-  }
+  if (!valueChanged) return v;
 
-  if (isOptimistic) {
-    const firstOverride = el._overrideValue === NOT_PENDING;
-    if (!firstOverride) globalQueue.initTransition(resolveTransition(el as any));
-    // No revert target is stashed: while the override is active every reader
-    // sees it (A17), so authoritative arrivals commit silently into _value and
-    // reverting is just dropping the override — _value is already correct.
-    if (firstOverride) globalQueue._optimisticNodes.push(el);
-
-    const lane = getOrCreateLane(el);
-    el._optimisticLane = lane;
-
-    el._overrideValue = v;
-    if (__DEV__) devTrackOptimistic(el);
-  } else {
-    if (el._pendingValue === NOT_PENDING) queuePendingNode(el);
-    el._pendingValue = v;
-    if (__DEV__) devTrackHeldPending(el);
-  }
+  if (el._pendingValue === NOT_PENDING) queuePendingNode(el);
+  el._pendingValue = v;
+  if (__DEV__) devTrackHeldPending(el);
 
   GlobalQueue._syncCompanions !== null && GlobalQueue._syncCompanions(el, v);
 
   el._time = clock;
-  insertSubs(el, isOptimistic);
+  insertSubs(el);
   schedule();
   return v;
 }

--- a/packages/solid-signals/src/core/index.ts
+++ b/packages/solid-signals/src/core/index.ts
@@ -61,7 +61,6 @@ export {
   flush,
   Queue,
   GlobalQueue,
-  trackOptimisticStore,
   enforceLoadingBoundary,
   resetErrorHalt,
   type IQueue,

--- a/packages/solid-signals/src/core/optimistic.ts
+++ b/packages/solid-signals/src/core/optimistic.ts
@@ -1,0 +1,346 @@
+/**
+ * The optimistic write engine, moved out of core.ts/scheduler.ts. Everything
+ * here serves only optimistic overrides — createOptimistic,
+ * createOptimisticStore (and its store-node writes), and the verdict layer's
+ * companions (which are optimistic nodes). Modules that can create optimistic
+ * state call `installOptimisticEngine()` before creating it; apps that never
+ * import one of those APIs never retain any of this.
+ *
+ * Core call sites fire the hooks behind guards on state only this module can
+ * create (`_overrideValue !== undefined`, `currentOptimisticLane !== null`,
+ * `_optimisticNodes.length`, `activeLanes.size`), so `!` invocations are safe
+ * once the gate holds — the same late-binding contract as verdict.ts.
+ */
+import {
+  CONFIG_OWNED_WRITE,
+  EFFECT_RENDER,
+  EFFECT_TRACKED,
+  EFFECT_USER,
+  NOT_PENDING,
+  REACTIVE_MANUAL_WRITE,
+  REACTIVE_OPTIMISTIC_DIRTY,
+  REACTIVE_ZOMBIE,
+  STATUS_PENDING,
+  STATUS_UNINITIALIZED
+} from "./constants.js";
+import { currentOptimisticLane, latestReadActive, stale } from "./core.js";
+import { NotReadyError } from "./error.js";
+import { insertIntoHeap } from "./heap.js";
+import { devCheckMergedLaneEmpty, devTrackOptimistic } from "./invariants.js";
+import {
+  activeLanes,
+  assignOrMergeLane,
+  findLane,
+  getOrCreateLane,
+  hasActiveOverride,
+  resolveLane,
+  resolveTransition,
+  signalLanes,
+  type OptimisticLane
+} from "./lanes.js";
+import {
+  activeTransition,
+  clock,
+  dirtyQueue,
+  finalizePureQueue,
+  GlobalQueue,
+  globalQueue,
+  insertSubs,
+  schedule,
+  zombieQueue,
+  type QueueCallback,
+  type Transition
+} from "./scheduler.js";
+import type { Computed, Link, Signal } from "./types.js";
+
+type OptimisticNode = Signal<any> | Computed<any>;
+
+// When a background transition is stashed, plain optimistic signals need one
+// committed-view rerun. Keep that override local to the stash flush.
+let stashedOptimisticReads: Set<Signal<any>> | null = null;
+
+/** The optimistic half of setSignal, fired when `_overrideValue !== undefined`. */
+function optimisticWrite<T>(el: Signal<T> | Computed<T>, v: T | ((prev: T) => T)): T {
+  const hasOverride = el._overrideValue !== NOT_PENDING;
+  const currentValue = hasOverride ? (el._overrideValue as T) : el._value;
+
+  if (typeof v === "function") v = (v as (prev: T) => T)(currentValue);
+
+  const valueChanged =
+    !!((el as Computed<T>)._statusFlags & STATUS_UNINITIALIZED) ||
+    !el._equals ||
+    !el._equals(currentValue, v);
+  if (!valueChanged) {
+    // Same-value write with an active override still entangles the current
+    // action's transition — the hold must outlast all overlapping actions.
+    if (hasOverride) {
+      const transition = resolveTransition(el as any);
+      if (transition && activeTransition !== transition) globalQueue.initTransition(transition);
+    }
+    return v;
+  }
+
+  if (hasOverride) globalQueue.initTransition(resolveTransition(el as any));
+  // No revert target is stashed: while the override is active every reader
+  // sees it (A17), so authoritative arrivals commit silently into _value and
+  // reverting is just dropping the override — _value is already correct.
+  else globalQueue._optimisticNodes.push(el);
+
+  const lane = getOrCreateLane(el as Signal<any>);
+  el._optimisticLane = lane;
+
+  el._overrideValue = v;
+  if (__DEV__) devTrackOptimistic(el);
+
+  GlobalQueue._syncCompanions !== null && GlobalQueue._syncCompanions(el, v);
+
+  el._time = clock;
+  insertSubs(el, true);
+  schedule();
+  return v;
+}
+
+function readStashed(node: Signal<any>): boolean {
+  return !!stashedOptimisticReads?.has(node);
+}
+
+function queueStashedOptimisticEffects(node: Signal<any>): void {
+  for (let s = node._subs; s !== null; s = s._nextSub) {
+    const sub = s._sub as any;
+    if (!sub._type) continue;
+    if (sub._type === EFFECT_TRACKED) {
+      if (!sub._modified) {
+        sub._modified = true;
+        sub._queue.enqueue(EFFECT_USER, sub._run);
+      }
+      continue;
+    }
+    const queue = sub._flags & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue;
+    if (queue._min > sub._height) queue._min = sub._height;
+    insertIntoHeap(sub, queue);
+  }
+}
+
+/**
+ * Incomplete-transition finalization when the stashed transition holds
+ * optimistic nodes: give plain optimistic signals one committed-view rerun.
+ */
+function stashOptimistic(stashedTransition: Transition): void {
+  stashedOptimisticReads = new Set();
+  for (let i = 0; i < stashedTransition._optimisticNodes.length; i++) {
+    const node = stashedTransition._optimisticNodes[i];
+    if ((node as any)._fn || node._config & CONFIG_OWNED_WRITE) continue;
+    stashedOptimisticReads.add(node as Signal<any>);
+    queueStashedOptimisticEffects(node as Signal<any>);
+  }
+  try {
+    finalizePureQueue(null, true);
+  } finally {
+    stashedOptimisticReads = null;
+  }
+}
+
+/**
+ * transitionComplete's override blockage: a settling transition stays open
+ * while one of its optimistic nodes holds an active override that is still
+ * pending on real (non-affects-sentinel) async.
+ */
+function transitionBlocked(transition: Transition): boolean {
+  for (let i = 0; i < transition._optimisticNodes.length; i++) {
+    const node = transition._optimisticNodes[i];
+    if (
+      hasActiveOverride(node) &&
+      "_statusFlags" in node &&
+      (node as Computed<any>)._statusFlags & STATUS_PENDING &&
+      (node as Computed<any>)._error instanceof NotReadyError &&
+      // Mark-sourced pending never blocks settlement: affects() releases AT
+      // settle, so counting its sentinel here would deadlock the window it
+      // is scoped to.
+      !(((node as Computed<any>)._error as NotReadyError).source as Computed<any> | undefined)
+        ?._affectsFor
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function resolveOptimisticNodes(nodes: OptimisticNode[]): void {
+  // Settlement writes below (snapCompanionsToState → updatePendingSignal-style
+  // notifications) may push fresh optimistic nodes; only this batch settles
+  // now, so iterate a fixed window and splice it out at the end.
+  const len = nodes.length;
+  for (let i = 0; i < len; i++) {
+    const node = nodes[i];
+    node._optimisticLane = undefined;
+    // Revert is a pure drop: there is no revert target to commit —
+    // override-covered authoritative values hold in _pendingValue and
+    // elevate on their OWN transition's schedule (A18 as re-ruled 2026-07-07).
+    if (!((node as any)._statusFlags & STATUS_PENDING))
+      (node as any)._statusFlags &= ~STATUS_UNINITIALIZED;
+    const prevOverride = node._overrideValue;
+    node._overrideValue = NOT_PENDING;
+    if (prevOverride !== NOT_PENDING && node._value !== prevOverride) insertSubs(node, true);
+    node._transition = null;
+  }
+  // Settlement checkpoint (#2838): companions caught in this batch (or owned
+  // by a node in it) re-derive from committed state, so verdicts survive the
+  // transition that produced them (A19 — pending is a property of the data).
+  for (let i = 0; i < len; i++) {
+    const node = nodes[i];
+    if (node._pendingSignal || node._latestValueComputed) GlobalQueue._snapCompanions!(node);
+    const owner = node._parentSource;
+    if (owner && (owner._pendingSignal === node || owner._latestValueComputed === node))
+      GlobalQueue._snapCompanions!(owner);
+  }
+  nodes.splice(0, len);
+}
+
+function runQueue(queue: QueueCallback[], type: number): void {
+  for (let i = 0; i < queue.length; i++) queue[i](type);
+}
+
+/**
+ * Run effects from all lanes that are ready (no pending async).
+ */
+function runLaneEffects(type: number): void {
+  for (const lane of activeLanes) {
+    if (__DEV__) devCheckMergedLaneEmpty(lane);
+    if (lane._mergedInto || lane._pendingAsync.size > 0) continue;
+    const effects = lane._effectQueues[type - 1];
+    if (effects.length) {
+      lane._effectQueues[type - 1] = [];
+      runQueue(effects, type);
+    }
+  }
+}
+
+function cleanupCompletedLanes(completingTransition: Transition | null): void {
+  for (const lane of activeLanes) {
+    const owned = completingTransition
+      ? lane._transition === completingTransition
+      : !lane._transition;
+    if (!owned) continue;
+    if (!lane._mergedInto) {
+      if (lane._effectQueues[0].length) runQueue(lane._effectQueues[0], EFFECT_RENDER);
+      if (lane._effectQueues[1].length) runQueue(lane._effectQueues[1], EFFECT_USER);
+    }
+    if (lane._source._optimisticLane === lane) lane._source._optimisticLane = undefined;
+    lane._pendingAsync.clear();
+    lane._effectQueues[0].length = 0;
+    lane._effectQueues[1].length = 0;
+    activeLanes.delete(lane);
+    signalLanes.delete(lane._source);
+  }
+}
+
+/** read()'s per-lane suspension test (pending-throw path, lane context). */
+function laneSuspends(owner: OptimisticNode): boolean {
+  // Per-lane suspension: only throw if in same lane as pending async
+  // AND the node doesn't have an active override (overrides are the visible value,
+  // downstream in the lane should read the override, not throw)
+  const pendingLane = (owner as any)._optimisticLane as OptimisticLane | undefined;
+  if (!pendingLane) return false;
+  return findLane(pendingLane) === findLane(currentOptimisticLane!) && !hasActiveOverride(owner);
+}
+
+/**
+ * read()'s entanglement gate: a reader recomputing under an optimistic lane
+ * that reads a pending mid-transition write sees the committed value; the sub
+ * is recorded for replay at commit.
+ */
+function gatedRead(el: Signal<any>, owner: OptimisticNode, c: Computed<any>): boolean {
+  if (
+    latestReadActive ||
+    el._pendingValue === NOT_PENDING ||
+    (el as Partial<Computed<unknown>>)._fn ||
+    (owner !== el && !((owner as Computed<unknown>)._flags & REACTIVE_MANUAL_WRITE))
+  ) {
+    return false;
+  }
+  activeTransition!._gatedSubs.add(c);
+  return true;
+}
+
+/**
+ * read()'s value selection under a lane: return the committed `_value` for
+ * optimistic/lane-assigned signals, stale-mode reads, and pending owners.
+ */
+function laneReadsCommitted(el: OptimisticNode, owner: OptimisticNode, c: Computed<any>): boolean {
+  return (
+    el._overrideValue !== undefined ||
+    !!(el as any)._optimisticLane ||
+    (owner === el && stale && (c as Computed<any>)._parentSource !== el) ||
+    !!((owner as Computed<any>)._statusFlags & STATUS_PENDING)
+  );
+}
+
+/**
+ * recompute()'s lane posture: resolve the node's own lane (own=true), or adopt
+ * a dependency's optimistic lane (own=false — parent-deeper-than-owned-child
+ * can run before its OPT-dirty child propagates).
+ */
+function recomputeLane(el: Computed<any>, own: boolean): OptimisticLane | null {
+  if (own) return resolveLane(el) ?? null;
+  for (let d: Link | null = el._deps; d; d = d._nextDep) {
+    const dep = d._dep as Computed<any>;
+    if (dep._flags & REACTIVE_OPTIMISTIC_DIRTY) {
+      const depLane = resolveLane(dep);
+      if (depLane) {
+        el._flags |= REACTIVE_OPTIMISTIC_DIRTY;
+        assignOrMergeLane(el as any, depLane);
+        return depLane;
+      }
+    }
+  }
+  return null;
+}
+
+/** recompute()'s catch path: track pending async in the current lane. */
+function laneAsyncPending(el: Computed<any>): void {
+  const lane = findLane(currentOptimisticLane!);
+  if (lane._source !== el) {
+    lane._pendingAsync.add(el);
+    el._optimisticLane = lane;
+    GlobalQueue._updatePendingSignal !== null && GlobalQueue._updatePendingSignal(lane._source);
+  }
+}
+
+/** recompute()'s success path: the node's async settled, clear it from its lane. */
+function laneAsyncSettled(el: Computed<any>): void {
+  const resolvedLane = resolveLane(el);
+  if (resolvedLane) {
+    resolvedLane._pendingAsync.delete(el);
+    GlobalQueue._updatePendingSignal !== null &&
+      GlobalQueue._updatePendingSignal(resolvedLane._source);
+  }
+}
+
+function trackOptimisticStore(store: any): void {
+  // After initTransition, globalQueue._optimisticStores IS activeTransition._optimisticStores (same reference)
+  globalQueue._optimisticStores.add(store);
+  schedule();
+}
+
+/**
+ * Installs the engine's hooks. Idempotent; called by every module that can
+ * create optimistic state (verdict.ts at module top level, createOptimistic
+ * and createOptimisticStore at first call) BEFORE any optimistic node exists.
+ */
+export function installOptimisticEngine(): void {
+  if (GlobalQueue._optimisticWrite !== null) return;
+  GlobalQueue._optimisticWrite = optimisticWrite;
+  GlobalQueue._resolveOptimistic = resolveOptimisticNodes;
+  GlobalQueue._stashOptimistic = stashOptimistic;
+  GlobalQueue._transitionBlocked = transitionBlocked;
+  GlobalQueue._cleanupLanes = cleanupCompletedLanes;
+  GlobalQueue._runLaneEffects = runLaneEffects;
+  GlobalQueue._readStashed = readStashed;
+  GlobalQueue._gatedRead = gatedRead;
+  GlobalQueue._laneSuspends = laneSuspends;
+  GlobalQueue._laneReadsCommitted = laneReadsCommitted;
+  GlobalQueue._recomputeLane = recomputeLane;
+  GlobalQueue._laneAsyncPending = laneAsyncPending;
+  GlobalQueue._laneAsyncSettled = laneAsyncSettled;
+  GlobalQueue._trackOptimisticStore = trackOptimisticStore;
+}

--- a/packages/solid-signals/src/core/scheduler.ts
+++ b/packages/solid-signals/src/core/scheduler.ts
@@ -1,6 +1,5 @@
 import {
   CONFIG_IN_SNAPSHOT_SCOPE,
-  CONFIG_OWNED_WRITE,
   EFFECT_RENDER,
   EFFECT_TRACKED,
   EFFECT_USER,
@@ -22,8 +21,8 @@ import {
   activeLanes,
   assignOrMergeLane,
   findLane,
-  hasActiveOverride,
-  signalLanes
+  signalLanes,
+  type OptimisticLane
 } from "./lanes.js";
 import {
   beginAsyncReporterWrites,
@@ -31,7 +30,6 @@ import {
   devCensusCompanions,
   devCheckActiveOverrides,
   devCheckFlushStart,
-  devCheckMergedLaneEmpty,
   devCheckQuiescent,
   endAsyncReporterWrites
 } from "./invariants.js";
@@ -65,9 +63,6 @@ let inTrackedQueueCallback = false;
 
 let _enforceLoadingBoundary = false;
 export let _hitUnhandledAsync = false;
-// When a background transition is stashed, plain optimistic signals need one
-// committed-view rerun. Keep that override local to the stash flush.
-let stashedOptimisticReads: Set<Signal<any>> | null = null;
 
 // Store property nodes that were created solely to carry a pending write (no
 // subscribers at write time). Swept after each flush that commits pending
@@ -121,42 +116,6 @@ export function resetUnhandledAsync(): void {
  */
 export function enforceLoadingBoundary(enabled: boolean): void {
   _enforceLoadingBoundary = enabled;
-}
-
-export function shouldReadStashedOptimisticValue(node: Signal<any>): boolean {
-  return !!stashedOptimisticReads?.has(node);
-}
-
-/**
- * Run effects from all lanes that are ready (no pending async).
- */
-function runLaneEffects(type: number): void {
-  for (const lane of activeLanes) {
-    if (__DEV__) devCheckMergedLaneEmpty(lane);
-    if (lane._mergedInto || lane._pendingAsync.size > 0) continue;
-    const effects = lane._effectQueues[type - 1];
-    if (effects.length) {
-      lane._effectQueues[type - 1] = [];
-      runQueue(effects, type);
-    }
-  }
-}
-
-function queueStashedOptimisticEffects(node: Signal<any>): void {
-  for (let s = node._subs; s !== null; s = s._nextSub) {
-    const sub = s._sub as any;
-    if (!sub._type) continue;
-    if (sub._type === EFFECT_TRACKED) {
-      if (!sub._modified) {
-        sub._modified = true;
-        sub._queue.enqueue(EFFECT_USER, sub._run);
-      }
-      continue;
-    }
-    const queue = sub._flags & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue;
-    if (queue._min > sub._height) queue._min = sub._height;
-    insertIntoHeap(sub, queue);
-  }
 }
 
 export function setProjectionWriteActive(value: boolean) {
@@ -213,64 +172,6 @@ function mergeTransitionState(target: Transition, outgoing: Transition): void {
   }
   if (__DEV__) endAsyncReporterWrites();
   for (const sub of outgoing._gatedSubs) target._gatedSubs.add(sub);
-}
-
-function resolveOptimisticNodes(nodes: OptimisticNode[]): void {
-  // Settlement writes below (snapCompanionsToState → updatePendingSignal-style
-  // notifications) may push fresh optimistic nodes; only this batch settles
-  // now, so iterate a fixed window and splice it out at the end.
-  const len = nodes.length;
-  for (let i = 0; i < len; i++) {
-    const node = nodes[i];
-    node._optimisticLane = undefined;
-    // Revert is a pure drop: there is no revert target to commit —
-    // override-covered authoritative values hold in _pendingValue and
-    // elevate on their OWN transition's schedule (A18 as re-ruled 2026-07-07). A pv still held
-    // here belongs to a transition that hasn't completed and must NOT commit
-    // early. (Reverts run inside finalizePureQueue AFTER commitPendingNodes,
-    // so holds owned by the completing transition have already elevated.)
-    // A node that lived its whole first transition under an override (e.g.
-    // the latest() shadow created mid-initial-load, #2829) has shown values
-    // without ever committing one; it is initialized in every observable
-    // sense, so clear the marker or later refetches mis-classify as initial
-    // load (pending reads false / readers suspend).
-    if (!((node as any)._statusFlags & STATUS_PENDING))
-      (node as any)._statusFlags &= ~STATUS_UNINITIALIZED;
-    const prevOverride = node._overrideValue;
-    node._overrideValue = NOT_PENDING;
-    if (prevOverride !== NOT_PENDING && node._value !== prevOverride) insertSubs(node, true);
-    node._transition = null;
-  }
-  // Settlement checkpoint (#2838): companions caught in this batch (or owned
-  // by a node in it) re-derive from committed state, so verdicts survive the
-  // transition that produced them (A19 — pending is a property of the data).
-  for (let i = 0; i < len; i++) {
-    const node = nodes[i];
-    if (node._pendingSignal || node._latestValueComputed) GlobalQueue._snapCompanions!(node);
-    const owner = node._parentSource;
-    if (owner && (owner._pendingSignal === node || owner._latestValueComputed === node))
-      GlobalQueue._snapCompanions!(owner);
-  }
-  nodes.splice(0, len);
-}
-
-function cleanupCompletedLanes(completingTransition: Transition | null): void {
-  for (const lane of activeLanes) {
-    const owned = completingTransition
-      ? lane._transition === completingTransition
-      : !lane._transition;
-    if (!owned) continue;
-    if (!lane._mergedInto) {
-      if (lane._effectQueues[0].length) runQueue(lane._effectQueues[0], EFFECT_RENDER);
-      if (lane._effectQueues[1].length) runQueue(lane._effectQueues[1], EFFECT_USER);
-    }
-    if (lane._source._optimisticLane === lane) lane._source._optimisticLane = undefined;
-    lane._pendingAsync.clear();
-    lane._effectQueues[0].length = 0;
-    lane._effectQueues[1].length = 0;
-    activeLanes.delete(lane);
-    signalLanes.delete(lane._source);
-  }
 }
 
 export function schedule() {
@@ -450,6 +351,32 @@ export class GlobalQueue extends Queue {
   static _applyReask: ((el: Computed<any>, hadReask: boolean) => boolean) | null = null;
   static _repollVerdicts: ((el: Computed<any>) => void) | null = null;
   static _witnessAffects: ((node: OptimisticNode) => void) | null = null;
+  // Optimistic-engine hooks (wired by core/optimistic.ts via
+  // installOptimisticEngine(), called from verdict.ts / createOptimistic /
+  // createOptimisticStore — every module that can create optimistic state).
+  // Call sites are gated by state only the engine can create: an
+  // `_overrideValue` slot, a lane in `activeLanes`, an `_optimisticNodes`
+  // entry, or a non-null `currentOptimisticLane`, so `!` invocations are safe
+  // once the gate holds.
+  static _optimisticWrite: (<T>(el: Signal<T> | Computed<T>, v: T | ((prev: T) => T)) => T) | null =
+    null;
+  static _resolveOptimistic: ((nodes: OptimisticNode[]) => void) | null = null;
+  static _stashOptimistic: ((stashedTransition: Transition) => void) | null = null;
+  static _transitionBlocked: ((transition: Transition) => boolean) | null = null;
+  static _cleanupLanes: ((completingTransition: Transition | null) => void) | null = null;
+  static _runLaneEffects: ((type: number) => void) | null = null;
+  static _readStashed: ((el: Signal<any>) => boolean) | null = null;
+  static _gatedRead:
+    | ((el: Signal<any>, owner: OptimisticNode, c: Computed<any>) => boolean)
+    | null = null;
+  static _laneSuspends: ((owner: OptimisticNode) => boolean) | null = null;
+  static _laneReadsCommitted:
+    | ((el: OptimisticNode, owner: OptimisticNode, c: Computed<any>) => boolean)
+    | null = null;
+  static _recomputeLane: ((el: Computed<any>, own: boolean) => OptimisticLane | null) | null = null;
+  static _laneAsyncPending: ((el: Computed<any>) => void) | null = null;
+  static _laneAsyncSettled: ((el: Computed<any>) => void) | null = null;
+  static _trackOptimisticStore: ((store: any) => void) | null = null;
   flush() {
     if (this._running) return;
     this._running = true;
@@ -468,31 +395,27 @@ export class GlobalQueue extends Queue {
           this._optimisticStores = new Set();
 
           // Run lane effects immediately (before stashing) - lanes with no pending async
-          runLaneEffects(EFFECT_RENDER);
-          runLaneEffects(EFFECT_USER);
+          if (activeLanes.size) {
+            GlobalQueue._runLaneEffects!(EFFECT_RENDER);
+            GlobalQueue._runLaneEffects!(EFFECT_USER);
+          }
 
           this.stashQueues(stashedTransition._queueStash);
           clock++;
           scheduled = dirtyQueue._max >= dirtyQueue._min;
           reassignPendingTransition(stashedTransition._pendingNodes);
           activeTransition = null;
+          // The stash pass (committed-view rerun of plain optimistic signals)
+          // wraps finalizePureQueue in the engine; a non-empty _optimisticNodes
+          // means _optimisticWrite ran, which installed the hook.
           if (
             !stashedTransition._actions.length &&
             !stashedTransition._asyncReporters.size &&
             stashedTransition._optimisticNodes.length
           ) {
-            stashedOptimisticReads = new Set();
-            for (let i = 0; i < stashedTransition._optimisticNodes.length; i++) {
-              const node = stashedTransition._optimisticNodes[i];
-              if ((node as any)._fn || node._config & CONFIG_OWNED_WRITE) continue;
-              stashedOptimisticReads.add(node);
-              queueStashedOptimisticEffects(node);
-            }
-          }
-          try {
+            GlobalQueue._stashOptimistic!(stashedTransition);
+          } else {
             finalizePureQueue(null, true);
-          } finally {
-            stashedOptimisticReads = null;
           }
           return;
         }
@@ -520,9 +443,9 @@ export class GlobalQueue extends Queue {
       // Check if finalization added items to the heap (from optimistic reversion)
       scheduled = dirtyQueue._max >= dirtyQueue._min;
       // Run lane effects first (for ready lanes), then regular effects
-      activeLanes.size && runLaneEffects(EFFECT_RENDER);
+      activeLanes.size && GlobalQueue._runLaneEffects!(EFFECT_RENDER);
       this.run(EFFECT_RENDER);
-      activeLanes.size && runLaneEffects(EFFECT_USER);
+      activeLanes.size && GlobalQueue._runLaneEffects!(EFFECT_USER);
       this.run(EFFECT_USER);
       if (__DEV__) {
         devCheckActiveOverrides(n => {
@@ -750,9 +673,12 @@ export function finalizePureQueue(
   if (ranHeap) runHeap(dirtyQueue, GlobalQueue._update);
   if (resolvePending) {
     if (ranHeap) commitPendingNodes();
-    resolveOptimisticNodes(
-      completingTransition ? completingTransition._optimisticNodes : globalQueue._optimisticNodes
-    );
+    // Optimistic reversion: a non-empty batch means _optimisticWrite ran,
+    // which installed the engine's hooks.
+    const optimisticNodes = completingTransition
+      ? completingTransition._optimisticNodes
+      : globalQueue._optimisticNodes;
+    if (optimisticNodes.length) GlobalQueue._resolveOptimistic!(optimisticNodes);
     // Replay entanglement: subs recorded by the read-time gate get rescheduled
     // so they re-run with the now-committed values visible.
     if (completingTransition && completingTransition._gatedSubs.size) {
@@ -789,7 +715,8 @@ export function finalizePureQueue(
       schedule();
     }
     sweepTransientStoreNodes();
-    cleanupCompletedLanes(completingTransition);
+    // Lanes only enter activeLanes through the engine's getOrCreateLane.
+    if (activeLanes.size) GlobalQueue._cleanupLanes!(completingTransition);
   }
 }
 
@@ -798,12 +725,6 @@ function checkBoundaryChildren(queue: Queue) {
     (child as any).checkSources?.();
     checkBoundaryChildren(child as Queue);
   }
-}
-
-export function trackOptimisticStore(store: any): void {
-  // After initTransition, globalQueue._optimisticStores IS activeTransition._optimisticStores (same reference)
-  globalQueue._optimisticStores.add(store);
-  schedule();
 }
 
 /**
@@ -941,24 +862,11 @@ function transitionComplete(transition: Transition): boolean {
       break;
     }
   }
-  if (done) {
-    for (let i = 0; i < transition._optimisticNodes.length; i++) {
-      const node = transition._optimisticNodes[i];
-      if (
-        hasActiveOverride(node) &&
-        "_statusFlags" in node &&
-        node._statusFlags & STATUS_PENDING &&
-        node._error instanceof NotReadyError &&
-        // Mark-sourced pending never blocks settlement: affects() releases AT
-        // settle, so counting its sentinel here would deadlock the window it
-        // is scoped to.
-        !(node._error.source as Computed<any> | undefined)?._affectsFor
-      ) {
-        done = false;
-        break;
-      }
-    }
-  }
+  // Override blockage lives with the engine. Absent hook = "no optimistic
+  // blockage", which is exact: only _optimisticWrite (engine) pushes to
+  // _optimisticNodes, so without the engine the loop was vacuous anyway.
+  if (done && transition._optimisticNodes.length && GlobalQueue._transitionBlocked!(transition))
+    done = false;
   done && (transition._done = true);
   return done;
 }

--- a/packages/solid-signals/src/core/verdict.ts
+++ b/packages/solid-signals/src/core/verdict.ts
@@ -36,8 +36,14 @@ import { link } from "./graph.js";
 import { insertIntoHeap } from "./heap.js";
 import { devTrackCompanionOwner, InvariantHooks } from "./invariants.js";
 import { findLane, hasActiveOverride } from "./lanes.js";
+import { installOptimisticEngine } from "./optimistic.js";
 import { clock, dirtyQueue, GlobalQueue, insertSubs, schedule, zombieQueue } from "./scheduler.js";
 import type { Computed, FirewallSignal, Signal } from "./types.js";
+
+// Companions (pending signals / latest shadows) are optimistic nodes: their
+// writes go through the optimistic write path and their reversion rides the
+// same lanes, so the verdict layer brings the engine with it.
+installOptimisticEngine();
 
 interface PendingProbe {
   found: boolean;

--- a/packages/solid-signals/src/signals.ts
+++ b/packages/solid-signals/src/signals.ts
@@ -23,6 +23,7 @@ import {
   untrack
 } from "./core/index.js";
 import { emitDiagnostic, registerGraph } from "./core/dev.js";
+import { installOptimisticEngine } from "./core/optimistic.js";
 import { globalQueue } from "./core/scheduler.js";
 
 /**
@@ -703,6 +704,10 @@ export function createOptimistic<T>(
   first?: T | ComputeFunction<T>,
   second?: SignalOptions<T> & MemoOptions<T>
 ): Signal<T | undefined> {
+  // Install before the node exists: only engine-installed programs can carry
+  // an _overrideValue slot (same runtime-install pattern as
+  // GlobalQueue._clearOptimisticStore in createOptimisticStore).
+  installOptimisticEngine();
   if (typeof first === "function") {
     const node = optimisticComputed<T>(first as any, second as any);
     node._config &= ~CONFIG_AUTO_DISPOSE;

--- a/packages/solid-signals/src/store/optimistic.ts
+++ b/packages/solid-signals/src/store/optimistic.ts
@@ -5,6 +5,7 @@ import {
   type Computed,
   type Refreshable
 } from "../core/index.js";
+import { installOptimisticEngine } from "../core/optimistic.js";
 import {
   GlobalQueue,
   insertSubs,
@@ -93,7 +94,10 @@ export function createOptimisticStore<T extends object = {}>(
   second?: NoFn<T> | Store<NoFn<T>>,
   options?: ProjectionOptions
 ): [get: Store<T>, set: StoreSetter<T>] {
-  // Register clear function with scheduler
+  // Register clear function with scheduler; store nodes marked
+  // STORE_OPTIMISTIC take the engine's write path, so install it before any
+  // node can be created.
+  installOptimisticEngine();
   GlobalQueue._clearOptimisticStore ||= clearOptimisticStore;
   const derived = typeof first === "function";
   const initialValue = (derived ? second : first) as T;

--- a/packages/solid-signals/src/store/store.ts
+++ b/packages/solid-signals/src/store/store.ts
@@ -18,7 +18,6 @@ import {
   signal,
   STORE_SNAPSHOT_PROPS,
   suppressComputedRecompute,
-  trackOptimisticStore,
   untrack,
   type Computed,
   type Refreshable,
@@ -589,8 +588,10 @@ function prepareStoreWrite(target: StoreNode, store: any, property: PropertyKey)
  * neither pends its own slot nor silences anyone else's.
  */
 function armOptimisticStoreWrite(target: StoreNode, store: any): void {
+  // STORE_OPTIMISTIC is only set by createOptimisticStore, which installs the
+  // optimistic engine before wrapping.
   if (target[STORE_OPTIMISTIC] && !projectionWriteActive) {
-    trackOptimisticStore(store);
+    GlobalQueue._trackOptimisticStore!(store);
   }
 }
 

--- a/packages/solid-signals/tests/treeshake.test.ts
+++ b/packages/solid-signals/tests/treeshake.test.ts
@@ -74,13 +74,14 @@ describe("pay-for-use tree-shaking (#2883)", () => {
         "map.ts",
         "affects.ts",
         "core/verdict.ts",
+        "core/optimistic.ts",
         "core/action.ts",
         "core/context.ts"
       ])
     ).toEqual([]);
-    // Ceiling: 19,546 bytes measured at landing (vite/rollup bundle +
+    // Ceiling: 18,214 bytes measured at landing (vite/rollup bundle +
     // esbuild minify with `_`-property mangling) + ~7% headroom.
-    expect(minifiedBytes).toBeLessThan(21_000);
+    expect(minifiedBytes).toBeLessThan(19_500);
   });
 
   it("plain stores shed the verdict layer, affects, boundaries, and map", async () => {
@@ -90,8 +91,21 @@ describe("pay-for-use tree-shaking (#2883)", () => {
     // reconcile.ts/projection.ts stay: the derived createStore overload keeps
     // them statically coupled by design (API symmetry ruling, #2883).
     expect(
-      retainedFrom(retained, ["core/verdict.ts", "affects.ts", "boundaries.ts", "map.ts"])
+      retainedFrom(retained, [
+        "core/verdict.ts",
+        "core/optimistic.ts",
+        "affects.ts",
+        "boundaries.ts",
+        "map.ts"
+      ])
     ).toEqual([]);
+  });
+
+  it("createOptimistic loads the optimistic engine; the floor ceiling reflects its absence", async () => {
+    const { retained } = await bundleFixture(
+      `export { createSignal, createEffect, createRoot, flush, createOptimistic } from "sigsrc";`
+    );
+    expect(retainedFrom(retained, ["core/optimistic.ts"])).toEqual(["core/optimistic.ts"]);
   });
 
   it("isPending/latest load the verdict layer and nothing else new", async () => {

--- a/packages/solid/src/client/hydration.ts
+++ b/packages/solid/src/client/hydration.ts
@@ -220,6 +220,7 @@ let _createStore: Function | undefined;
 let _createOptimisticStore: Function | undefined;
 let _createRenderEffect: Function | undefined;
 let _createEffect: Function | undefined;
+let _createLoadingBoundary: Function | undefined;
 
 // --- Hydration helpers ---
 
@@ -763,6 +764,7 @@ export function enableHydration() {
   _createOptimisticStore = hydratedCreateOptimisticStore;
   _createRenderEffect = hydratedCreateRenderEffect;
   _createEffect = hydratedCreateEffect;
+  _createLoadingBoundary = hydratedCreateLoadingBoundary;
 
   _hydratingValue = sharedConfig.hydrating;
   _doneValue = sharedConfig.done;
@@ -1362,7 +1364,20 @@ function scheduleResumeAfterAssets(
  *
  * @internal
  */
-export function createLoadingBoundary<T, U>(
+export const createLoadingBoundary = (<T, U>(
+  fn: () => T,
+  fallback: () => U,
+  options?: { on?: () => any }
+): Accessor<T | U> => (_createLoadingBoundary || coreLoadingBoundary)(fn, fallback, options)) as <
+  T,
+  U
+>(
+  fn: () => T,
+  fallback: () => U,
+  options?: { on?: () => any }
+) => Accessor<T | U>;
+
+function hydratedCreateLoadingBoundary<T, U>(
   fn: () => T,
   fallback: () => U,
   options?: { on?: () => any }


### PR DESCRIPTION
Phase 2 of #2883. Two seams, both following the phase-1 hook pattern, both adversarially verified with byte-exact reproduction before landing.

## Measured (esbuild, minify, `--mangle-props='^_'`, gzip -9)

| Fixture | before | after | Δ gzip |
|---|---|---|---|
| Core floor from src | 20,404 / 8,248 | **18,921 / 7,683** | −7% |
| Plain-store subset | 33,740 / 13,039 | **32,230 / 12,445** | −5% |
| Minimal app from published dist | 29,081 / 11,461 | **27,570 / 10,866** | −5% |
| CSR app using `<Loading>`/`<Errored>`/`lazy` | 37,313 / 14,775 | **34,844 / 13,876** | −6% |
| `hydrate()` opt-in overhead | — | +43 min bytes | — |
| Full flat bundle | 54,477 / 20,319 | 55,366 / 20,583 | +264 (hook tax; chunked prod dist consumers unaffected) |

Cumulative with phase 1 (#2885): minimal app 12,656 → 10,866 gz (**−14%**), signals floor 8,885 → 7,683 gz (**−13.5%**).

## Optimistic write engine (`@solidjs/signals`)

New internal `core/optimistic.ts` absorbs everything the floor retained purely for optimistic APIs: the `setSignal` override write path, lane routing in `read()`/`recompute`, stashed-optimistic reads, `transitionComplete`'s override blockage, optimistic-node resolution and store-stash effects — 14 nullable `GlobalQueue` statics, installed idempotently by `verdict.ts` (companions are optimistic nodes) and at first `createOptimistic`/`createOptimisticStore` call.

Boundary discipline per the design rulings: `async.ts` is untouched (promise-triggered transitions stay core), `lanes.ts` keeps everything async writes reach, A17's override-is-the-value check and return stay inline in `read()`, and every hooked call site is gated on state only the engine can create (an `_overrideValue` slot, a live lane, a non-empty `_optimisticNodes` batch) — so the `!` invocations follow the same structural-safety contract as phase 1. A 25-assertion differential smoke (plain propagation, promise-memo through a transition with holds and verdicts, optimistic revert, `action()` + `createOptimistic`, optimistic store write/revert) is byte-identical baseline vs hooked.

## `<Loading>` hydration-resume seam (`solid-js`)

`createLoadingBoundary` becomes a dispatcher over a tenth hydration override slot (`_createLoadingBoundary`), exactly like the existing `hydratedCreate*` overrides installed by `enableHydration()`. The resume machinery — `createBoundaryTrigger`, `resumeBoundaryHydration`, `initBoundaryResume`, `waitAndResume`, `reportAssetFailure`, `scheduleResumeAfterAssets`, plus the snapshot-capture APIs — is now reachable only through hydration, so client-rendered apps shake it (−2,469 min / −899 gz on the controlled fixture; `hydration.ts` contribution drops 2,686 → 607).

## Verification

- 984 signals + 456 solid + 501 solid-web (client/server/hydrate) tests green; typecheck clean.
- Tree-shake guard extended: `core/optimistic.ts` must be absent from the floor and plain-store fixtures and present with `createOptimistic`; floor byte ceiling tightened 21 KB → 19.5 KB.
- Prod chunked-dist runtime smoke covering signal→memo→effect, `createOptimistic` + `isPending`, cross-module mangled property access.

Companion change: ryansolid/dom-expressions#543 dedupes the `DOMElements` set (286 → 149 entries, membership-identical) for ~1 KB wherever the set is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
