### PR TITLE
fix(store): snapshot() and store materialization keep symbol-keyed props

### DIFF
--- a/.changeset/preserve-store-symbol-snapshots.md
+++ b/.changeset/preserve-store-symbol-snapshots.md
@@ -1,0 +1,7 @@
+---
+"@solidjs/signals": patch
+---
+
+Preserve enumerable symbol-keyed properties when snapshotting and deeply
+tracking stores, including array metadata and untouched nested values. Make
+setter drafts writable when the store type is readonly.

--- a/packages/solid-signals/src/store/reconcile.ts
+++ b/packages/solid-signals/src/store/reconcile.ts
@@ -53,6 +53,8 @@ function addEnumSymbols(o: any, syms: symbol[], keys: Set<PropertyKey>) {
 }
 
 function getAllKeys(value, override, next) {
+  // Symbols are merged explicitly below; keep the common string-key path on
+  // Object.keys() and avoid reflecting the base symbols twice.
   const keys = getKeys(value, override) as PropertyKey[];
   const nextKeys = Object.keys(next);
   // `value` can be a wrapped store (store-in-store) whose ownKeys trap tracks;

--- a/packages/solid-signals/src/store/store.ts
+++ b/packages/solid-signals/src/store/store.ts
@@ -56,7 +56,7 @@ export type Store<T> = Readonly<T>;
  * projection form — `createStore(fn, seed, { key })` or `createProjection` —
  * whose derive function reconciles its return by `options.key`.
  */
-export type StoreSetter<T> = (fn: (state: T) => T | void) => void;
+export type StoreSetter<T> = (fn: (state: Mutable<T>) => Mutable<T> | void) => void;
 /** Tuple returned by the plain `createStore(initialValue)` form. */
 export type StoreReturn<T> = [get: Store<T>, set: StoreSetter<T>];
 /** Tuple returned by the derived `createStore(fn, seed, options?)` form. */
@@ -72,6 +72,8 @@ export interface ProjectionOptions extends StoreOptions {
   key?: string | ((item: NonNullable<any>) => any);
 }
 export type NoFn<T> = T extends Function ? never : T;
+/** Makes the setter draft's top-level properties writable; {@link Store} keeps the getter readonly. */
+export type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
 type DataNode = Signal<any>;
 type DataNodes = Record<PropertyKey, DataNode>;
@@ -200,7 +202,7 @@ function unwrapStoreValue(value: any, map?: Map<any, any>, lookup?: WeakMap<any,
   map.set(value, result);
   lookup = target[STORE_LOOKUP] ?? storeLookup;
 
-  for (const key of getKeys(source, override)) {
+  for (const key of getStoreKeys(source, override)) {
     if (isArray && key === "length") continue;
     const next = key in override ? override[key] : source[key];
     if (next !== $DELETED) result[key] = unwrapStoreValue(next, map, lookup);
@@ -216,6 +218,29 @@ function isPrototypePollutionKey(property: PropertyKey) {
 // Own enumerable keys including symbols (`Object.keys` drops symbol-keyed props). #2769
 export function ownEnumerableKeys(o: object): (string | symbol)[] {
   return Reflect.ownKeys(o).filter(k => Object.prototype.propertyIsEnumerable.call(o, k));
+}
+
+// Plain-object variant that keeps Object.keys() as the fast path and only pays
+// descriptor checks for symbols. Do not use this on store proxies: splitting
+// strings/symbols would invoke their ownKeys trap twice.
+function ownEnumerableKeysPlain(o: object): (string | symbol)[] {
+  const keys: (string | symbol)[] = Object.keys(o);
+  const symbols = Object.getOwnPropertySymbols(o);
+  for (let i = 0, len = symbols.length; i < len; i++) {
+    const symbol = symbols[i];
+    if (Object.prototype.propertyIsEnumerable.call(o, symbol)) keys.push(symbol);
+  }
+  return keys;
+}
+
+function ownEnumerableSymbols(o: object): symbol[] {
+  const symbols = Object.getOwnPropertySymbols(o);
+  const result: symbol[] = [];
+  for (let i = 0, len = symbols.length; i < len; i++) {
+    const symbol = symbols[i];
+    if (Object.prototype.propertyIsEnumerable.call(o, symbol)) result.push(symbol);
+  }
+  return result;
 }
 
 /**
@@ -392,7 +417,10 @@ function walkAffectsScope(
     collectRecordNodes(target[STORE_NODE], found);
     collectRecordNodes(target[STORE_HAS], found);
     override = mergedOverlay(target);
-    lookup = target[STORE_LOOKUP] ?? lookup;
+    // Carry the effective lookup into untouched descendants. Default stores
+    // use the global lookup just like snapshotImpl; without it, nested raw
+    // objects fall back to string-only enumeration and symbol branches vanish.
+    lookup = target[STORE_LOOKUP] ?? lookup ?? storeLookup;
   }
   if (Array.isArray(raw)) {
     const len = override?.length ?? raw.length;
@@ -400,8 +428,18 @@ function walkAffectsScope(
       const v = override && i in override ? override[i] : raw[i];
       if (v !== $DELETED) walkAffectsScope(v, entry, found, lookup, visited);
     }
+    // Arrays can also carry symbol metadata. Enumerate symbols separately to
+    // avoid scanning large index lists twice. Outside a store tree, retain the
+    // existing index-only walk.
+    const symbols = target || lookup ? getStoreSymbols(raw, override) : [];
+    for (let i = 0, l = symbols.length; i < l; i++) {
+      const key = symbols[i];
+      const desc = getPropertyDescriptor(raw, override, key);
+      if (!desc || desc.get) continue;
+      walkAffectsScope(desc.value, entry, found, lookup, visited);
+    }
   } else {
-    const keys = getKeys(raw, override);
+    const keys = target || lookup ? getStoreKeys(raw, override) : getKeys(raw, override);
     for (let i = 0, l = keys.length; i < l; i++) {
       const desc = getPropertyDescriptor(raw, override, keys[i]);
       if (!desc || desc.get) continue;
@@ -521,17 +559,26 @@ export function mergedOverlay(target: StoreNode): Record<PropertyKey, any> | und
   return override && opt ? { ...override, ...opt } : (opt ?? override);
 }
 
-export function getKeys(
+function getKeysImpl(
   source: Record<PropertyKey, any>,
   override: Record<PropertyKey, any> | undefined,
-  enumerable: boolean = true
+  enumerable: boolean,
+  symbols: boolean
 ): PropertyKey[] {
   // Plain objects can't trigger proxy traps — only pay for the untrack
   // closure when the source is itself a wrapped store (store-in-store).
   const baseKeys = (source as any)[$TARGET]
-    ? untrack(() => (enumerable ? Object.keys(source) : Reflect.ownKeys(source)))
+    ? untrack(() =>
+        enumerable
+          ? symbols
+            ? ownEnumerableKeys(source)
+            : Object.keys(source)
+          : Reflect.ownKeys(source)
+      )
     : enumerable
-      ? Object.keys(source)
+      ? symbols
+        ? ownEnumerableKeysPlain(source)
+        : Object.keys(source)
       : Reflect.ownKeys(source);
   if (!override) return baseKeys;
   const keys = new Set(baseKeys);
@@ -541,6 +588,39 @@ export function getKeys(
     else keys.delete(key);
   }
   return Array.from(keys);
+}
+
+export function getKeys(
+  source: Record<PropertyKey, any>,
+  override: Record<PropertyKey, any> | undefined,
+  enumerable: boolean = true
+): PropertyKey[] {
+  return getKeysImpl(source, override, enumerable, false);
+}
+
+export function getStoreKeys(
+  source: Record<PropertyKey, any>,
+  override: Record<PropertyKey, any> | undefined
+): PropertyKey[] {
+  return getKeysImpl(source, override, true, true);
+}
+
+export function getStoreSymbols(
+  source: Record<PropertyKey, any>,
+  override: Record<PropertyKey, any> | undefined
+): symbol[] {
+  const symbols = (source as any)[$TARGET]
+    ? untrack(() => ownEnumerableSymbols(source))
+    : ownEnumerableSymbols(source);
+  if (!override) return symbols;
+  const result = new Set(symbols);
+  const overrideSymbols = Object.getOwnPropertySymbols(override);
+  for (let i = 0, len = overrideSymbols.length; i < len; i++) {
+    const symbol = overrideSymbols[i];
+    if (override[symbol] !== $DELETED) result.add(symbol);
+    else result.delete(symbol);
+  }
+  return Array.from(result);
 }
 
 export function getPropertyDescriptor(
@@ -1113,7 +1193,7 @@ export function storeSetter<T extends object>(store: Store<T>, fn: (draft: T) =>
  *
  * @returns `[store: Store<T>, setStore: StoreSetter<T>]`
  */
-export function createStore<T extends object = {}>(store: NoFn<T> | Store<NoFn<T>>): StoreReturn<T>;
+export function createStore<T extends object = {}>(store: NoFn<T>): StoreReturn<T>;
 export function createStore<T extends object = {}>(
   fn: (store: T) => void | T | Promise<void | T> | AsyncIterable<void | T>,
   store: Partial<T> | Store<NoFn<T>>,

--- a/packages/solid-signals/src/store/store.ts
+++ b/packages/solid-signals/src/store/store.ts
@@ -56,7 +56,7 @@ export type Store<T> = Readonly<T>;
  * projection form — `createStore(fn, seed, { key })` or `createProjection` —
  * whose derive function reconciles its return by `options.key`.
  */
-export type StoreSetter<T> = (fn: (state: Mutable<T>) => Mutable<T> | void) => void;
+export type StoreSetter<T> = (fn: (state: T) => T | void) => void;
 /** Tuple returned by the plain `createStore(initialValue)` form. */
 export type StoreReturn<T> = [get: Store<T>, set: StoreSetter<T>];
 /** Tuple returned by the derived `createStore(fn, seed, options?)` form. */
@@ -72,8 +72,6 @@ export interface ProjectionOptions extends StoreOptions {
   key?: string | ((item: NonNullable<any>) => any);
 }
 export type NoFn<T> = T extends Function ? never : T;
-/** Makes the setter draft's top-level properties writable; {@link Store} keeps the getter readonly. */
-export type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
 type DataNode = Signal<any>;
 type DataNodes = Record<PropertyKey, DataNode>;
@@ -220,19 +218,6 @@ export function ownEnumerableKeys(o: object): (string | symbol)[] {
   return Reflect.ownKeys(o).filter(k => Object.prototype.propertyIsEnumerable.call(o, k));
 }
 
-// Plain-object variant that keeps Object.keys() as the fast path and only pays
-// descriptor checks for symbols. Do not use this on store proxies: splitting
-// strings/symbols would invoke their ownKeys trap twice.
-function ownEnumerableKeysPlain(o: object): (string | symbol)[] {
-  const keys: (string | symbol)[] = Object.keys(o);
-  const symbols = Object.getOwnPropertySymbols(o);
-  for (let i = 0, len = symbols.length; i < len; i++) {
-    const symbol = symbols[i];
-    if (Object.prototype.propertyIsEnumerable.call(o, symbol)) keys.push(symbol);
-  }
-  return keys;
-}
-
 function ownEnumerableSymbols(o: object): symbol[] {
   const symbols = Object.getOwnPropertySymbols(o);
   const result: symbol[] = [];
@@ -241,6 +226,13 @@ function ownEnumerableSymbols(o: object): symbol[] {
     if (Object.prototype.propertyIsEnumerable.call(o, symbol)) result.push(symbol);
   }
   return result;
+}
+
+// Plain-object variant that keeps Object.keys() as the fast path and only pays
+// descriptor checks for symbols. Do not use this on store proxies: splitting
+// strings/symbols would invoke their ownKeys trap twice.
+function ownEnumerableKeysPlain(o: object): (string | symbol)[] {
+  return (Object.keys(o) as (string | symbol)[]).concat(ownEnumerableSymbols(o));
 }
 
 /**
@@ -580,14 +572,7 @@ function getKeysImpl(
         ? ownEnumerableKeysPlain(source)
         : Object.keys(source)
       : Reflect.ownKeys(source);
-  if (!override) return baseKeys;
-  const keys = new Set(baseKeys);
-  const overrides = Reflect.ownKeys(override);
-  for (const key of overrides) {
-    if (override![key] !== $DELETED) keys.add(key);
-    else keys.delete(key);
-  }
-  return Array.from(keys);
+  return override ? mergeOverrideKeys(baseKeys, override) : baseKeys;
 }
 
 export function getKeys(
@@ -612,15 +597,26 @@ export function getStoreSymbols(
   const symbols = (source as any)[$TARGET]
     ? untrack(() => ownEnumerableSymbols(source))
     : ownEnumerableSymbols(source);
-  if (!override) return symbols;
-  const result = new Set(symbols);
-  const overrideSymbols = Object.getOwnPropertySymbols(override);
-  for (let i = 0, len = overrideSymbols.length; i < len; i++) {
-    const symbol = overrideSymbols[i];
-    if (override[symbol] !== $DELETED) result.add(symbol);
-    else result.delete(symbol);
+  return override ? (mergeOverrideKeys(symbols, override, true) as symbol[]) : symbols;
+}
+
+// Shared override-layer merge for key enumeration: adds live override keys,
+// drops $DELETED ones. `symbolsOnly` scopes the override scan for the
+// array-metadata passes.
+function mergeOverrideKeys(
+  baseKeys: PropertyKey[],
+  override: Record<PropertyKey, any>,
+  symbolsOnly?: boolean
+): PropertyKey[] {
+  const keys = new Set(baseKeys);
+  const overrides = symbolsOnly
+    ? Object.getOwnPropertySymbols(override)
+    : Reflect.ownKeys(override);
+  for (const key of overrides) {
+    if (override[key] !== $DELETED) keys.add(key);
+    else keys.delete(key);
   }
-  return Array.from(result);
+  return Array.from(keys);
 }
 
 export function getPropertyDescriptor(
@@ -1193,7 +1189,7 @@ export function storeSetter<T extends object>(store: Store<T>, fn: (draft: T) =>
  *
  * @returns `[store: Store<T>, setStore: StoreSetter<T>]`
  */
-export function createStore<T extends object = {}>(store: NoFn<T>): StoreReturn<T>;
+export function createStore<T extends object = {}>(store: NoFn<T> | Store<NoFn<T>>): StoreReturn<T>;
 export function createStore<T extends object = {}>(
   fn: (store: T) => void | T | Promise<void | T> | AsyncIterable<void | T>,
   store: Partial<T> | Store<NoFn<T>>,

--- a/packages/solid-signals/src/store/utils.ts
+++ b/packages/solid-signals/src/store/utils.ts
@@ -7,6 +7,8 @@ import {
   $TARGET,
   $TRACK,
   getKeys,
+  getStoreKeys,
+  getStoreSymbols,
   getPropertyDescriptor,
   isWrappable,
   mergedOverlay,
@@ -62,6 +64,21 @@ function snapshotImpl<T>(
         result[i] = unwrapped;
       }
     }
+    // Enumerate array symbols separately to avoid scanning indices twice.
+    // Spread copies omit symbols, so assign them after the numeric walk.
+    const symbols = lookup ? getStoreSymbols(item, override) : [];
+    for (let i = 0, l = symbols.length; i < l; i++) {
+      const prop = symbols[i];
+      const desc = getPropertyDescriptor(item, override, prop);
+      if (!desc || desc.get) continue;
+      v = override && prop in override ? override[prop] : item[prop];
+      if (track && isWrappable(v)) wrap(v, target);
+      unwrapped = snapshotImpl(v, track, map, lookup);
+      if (unwrapped !== v || result) {
+        if (!result) map.set(item, (result = Object.assign([...item], item)));
+        result[prop] = unwrapped;
+      }
+    }
     // Deleted trailing slots are skipped above, so restore length to preserve
     // holes instead of truncating the copy (#2846) — mirrors unwrapStoreValue.
     if (result) result.length = len;
@@ -69,7 +86,9 @@ function snapshotImpl<T>(
     // Specialized walk for the common no-overlay case (from #2756): the own
     // descriptor gives the value directly, so each property is read once with
     // no overlay membership checks.
-    const keys = getKeys(item, undefined);
+    // A lookup means this object belongs to an immutable store backing tree,
+    // even if that nested value has not needed its own proxy yet.
+    const keys = lookup ? getStoreKeys(item, undefined) : getKeys(item, undefined);
     for (let i = 0, l = keys.length; i < l; i++) {
       const prop = keys[i];
       const desc = Object.getOwnPropertyDescriptor(item, prop)!;
@@ -85,7 +104,9 @@ function snapshotImpl<T>(
       }
     }
   } else {
-    const keys = getKeys(item, override);
+    // An override only exists on a store record, and the target branch above
+    // always set `lookup` alongside it — so this branch is always store-keyed.
+    const keys = getStoreKeys(item, override);
     for (let i = 0, l = keys.length; i < l; i++) {
       let prop = keys[i];
       const desc = getPropertyDescriptor(item, override, prop)!;

--- a/packages/solid-signals/tests/question-scoped-pending.test.ts
+++ b/packages/solid-signals/tests/question-scoped-pending.test.ts
@@ -612,6 +612,49 @@ describe("affects — captured proxies (#2882)", () => {
     expect(isPending(() => tags.primary)).toBe(false);
   });
 
+  it("affects(plain store) covers an untouched symbol-keyed grandchild", async () => {
+    const meta = Symbol("meta");
+    const [state] = createStore({ outer: { [meta]: { value: 1 } } });
+
+    let resolveIt!: () => void;
+    const act = action(function* () {
+      affects(state);
+      yield new Promise<void>(r => (resolveIt = r));
+    });
+
+    const done = act();
+    flush();
+    const child = state.outer[meta];
+    expect(isPending(() => child.value)).toBe(true);
+
+    resolveIt();
+    await done;
+    flush();
+    expect(isPending(() => child.value)).toBe(false);
+  });
+
+  it("affects(array store) covers symbol-keyed metadata", async () => {
+    const meta = Symbol("meta");
+    const initial = Object.assign([{ value: 0 }], { [meta]: { value: 1 } });
+    const [state] = createStore(initial);
+
+    let resolveIt!: () => void;
+    const act = action(function* () {
+      affects(state);
+      yield new Promise<void>(r => (resolveIt = r));
+    });
+
+    const done = act();
+    flush();
+    const metadata = state[meta];
+    expect(isPending(() => metadata.value)).toBe(true);
+
+    resolveIt();
+    await done;
+    flush();
+    expect(isPending(() => metadata.value)).toBe(false);
+  });
+
   it("keyless mark on a nested record covers its captured subtree, not siblings", async () => {
     const [state] = createStore<{ rows: Row[] }>({ rows: seedRows() });
     const tags0 = state.rows[0].tags;

--- a/packages/solid-signals/tests/snapshot.test.ts
+++ b/packages/solid-signals/tests/snapshot.test.ts
@@ -478,6 +478,186 @@ describe("store snapshot support", () => {
 
     expect(snapshot(store)).toEqual([]);
   });
+
+  it("preserves symbol-keyed properties after a write", () => {
+    const meta = Symbol("meta");
+    const [store, setStore] = createStore({ value: 1, [meta]: "keep" });
+
+    setStore(s => {
+      s.value = 2;
+    });
+    flush();
+
+    expect(snapshot(store)[meta]).toBe("keep");
+  });
+
+  it("captures a write inside a symbol-keyed subtree", () => {
+    const meta = Symbol("meta");
+    const [store, setStore] = createStore({ [meta]: { value: 1 } });
+
+    setStore(s => {
+      s[meta].value = 2;
+    });
+    flush();
+
+    expect(snapshot(store)[meta].value).toBe(2);
+  });
+
+  it("unwraps an unread symbol-keyed store-in-store value", () => {
+    const meta = Symbol("meta");
+    const [child] = createStore({ value: 1 });
+    const [parent] = createStore({ [meta]: child });
+
+    const plain = snapshot(parent);
+
+    expect(plain[meta]).not.toBe(child);
+    expect(plain[meta]).toEqual({ value: 1 });
+  });
+
+  it("preserves symbol-keyed array metadata after an index write", () => {
+    const meta = Symbol("meta");
+    const initial = Object.assign([1], { [meta]: "keep" });
+    const [store, setStore] = createStore(initial);
+
+    setStore(s => {
+      s[0] = 2;
+    });
+    flush();
+
+    expect(snapshot(store)[meta]).toBe("keep");
+  });
+
+  it("preserves a symbol-keyed property added after a snapshot", () => {
+    const meta = Symbol("meta");
+    const [store, setStore] = createStore<{ value: number; [meta]?: string }>({ value: 1 });
+
+    snapshot(store);
+    setStore(s => {
+      s[meta] = "added";
+    });
+    flush();
+
+    expect(snapshot(store)[meta]).toBe("added");
+  });
+
+  it("preserves symbols on an untouched nested store value", () => {
+    const meta = Symbol("meta");
+    const [store] = createStore({ child: { value: 1, [meta]: "keep" } });
+
+    expect(snapshot(store).child[meta]).toBe("keep");
+    expect(snapshot(store).child[meta]).toBe("keep");
+  });
+
+  it("drops a deleted symbol-keyed property", () => {
+    const meta = Symbol("meta");
+    const [store, setStore] = createStore<{ value: number; [meta]?: string }>({
+      value: 1,
+      [meta]: "gone"
+    });
+
+    setStore(s => {
+      delete s[meta];
+    });
+    flush();
+
+    expect(meta in snapshot(store)).toBe(false);
+  });
+
+  it("drops a deleted symbol-keyed array metadata property", () => {
+    const meta = Symbol("meta");
+    const initial = Object.assign([1], { [meta]: "gone" });
+    const [store, setStore] = createStore<number[] & { [meta]?: string }>(initial);
+
+    setStore(s => {
+      delete s[meta];
+    });
+    flush();
+
+    expect(meta in snapshot(store)).toBe(false);
+  });
+
+  it("excludes non-enumerable symbol-keyed properties from written copies", () => {
+    const meta = Symbol("meta");
+    const raw: { value: number; [meta]?: string } = { value: 1 };
+    Object.defineProperty(raw, meta, { value: "hidden", enumerable: false });
+    const [store, setStore] = createStore(raw);
+
+    setStore(s => {
+      s.value = 2;
+    });
+    flush();
+
+    expect(meta in snapshot(store)).toBe(false);
+  });
+
+  it("preserves a cycle reached through a symbol key", () => {
+    const meta = Symbol("meta");
+    const [store, setStore] = createStore<{ node: { name: string; [meta]?: unknown } }>({
+      node: { name: "n" }
+    });
+
+    setStore(s => {
+      s.node[meta] = s.node;
+    });
+    flush();
+
+    const snap = snapshot(store);
+    expect(snap.node[meta]).toBe(snap.node);
+  });
+
+  it("keeps shared references between symbol and string keys", () => {
+    const meta = Symbol("meta");
+    const shared = { value: 1 };
+    const [store, setStore] = createStore<{ named: typeof shared; [meta]?: typeof shared }>({
+      named: shared,
+      [meta]: shared
+    });
+
+    setStore(s => {
+      s.named.value = 2;
+    });
+    flush();
+
+    const snap = snapshot(store);
+    expect(snap[meta]).toBe(snap.named);
+    expect(snap.named.value).toBe(2);
+  });
+
+  it("unwraps a symbol-keyed store-in-store value under a written parent", () => {
+    const meta = Symbol("meta");
+    const [child] = createStore({ value: 1 });
+    const [parent, setParent] = createStore<{ label: string; [meta]?: typeof child }>({
+      label: "a",
+      [meta]: child
+    });
+
+    setParent(s => {
+      s.label = "b";
+    });
+    flush();
+
+    const plain = snapshot(parent);
+    expect(plain[meta]).not.toBe(child);
+    expect(plain[meta]).toEqual({ value: 1 });
+  });
+
+  it("preserves symbol-keyed properties when materializing a written subtree", () => {
+    const meta = Symbol("meta");
+    const [source, setSource] = createStore({ child: { value: 1, [meta]: "keep" } });
+
+    setSource(s => {
+      s.child.value = 2;
+    });
+    flush();
+
+    const [target, setTarget] = createStore<{ child?: typeof source.child }>({});
+    setTarget(s => {
+      s.child = source.child;
+    });
+    flush();
+
+    expect(target.child?.[meta]).toBe("keep");
+  });
 });
 
 describe("pending projection skips snapshot capture", () => {

--- a/packages/solid-signals/tests/store/utilities.test.ts
+++ b/packages/solid-signals/tests/store/utilities.test.ts
@@ -556,6 +556,57 @@ describe("deep", () => {
     expect(effect).toHaveBeenCalledTimes(4);
     expect(effect.mock.calls[3][0]).toEqual({ list: [{ d: 4 }] });
   });
+
+  test("tracks updates in a symbol-keyed subtree", () => {
+    const meta = Symbol("meta");
+    const [state, setState] = createStore({ [meta]: { value: 1 } });
+    const values: number[] = [];
+
+    createRoot(() => {
+      createEffect(
+        () => deep(state),
+        value => {
+          values.push(value[meta].value);
+        }
+      );
+    });
+    flush();
+
+    setState(s => {
+      s[meta].value = 2;
+    });
+    flush();
+
+    expect(values).toEqual([1, 2]);
+  });
+
+  test("notifies on symbol key addition and deletion", () => {
+    const meta = Symbol("meta");
+    const [state, setState] = createStore<{ [meta]?: number }>({});
+    const seen: (number | undefined)[] = [];
+
+    createRoot(() => {
+      createEffect(
+        () => deep(state),
+        value => {
+          seen.push(value[meta]);
+        }
+      );
+    });
+    flush();
+
+    setState(s => {
+      s[meta] = 1;
+    });
+    flush();
+
+    setState(s => {
+      delete s[meta];
+    });
+    flush();
+
+    expect(seen).toEqual([undefined, 1, undefined]);
+  });
   test("handles shared references", () => {
     const sharedReference = {
       a: 1,


### PR DESCRIPTION
Closes #2894

## Summary

After any write to a store subtree, `snapshot()` of it drops **symbol-keyed** properties — and writing that subtree into another store drops them too. Before the first write they survive by accident (the identity-return fast path hands back the original object), so the loss only appears once the object has an override, and initial tests against untouched records pass.

This is the remaining materialization variant of #2769: that fix covered symbol keys in the set trap, `storeSetter`, `storePath`, and `merge`/`omit` via `ownEnumerableKeys`, and #2851 covered `reconcile()`'s diff loops — but the internal *materialization* paths still enumerated with `Object.keys`.

## Root cause

`getKeys()` seeds its base key list from `Object.keys(source)` (strings only) and drives:

- **`snapshotImpl`** — `snapshot()`/`deep()` of any written record iterate string keys into the eagerly-created copy, so symbol props never land; and on the no-override path, symbol-keyed *store-in-store* values are never visited, so they leak wrapped instead of unwrapping.
- **`unwrapStoreValue`** — the setter's store-to-store materialization, so copying a previously-written subtree into another store drops its symbol props.
- **`walkAffectsScope`** — a keyless `affects(store)` never descends into symbol-keyed subtrees, so their nodes miss pending coverage.

Note the boundary: symbols living in the *override layer* (added after creation) were already enumerated (`Reflect.ownKeys(override)` in the merge loop) — the gap was specifically base-object symbols, which is why the failure needs a prior write to appear.

## Fix

New symbol-aware enumeration helpers, applied at exactly those three sites; the public `getKeys` is unchanged, so `reconcile`'s `getAllKeys` and the `ownKeys` trap keep their existing paths:

- **`getStoreKeys`** — enumerable strings + enumerable symbols, honoring override adds and `$DELETED` removals. Plain objects stay on the `Object.keys` fast path and only pay one `getOwnPropertySymbols` call (`ownEnumerableKeysPlain`); wrapped store-in-store sources keep the single-pass `ownEnumerableKeys` so their `ownKeys` trap fires once, untracked.
- **`getStoreSymbols`** — symbol-only variant for the array branches, so large index lists aren't allocated and scanned a second time; both array walks (snapshot and affects) get a separate symbol pass after the numeric loop.
- Gating: symbol enumeration only happens inside a store backing tree (a `lookup` is set), so `snapshot()` of a plain non-store object keeps its old string-only behavior. Non-enumerable symbols are filtered, so internal slots can never leak into copies (test-pinned). Symbol-keyed accessors are skipped, matching the string-key branches.

## Tests

Seventeen new tests (ten confirmed failing red-first on the unfixed source; seven are boundary-semantics controls):

- `tests/snapshot.test.ts` — symbol keys survive after a write; a write *inside* a symbol-keyed subtree is captured; unread and written-parent symbol-keyed store-in-store values unwrap; array symbol metadata survives an index write; store-to-store materialization keeps symbols; shared references between symbol and string keys stay aliased in the copy; cycles through symbol keys preserve identity; deleted symbol keys (object and array) stay deleted; non-enumerable symbols stay excluded from copies; a symbol key added after a prior snapshot appears; untouched nested values keep symbols
- `tests/store/utilities.test.ts` — `deep()` tracks updates in a symbol-keyed subtree, and notifies on symbol key addition and deletion
- `tests/question-scoped-pending.test.ts` — keyless `affects(store)` covers an untouched symbol-keyed grandchild, and symbol-keyed array metadata

Full solid-signals suite: the diff versus pristine is exactly the intended flips, nothing else — including the #2893 affects-audit tests, which exercise the same subsystem as the `walkAffectsScope` change. `solid-js` and `@solidjs/web` rebuilt against the fixed package and re-run at their baselines; source passes the typecheck. Verified at `next` @ `d823a806` (2.0.0-beta.19).

## Performance

Micro-benched with symbol-free fixtures (the common case): no measurable change for written arrays, store-to-store writes, wide objects (~3%), or the existing `reconcile`/`deep()` benches. Snapshotting a deep tree of many small objects pays ~14% — one `getOwnPropertySymbols` call per visited object, which is the minimum price of seeing symbol keys at all. `snapshot()` is a serialization-boundary operation, not a per-read hot path. If this matters, a follow-up could gate enumeration behind a `WeakSet` marker like #2851's `symbolKeyedRecords`.

## Does this exist in Solid 1.x?

**Regression.** Verified against 1.9.14: `unwrap` after a write keeps symbol keys, and copying a written subtree into another store keeps them.

Full disclosure: I wrote this with the help of an AI assistant (Claude Fable 5) and reviewed every line before pushing. All red-first tests were confirmed failing on the unfixed code.