### PR TITLE
ci probe: tier1-spike2 isolation (do not merge)

### DIFF
--- a/packages/solid-signals/src/affects.ts
+++ b/packages/solid-signals/src/affects.ts
@@ -1,10 +1,4 @@
-import {
-  addPendingSource,
-  forEachDependent,
-  notifyStatus,
-  setPendingError,
-  settlePendingSource
-} from "./core/async.js";
+import { forEachDependent } from "./core/async.js";
 import { STATUS_PENDING } from "./core/constants.js";
 import { emitDiagnostic } from "./core/dev.js";
 import { NotReadyError } from "./core/error.js";
@@ -17,133 +11,81 @@ import { $TARGET, getStoreAffectsNodes, type Store, type StoreNode } from "./sto
 type MarkedNode = Signal<any> | Computed<any>;
 
 /**
- * The pending-source identity of a live `affects()` mark on `node` (lazy,
- * one per node, shared by overlapping registrations via the refcount).
- *
- * A mark rides the SAME status rails as real in-flight async — downstream
- * subscribers hold the sentinel in `_pendingSources` — but under its own
- * identity so the two channels can't clear each other:
- * - `_reask` is permanently `false`: a mark is by definition a declared
- *   value change, so `quietPending` never silences a window it participates
- *   in — even when the mark rides over an otherwise-quiet `refresh()`
- *   re-ask of the same node (the whole point of declaring one).
- * - A landing on the marked node settles only the node's OWN source entry;
- *   the sentinel entry survives until the mark's transaction releases it.
- * - The sentinel itself never carries `STATUS_PENDING`, so
- *   `transitionComplete` never counts a mark as a blocker of its own
- *   transaction (release happens AT settle — self-blocking would deadlock),
- *   and reads of the marked node never throw (marks are value-transparent
- *   at the source; pendingness is what propagates).
- */
-function getAffectsSentinel(node: MarkedNode): Computed<any> {
-  return (node._affectsSentinel ??= {
-    _name: __DEV__ ? "affects-sentinel" : undefined,
-    // Brand + backref: lets the scheduler's settlement checks recognize
-    // mark-sourced pending (which must never block its own transaction —
-    // release happens AT settle).
-    _affectsFor: node,
-    _flags: 0,
-    _statusFlags: 0,
-    _reask: false,
-    _error: undefined,
-    _subs: null,
-    _deps: null
-  } as unknown as Computed<any>);
-}
-
-/**
- * Push a live mark's pendingness downstream from the marked node through the
- * normal status rails. Runs on every registration (dedup in `notifyStatus`
- * stops re-descent at already-covered subscribers). Subscribers that
- * recompute mid-window shed this via `clearStatus` and re-acquire it through
- * the read path (`applyAffectsReads` for direct readers of the marked node,
- * `collectMarkSources` transitively) — the mark analogue of real async's
- * re-throw-on-read. Subscribers are deliberately NOT queued as pending nodes
- * (#2893): they hold no value needing a transition-scheduled commit, and
- * queueing would stamp the marking action's transaction onto them — from then
- * on ANY write dirtying one of them (including writes to unmarked signals
- * that merely share a downstream memo) would be captured and frozen until the
- * action settles.
- */
-function propagateAffectsMark(node: MarkedNode): void {
-  if (!node._subs && !(node as Computed<any>)._child) return;
-  const sentinel = getAffectsSentinel(node);
-  const error = new NotReadyError(sentinel);
-  forEachDependent(node as Computed<any>, sub => {
-    if (!sub._pendingSources?.has(sentinel)) {
-      notifyStatus(sub, STATUS_PENDING, error);
-    }
-  });
-}
-
-/**
- * Re-establish mark pendingness on a computed that read marked sources
- * during its recompute (`clearStatus` at the top of the commit path wiped
- * any sentinel entries it held). Called by `recompute` after the commit —
- * not before, because setting `_error` earlier would make the commit path
- * treat the node as errored and skip the value write.
- */
-function applyAffectsReads(el: Computed<any>, sources: MarkedNode[]): void {
-  let applied = false;
-  for (let i = 0; i < sources.length; i++) {
-    const src = sources[i];
-    if (!src._affectsCount) continue;
-    const sentinel = getAffectsSentinel(src);
-    if (addPendingSource(el, sentinel)) {
-      el._statusFlags |= STATUS_PENDING;
-      setPendingError(el, sentinel);
-      applied = true;
-    }
-  }
-  if (applied && GlobalQueue._updatePendingSignal !== null) GlobalQueue._updatePendingSignal(el);
-}
-
-/**
  * The counting half of a mark, shared by direct registration and store-scope
- * inheritance (a node created inside a live keyless mark's identity scope):
- * bumps the refcount and pokes the node's verdict companions so an
- * already-materialized `false` flips reactively.
+ * inheritance (a node created inside a live keyless mark's identity scope).
+ * A mark is ONLY this count: coverage of everything derived from the node is
+ * pull-derived by the verdict layer's `markWalk` (dep-graph reachability), so
+ * nothing is stored downstream and nothing can be stranded or stripped by
+ * mid-window recomputes.
  */
 function markAffects(node: MarkedNode): void {
   node._affectsCount = (node._affectsCount || 0) + 1;
   shiftAffectsMarks(1);
   if (__DEV__) devTrackAffects(node);
-  // Companions only exist once the verdict layer (isPending/latest) loaded;
-  // without them there is no materialized verdict to flip.
-  if (node._affectsCount === 1 && GlobalQueue._updatePendingSignal !== null)
-    GlobalQueue._updatePendingSignal(node);
+}
+
+/**
+ * Boundary visual channel: within a transaction, a live mark holds Loading
+ * fallbacks / reveal ordering the way real in-flight async would — but the
+ * notification is tagged visibility-only at the source (`_markVisual`), so
+ * the root queue never registers reporters from it: marks are invisible to
+ * ALL completion and settlement accounting by construction. Boundaries hold
+ * the marked node in `_sources` while `_affectsCount` is live; the release
+ * sweep (finalizePureQueue re-checks boundary children after mark release)
+ * is the display-state update point. Ambient marks release inside the same
+ * flush that would surface them, before effects run — verdict-only, netting
+ * no visual change.
+ */
+function notifyMarkBoundaries(node: MarkedNode): void {
+  if (!node._subs && !(node as Computed<any>)._child) return;
+  const error = new NotReadyError(node);
+  error._markVisual = true;
+  const visited = new Set<Computed<any>>();
+  const visit = (sub: Computed<any>) => {
+    if (visited.has(sub)) return;
+    visited.add(sub);
+    // Display consumers (render effects, boundary computeds) act on the
+    // notification; descent stops there, exactly like the status rails.
+    if (sub._notifyStatus) {
+      sub._notifyStatus(STATUS_PENDING, error);
+      return;
+    }
+    forEachDependent(sub, visit);
+  };
+  forEachDependent(node as Computed<any>, visit);
 }
 
 /**
  * Registers one `affects()` mark on a node: counts it, records the
  * registration with the current transaction (after initTransition the queue's
- * batch IS the active transition, mirroring `_optimisticNodes`), and
- * propagates STATUS_PENDING downstream on the status rails so everything
- * DERIVED from the marked data reads pending too. Propagation runs on every
- * registration (not just the first): subscribers gained since an earlier
- * overlapping registration get covered, and dedup stops re-descent early.
+ * batch IS the active transition, mirroring `_optimisticNodes`), re-derives
+ * every downstream verdict companion (the mark channel's only push — verdict
+ * pokes, not state), and notifies boundary display state. Both walks run on
+ * every registration (not just the first): subscribers gained since an
+ * earlier overlapping registration get covered, and dedup stops re-descent.
  */
 function registerAffectsMark(node: MarkedNode): void {
   markAffects(node);
   globalQueue._batch._affectsNodes.push(node);
-  propagateAffectsMark(node);
+  // Companions only exist once the verdict layer (isPending/latest) loaded;
+  // without them there is no materialized verdict to poke.
+  GlobalQueue._repollVerdicts !== null && GlobalQueue._repollVerdicts(node as Computed<any>);
+  notifyMarkBoundaries(node);
   schedule();
 }
 
 /**
- * Releases one registration. When the node's last mark drops, settles the
- * mark's sentinel out of every downstream `_pendingSources` (waking blocked
- * nodes and re-deriving verdicts along the walk). Companion writes go through
- * the settlement snap (committed, not transition-scoped) so releasing a mark
- * can't open a fresh override window that would itself need settlement.
+ * Releases one registration. When the node's last mark drops, re-derives
+ * every downstream verdict through the settlement snap (committed, not
+ * transition-scoped — release runs inside queue finalization, where a
+ * setSignal would open a fresh override window that nothing settles).
  */
 function releaseAffectsMark(node: MarkedNode): void {
   shiftAffectsMarks(-1);
   node._affectsCount!--;
   if (!node._affectsCount) {
-    const sentinel = node._affectsSentinel;
-    if (sentinel) settlePendingSource(node as Computed<any>, sentinel, true);
-    GlobalQueue._snapCompanions !== null && GlobalQueue._snapCompanions(node);
+    GlobalQueue._repollVerdicts !== null &&
+      GlobalQueue._repollVerdicts(node as Computed<any>, true);
     GlobalQueue._releaseAffectsScope?.(node);
   }
 }
@@ -157,69 +99,28 @@ function releaseAffectsMarks(nodes: MarkedNode[]): void {
   nodes.length = 0;
 }
 
-/**
- * True when a node's pending status comes ONLY from affects() sentinels. A
- * mark is a promise of change, not an absence of value: reads of mark-pended
- * derived nodes stay value-transparent (verdicts report pending; the read
- * path must not suspend). Any real async source among the pending sources
- * keeps normal suspension semantics. Core's read path reaches this through
- * `GlobalQueue._onlyMarkPending`, gated on the `activeAffectsMarks` counter.
- */
-function onlyMarkPending(el: Computed<any>): boolean {
-  const sources = el._pendingSources;
-  if (sources) {
-    for (const s of sources) if (!s._affectsFor) return false;
-    return true;
-  }
-  return false;
-}
-
-/**
- * Collect the still-live marked nodes behind a pended owner's sentinel
- * sources into a recompute's `affectsReads`. This is the transitive half of
- * read-path re-establishment (#2893): real async re-establishes at every
- * derivation level because its re-throw on read re-registers the source, but
- * mark-pended reads are value-transparent — without this, pendingness dies on
- * the first mid-window recompute past depth one, and the isPending() probe
- * itself (whose prepare step recomputes retryable NotReady holders) strips
- * the very status it reports on. Reached through
- * `GlobalQueue._collectMarkSources`, gated on `activeAffectsMarks`.
- */
-function collectMarkSources(el: Computed<any>, into: MarkedNode[]): void {
-  if (el._pendingSources) {
-    for (const s of el._pendingSources) {
-      const marked = s._affectsFor;
-      if (marked && marked._affectsCount) into.push(marked);
-    }
-  }
-}
-
 // Late installation (same pattern as `GlobalQueue._update`): the mark engine
 // lives with the feature so graphs that never declare a mark never ship it.
-// Each call site is gated by state only this module creates (`markedReads`
-// collection under `activeAffectsMarks`, a non-empty `_affectsNodes` batch,
-// a live scope in the store's `affectsScopes`), so the hooks are installed
-// before the first time any of them can fire.
-GlobalQueue._applyAffectsReads = applyAffectsReads;
+// Each call site is gated by state only this module creates (a non-empty
+// `_affectsNodes` batch, a live scope in the store's `affectsScopes`), so the
+// hooks are installed before the first time any of them can fire.
 GlobalQueue._releaseAffectsMarks = releaseAffectsMarks;
 GlobalQueue._markAffects = markAffects;
 GlobalQueue._releaseAffectsMark = releaseAffectsMark;
-GlobalQueue._onlyMarkPending = onlyMarkPending;
-GlobalQueue._collectMarkSources = collectMarkSources;
 
 /**
  * Declares that in-flight work will change the targeted data: the named
  * slot(s) — and everything DERIVED from them — read as pending
  * (`isPending` → `true`) from the declaration until the surrounding
- * transaction settles or reverts. Marks ride the same status rails as real
- * in-flight async, so pendingness flows through memos and effects like any
- * other pending source, while the marked values themselves stay readable
- * (a mark is a promise of change, not an absence of value). This is the
- * declaration verb of the pending model — additive only. A mark can turn
- * pending ON for data the graph can't see changing yet; nothing can turn
- * pending OFF while a real change is in flight — a quiet `refresh()`
- * re-ask under a mark still reads pending (declaring the reload is what
- * makes it a real question).
+ * transaction settles or reverts. A mark lives on its own channel — a
+ * refcount on the marked node plus dep-graph reachability in the verdict
+ * layer — so the marked values themselves stay readable (a mark is a promise
+ * of change, not an absence of value), no reader ever suspends on one, and
+ * completion/settlement accounting never sees one. This is the declaration
+ * verb of the pending model — additive only. A mark can turn pending ON for
+ * data the graph can't see changing yet; nothing can turn pending OFF while
+ * a real change is in flight — a quiet `refresh()` re-ask under a mark still
+ * reads pending (declaring the reload is what makes it a real question).
  *
  * Targets:
  * - `affects(store)` — a store proxy (any record, root or nested): every

--- a/packages/solid-signals/src/boundaries.ts
+++ b/packages/solid-signals/src/boundaries.ts
@@ -339,9 +339,14 @@ export class CollectionQueue extends Queue {
   }
   _checkSources() {
     for (const source of this._sources) {
+      // A source with a live affects() mark holds display state for the
+      // mark's lifetime (the visual channel): the marked node carries no
+      // status of its own, so the count is the liveness test. The release
+      // sweep (finalizePureQueue after mark release) re-runs this check.
       if (
         source._flags & REACTIVE_DISPOSED ||
-        (!(source._statusFlags & this._collectionType) &&
+        (!source._affectsCount &&
+          !(source._statusFlags & this._collectionType) &&
           !(this._collectionType & STATUS_ERROR && source._statusFlags & STATUS_PENDING))
       )
         this._sources.delete(source);

--- a/packages/solid-signals/src/core/async.ts
+++ b/packages/solid-signals/src/core/async.ts
@@ -88,20 +88,13 @@ export function forEachDependent(
 // settles and when an `isPending` observer must re-evaluate after a real error):
 // shared scheduling helper in heap.ts (tracked effects bypass the heap).
 
-export function settlePendingSource(
-  el: Computed<any>,
-  source: Computed<any> = el,
-  // Mark release runs inside queue finalization: companion writes must go
-  // through the settlement snap (committed), because a setSignal here would
-  // open a fresh transition-scoped override window that nothing reverts.
-  snap: boolean = false
-): void {
+export function settlePendingSource(el: Computed<any>): void {
   let scheduled = false;
   const visited = new Set<Computed<any>>();
-  // Companion updates no-op without the verdict layer (null hooks).
-  const updateCompanions = snap ? GlobalQueue._snapCompanions : GlobalQueue._updatePendingSignal;
+  // Companion updates no-op without the verdict layer (null hook).
+  const updateCompanions = GlobalQueue._updatePendingSignal;
   const settle = (node: Computed<any>) => {
-    if (visited.has(node) || !removePendingSource(node, source)) return;
+    if (visited.has(node) || !removePendingSource(node, el)) return;
     visited.add(node);
     node._time = clock;
     const remaining = node._pendingSources?.values().next().value;
@@ -410,18 +403,6 @@ export function notifyStatus(
 
   const pendingSource =
     status === STATUS_PENDING && error instanceof NotReadyError ? error.source : undefined;
-  // Mark-sourced propagation must not capture subscribers into the marking
-  // action's transaction (#2893): they carry no held value needing a
-  // transition-scheduled commit, and stamping `_transition` on them would
-  // freeze unrelated writes that share a downstream memo until the action
-  // settles. Real async keeps queuing (its commits ride the transition).
-  const markSourced = pendingSource?._affectsFor !== undefined;
-  // A real error is a settled verdict a mark must not erase (#2893): landing
-  // STATUS_PENDING here would clobber `_error` with the sentinel's
-  // NotReadyError, and unlike real async there is no arriving value whose
-  // recompute would surface the error again. Descent stops too — everything
-  // downstream holds the propagated error for the same reason.
-  if (markSourced && el._statusFlags & STATUS_ERROR) return;
   const isSource = pendingSource === el;
   const isOptimisticBoundary =
     status === STATUS_PENDING && el._overrideValue !== undefined && !isSource;
@@ -479,7 +460,7 @@ export function notifyStatus(
         schedule();
         return;
       }
-      if (!downstreamBlockStatus && !markSourced && !sub._transition) queuePendingNode(sub);
+      if (!downstreamBlockStatus && !sub._transition) queuePendingNode(sub);
       notifyStatus(sub, status, error, downstreamBlockStatus, downstreamLane);
     }
   });

--- a/packages/solid-signals/src/core/core.ts
+++ b/packages/solid-signals/src/core/core.ts
@@ -55,7 +55,6 @@ import {
 import { devTrackHeldPending } from "./invariants.js";
 import { cleanup, disposeChildren, inheritId, markDisposal } from "./owner.js";
 import {
-  activeAffectsMarks,
   activeTransition,
   armReaskClear,
   clock,
@@ -101,18 +100,6 @@ export let pendingCheckActive = false;
 export let latestReadActive = false;
 export let context: Owner | null = null;
 export let currentOptimisticLane: OptimisticLane | null = null;
-
-/**
- * Marked sources read by the recompute currently on the stack (saved/restored
- * per recompute, like `context`). A computed that reads a node with a live
- * `affects()` mark inherits the mark's pendingness — `recompute` applies the
- * collected sources through `applyAffectsReads` after its commit, because the
- * `clearStatus` at the top of the commit path wipes whatever sentinel entries
- * the node held from the registration-time push. This is the pull half of
- * mark propagation (real async re-establishes itself by re-throwing on read;
- * marks are value-transparent, so they re-establish here instead).
- */
-let affectsReads: (Signal<any> | Computed<any>)[] | null = null;
 
 export let snapshotCaptureActive = false;
 export let snapshotSources: Set<any> | null = null;
@@ -209,9 +196,6 @@ export function recompute(el: Computed<any>, create: boolean = false): void {
   let value = el._pendingValue === NOT_PENDING ? el._value : el._pendingValue;
   let oldHeight = el._height;
   let prevTracking = tracking;
-  const prevAffectsReads = affectsReads;
-  affectsReads = null;
-  let markedReads: (Signal<any> | Computed<any>)[] | null = null;
   let prevLane = currentOptimisticLane;
   let prevStrictRead: string | false = false;
   if (__DEV__) {
@@ -281,8 +265,6 @@ export function recompute(el: Computed<any>, create: boolean = false): void {
     if (isStaleEffect) stale = prevStale;
     el._flags = REACTIVE_NONE | (create ? el._flags & REACTIVE_SNAPSHOT_STALE : 0);
     context = oldcontext;
-    markedReads = affectsReads;
-    affectsReads = prevAffectsReads;
   }
 
   if (!el._error) {
@@ -364,28 +346,11 @@ export function recompute(el: Computed<any>, create: boolean = false): void {
     }
   }
   currentOptimisticLane = prevLane;
-  // Marks read during this recompute re-attach after the commit above:
-  // earlier, the sentinel's NotReadyError in `_error` would have routed the
-  // fresh value into the error-skip branch instead of committing it. A real
-  // (non-NotReady) error wins over marks (#2893): applying the sentinel here
-  // would clobber the user's error with a NotReadyError from a node whose
-  // reads value-transparency promises can never throw NotReady.
-  // `markedReads` only collects under a live mark, so the hook is installed.
-  if (markedReads && !(el._statusFlags & STATUS_ERROR))
-    GlobalQueue._applyAffectsReads!(el, markedReads);
-  // Mark-only pending doesn't queue (#2893): the node holds no value needing
-  // a transition-scheduled commit, and queueing would stamp the marking
-  // action's transaction onto it — freezing unrelated writes that share it.
-  // (Single mask test up front keeps the mark-free hot path at original cost.)
-  const pendFlags = el._statusFlags & (STATUS_PENDING | STATUS_UNINITIALIZED);
   const needsPendingCommit =
     el._pendingValue !== NOT_PENDING ||
     el._pendingFirstChild !== null ||
     el._pendingDisposal !== null ||
-    (pendFlags !== 0 &&
-      (pendFlags !== STATUS_PENDING ||
-        activeAffectsMarks === 0 ||
-        !GlobalQueue._onlyMarkPending!(el)));
+    (el._statusFlags & (STATUS_PENDING | STATUS_UNINITIALIZED)) !== 0;
   // Override-covered holds (hasOverride) always queue: their commit belongs
   // to their own transition's schedule (A18 re-rule) and is unobservable
   // under the override (A17). Revert no longer commits anything, so an
@@ -746,14 +711,7 @@ export function read<T>(el: Signal<T> | Computed<T>): T {
     !snapshotCaptureActive &&
     (!__DEV__ || !strictRead)
   ) {
-    if (c && tracking) {
-      link(el, c as Computed<any>);
-      // A live mark on a read source flows to the reader (probe reads are
-      // excluded: the probe's own collection owns that verdict, and marking
-      // the enclosing memo would make an `isPending` wrapper itself pending).
-      if (activeAffectsMarks !== 0 && el._affectsCount && !pendingCheckActive)
-        (affectsReads ??= []).push(el);
-    }
+    if (c && tracking) link(el, c as Computed<any>);
     return (!c || el._pendingValue === NOT_PENDING ? el._value : el._pendingValue) as T;
   }
 
@@ -766,16 +724,6 @@ export function read<T>(el: Signal<T> | Computed<T>): T {
 
   if (c && tracking) {
     link(el, c as Computed<any>, pendingCheckActive);
-    // Mark inheritance through derivation (see the fast path above), and its
-    // transitive half (#2893): a mark-pended owner's sentinel sources flow to
-    // the reader like a direct mark — value-transparent reads have no throw
-    // to re-establish through, so without this a mid-window recompute sheds
-    // pendingness permanently past one derivation level.
-    if (activeAffectsMarks !== 0 && !pendingCheckActive) {
-      if (el._affectsCount) (affectsReads ??= []).push(el);
-      if (owner._statusFlags & STATUS_PENDING)
-        GlobalQueue._collectMarkSources!(owner as Computed<any>, (affectsReads ??= []));
-    }
 
     if ((owner as Computed<unknown>)._fn) {
       const elQueue = queueFor(el as Computed<unknown>);
@@ -792,16 +740,7 @@ export function read<T>(el: Signal<T> | Computed<T>): T {
     }
   }
 
-  // Mark-only pending never suspends the reader (#2886): an affects() mark is
-  // a promise of change, not an absence of value, so a derived node whose only
-  // pending sources are mark sentinels keeps its real value readable —
-  // pendingness reaches readers through verdicts (isPending), not throws.
-  // (`activeAffectsMarks` gates the source scan off the mark-free hot path;
-  // sentinels can't survive in pending sources past their last release.)
-  if (
-    owner._statusFlags & STATUS_PENDING &&
-    !(activeAffectsMarks !== 0 && GlobalQueue._onlyMarkPending!(owner as Computed<any>))
-  ) {
+  if (owner._statusFlags & STATUS_PENDING) {
     if (c && !(stale && owner._transition && activeTransition !== owner._transition)) {
       if (__DEV__ && c && c._config & CONFIG_CHILDREN_FORBIDDEN) {
         const message =

--- a/packages/solid-signals/src/core/error.ts
+++ b/packages/solid-signals/src/core/error.ts
@@ -23,6 +23,13 @@
  * ```
  */
 export class NotReadyError extends Error {
+  /**
+   * Tags a visibility-only notification on the affects() boundary channel:
+   * boundaries update display state from it, but the root queue never
+   * registers a reporter — marks are invisible to completion accounting by
+   * construction.
+   */
+  declare _markVisual?: boolean;
   constructor(public source: any) {
     super();
   }

--- a/packages/solid-signals/src/core/graph.ts
+++ b/packages/solid-signals/src/core/graph.ts
@@ -58,9 +58,14 @@ export function link(
   sub: Computed<any>,
   pendingObserver: boolean = false
 ) {
+  // Repeat touches within one pass AND-combine `_pendingObserver`: a probe
+  // read (`isPending(() => x())`) beside a value read of the same dep must
+  // not relabel the value dependency as probe-only — the value read is what
+  // real-error propagation and affects() coverage key off, regardless of
+  // read order within the computation.
   const prevDep = sub._depsTail;
   if (prevDep !== null && prevDep._dep === dep) {
-    prevDep._pendingObserver = pendingObserver;
+    prevDep._pendingObserver &&= pendingObserver;
     return;
   }
 
@@ -71,6 +76,7 @@ export function link(
     if (nextDep !== null && nextDep._dep === dep) {
       nextDep._gen = sub._depGen;
       sub._depsTail = nextDep;
+      // First touch of this pass: the previous pass's label is stale.
       nextDep._pendingObserver = pendingObserver;
       return;
     }
@@ -87,7 +93,10 @@ export function link(
     prevSub._sub === sub &&
     (!isRecomputing || prevSub._gen === sub._depGen)
   ) {
-    prevSub._pendingObserver = pendingObserver;
+    // Gen-matched during a recompute = repeat touch this pass (AND); outside
+    // a recompute there is no pass boundary, so the latest read labels it.
+    if (isRecomputing) prevSub._pendingObserver &&= pendingObserver;
+    else prevSub._pendingObserver = pendingObserver;
     return;
   }
 

--- a/packages/solid-signals/src/core/optimistic.ts
+++ b/packages/solid-signals/src/core/optimistic.ts
@@ -153,12 +153,7 @@ function transitionBlocked(transition: Transition): boolean {
       hasActiveOverride(node) &&
       "_statusFlags" in node &&
       (node as Computed<any>)._statusFlags & STATUS_PENDING &&
-      (node as Computed<any>)._error instanceof NotReadyError &&
-      // Mark-sourced pending never blocks settlement: affects() releases AT
-      // settle, so counting its sentinel here would deadlock the window it
-      // is scoped to.
-      !(((node as Computed<any>)._error as NotReadyError).source as Computed<any> | undefined)
-        ?._affectsFor
+      (node as Computed<any>)._error instanceof NotReadyError
     ) {
       return true;
     }

--- a/packages/solid-signals/src/core/scheduler.ts
+++ b/packages/solid-signals/src/core/scheduler.ts
@@ -350,17 +350,12 @@ export class GlobalQueue extends Queue {
   // _clearOptimisticStore).
   static _releaseAffectsScope: ((node: OptimisticNode) => void) | null = null;
   // affects()-side hooks (wired by affects.ts, mirroring _update): the mark
-  // engine — count/register/release plus the post-commit re-application of
-  // marked reads — lives with the feature. Every call site is gated by state
-  // only that module creates, so `!` invocations are safe once the gate holds.
-  static _applyAffectsReads:
-    | ((el: Computed<any>, sources: (Signal<any> | Computed<any>)[]) => void)
-    | null = null;
+  // engine — count/register/release — lives with the feature. Every call site
+  // is gated by state only that module creates, so `!` invocations are safe
+  // once the gate holds.
   static _releaseAffectsMarks: ((nodes: OptimisticNode[]) => void) | null = null;
   static _markAffects: ((node: OptimisticNode) => void) | null = null;
   static _releaseAffectsMark: ((node: OptimisticNode) => void) | null = null;
-  static _onlyMarkPending: ((el: Computed<any>) => boolean) | null = null;
-  static _collectMarkSources: ((el: Computed<any>, into: OptimisticNode[]) => void) | null = null;
   // External-source bridge (wired by enableExternalSource(); null while no
   // config is active — including after _resetExternalSourceConfig()).
   static _wireExternalSource: ((self: Computed<any>) => void) | null = null;
@@ -386,7 +381,7 @@ export class GlobalQueue extends Queue {
     | null = null;
   static _recordFresh: ((el: OptimisticNode, value: any) => void) | null = null;
   static _applyReask: ((el: Computed<any>, hadReask: boolean) => boolean) | null = null;
-  static _repollVerdicts: ((el: Computed<any>) => void) | null = null;
+  static _repollVerdicts: ((el: Computed<any>, snap?: boolean) => void) | null = null;
   static _witnessAffects: ((node: OptimisticNode) => void) | null = null;
   // Optimistic-engine hooks (wired by core/optimistic.ts via
   // installOptimisticEngine(), called from verdict.ts / createOptimistic /
@@ -531,6 +526,11 @@ export class GlobalQueue extends Queue {
     if (mask & STATUS_PENDING) {
       if (flags & STATUS_PENDING) {
         const actualError = error !== undefined ? error : node._error;
+        // A visibility-only mark notification (the affects() boundary
+        // channel) updates display state on its way up but must be invisible
+        // to completion accounting BY CONSTRUCTION: it never registers a
+        // reporter and never counts toward the loading-boundary diagnostic.
+        if ((actualError as NotReadyError)?._markVisual) return true;
         if (activeTransition && actualError) {
           const source = (actualError as NotReadyError).source;
           // The one sanctioned registration site (INV-3): async blockers only
@@ -694,8 +694,14 @@ export function finalizePureQueue(
     }
     // Declared motion ends with the transaction: settle (or plain flush end
     // for ambient marks) releases each registration's refcount. A non-empty
-    // batch means registerAffectsMark ran, which installed the hook.
-    if (batch._affectsNodes.length) GlobalQueue._releaseAffectsMarks!(batch._affectsNodes);
+    // batch means registerAffectsMark ran, which installed the hook. Marks
+    // held boundary display state through the visual channel, and their
+    // release is the display-state update point — re-run the boundary sweep
+    // (the earlier sweep above ran while the marks were still live).
+    if (batch._affectsNodes.length) {
+      GlobalQueue._releaseAffectsMarks!(batch._affectsNodes);
+      if (globalQueue._children.length) checkBoundaryChildren(globalQueue);
+    }
     // A non-empty set means trackOptimisticStore ran, which installed the
     // hook; the hook iterates, clears, and schedules (keeping the loop out of
     // core lets esbuild shake it — rollup already folds the null guard). The

--- a/packages/solid-signals/src/core/types.ts
+++ b/packages/solid-signals/src/core/types.ts
@@ -66,19 +66,14 @@ export interface RawSignal<T> {
   _parentSource?: Signal<any> | Computed<any>; // Back-reference for parent-child lane relationship
   /**
    * Live `affects()` marks on this node (refcount). Non-zero is declared
-   * motion: the node reads pending regardless of graph state, until every
-   * declaring transaction settles/reverts and releases its mark.
+   * motion: the node — and, via the verdict layer's dep-graph coverage walk,
+   * everything derived from it — reads pending regardless of graph state,
+   * until every declaring transaction settles/reverts and releases its mark.
+   * This count is the mark's ONLY graph state: the dedicated channel stores
+   * nothing downstream and never touches status flags, errors, or pending
+   * sources.
    */
   _affectsCount?: number;
-  /**
-   * The mark's identity on the pending-source rails (lazy, see
-   * `getAffectsSentinel`). Downstream subscribers hold it in
-   * `_pendingSources` exactly like a real in-flight source, but with its own
-   * identity so a landing or quiet re-ask on the node itself can't clear it.
-   */
-  _affectsSentinel?: Computed<any>;
-  /** Set only on sentinels: the marked node this sentinel stands for. */
-  _affectsFor?: Signal<any> | Computed<any>;
 }
 
 export interface FirewallSignal<T> extends RawSignal<T> {

--- a/packages/solid-signals/src/core/verdict.ts
+++ b/packages/solid-signals/src/core/verdict.ts
@@ -10,7 +10,9 @@ import {
   REACTIVE_DIRTY,
   REACTIVE_DISPOSED,
   REACTIVE_MANUAL_WRITE,
+  REACTIVE_RECOMPUTING_DEPS,
   REACTIVE_ZOMBIE,
+  STATUS_ERROR,
   STATUS_PENDING,
   STATUS_UNINITIALIZED
 } from "./constants.js";
@@ -39,6 +41,7 @@ import { devTrackCompanionOwner, InvariantHooks } from "./invariants.js";
 import { findLane, hasActiveOverride } from "./lanes.js";
 import { installOptimisticEngine } from "./optimistic.js";
 import {
+  activeAffectsMarks,
   activeTransition,
   clock,
   dirtyQueue,
@@ -94,6 +97,51 @@ function witnessAffects(node: Signal<any> | Computed<any>): void {
   pendingProbe?.sources.add(node);
 }
 
+/**
+ * The affects() coverage walk — the read half of the dedicated mark channel.
+ * A node is covered by a live mark iff it carries one (`_affectsCount`) or
+ * derives, through its CURRENT deps (hopping store firewalls), from a node
+ * that does. Pull-based coverage means graph rewires, mid-window recomputes,
+ * and probe-triggered recomputes can never strand or strip a mark — there is
+ * nothing stored downstream to corrupt. Probe-created links
+ * (`_pendingObserver`) are skipped so an `isPending` wrapper memo never
+ * inherits the coverage it reports on.
+ */
+function markWalk(
+  el: Signal<any> | Computed<any>,
+  seen: Set<Signal<any> | Computed<any>>
+): boolean {
+  if (el._affectsCount) return true;
+  // A real error outranks an inherited mark (A16/A24c): an errored node
+  // answers probes with its error, not a coverage verdict, and coverage does
+  // not flow through it — matching the rails' behavior, where propagation
+  // stopped at errored nodes. A DIRECT mark on an errored node still reads
+  // pending (the count check above), also matching.
+  if ((el as Computed<any>)._statusFlags & STATUS_ERROR) return false;
+  if (seen.has(el)) return false;
+  seen.add(el);
+  const firewall = (el as FirewallSignal<any>)._firewall;
+  if (firewall && markWalk(firewall, seen)) return true;
+  // Mid-recompute (the clearStatus companion poke runs before
+  // trimStaleDeps), only the validated prefix [_deps.._depsTail] is this
+  // pass's dependency set — walking past it would read dropped deps and
+  // latch a stale verdict on the companion.
+  const comp = el as Computed<any>;
+  const tail = comp._flags & REACTIVE_RECOMPUTING_DEPS ? comp._depsTail : undefined;
+  if (tail !== null) {
+    for (let d = comp._deps ?? null; d !== null; d = d._nextDep) {
+      if (!d._pendingObserver && markWalk(d._dep, seen)) return true;
+      if (d === tail) break;
+    }
+  }
+  return false;
+}
+
+/** Gated entry: apps with no live mark pay one integer compare. */
+function markCovered(el: Signal<any> | Computed<any>): boolean {
+  return activeAffectsMarks !== 0 && markWalk(el, new Set());
+}
+
 function quietPending(el: Computed<any>): boolean {
   if (el._pendingSources) {
     for (const source of el._pendingSources) if (!source._reask) return false;
@@ -113,11 +161,13 @@ function newQuestionInFlight(comp: Computed<any>): boolean {
 function computePendingState(el: Signal<any> | Computed<any>): boolean {
   const comp = el as Computed<any>;
   if (comp._flags & REACTIVE_DISPOSED) return false;
-  if (el._affectsCount) return true;
+  // Mark coverage is transitive by dep-graph reachability: a latest() shadow
+  // reaches its owner (and a store leaf its firewall) through its own deps,
+  // so the one walk covers direct marks, derivation, and companion chains.
+  if (markCovered(el)) return true;
   const firewall = (el as FirewallSignal<any>)._firewall;
   if (el._parentSource) {
     const parentNode = el._parentSource as FirewallSignal<any>;
-    if (parentNode._affectsCount) return true;
     const parent = (parentNode._firewall || parentNode) as Computed<any>;
     return newQuestionInFlight(parent);
   }
@@ -158,12 +208,22 @@ function updateChildCompanions(el: Computed<any>): void {
   }
 }
 
-function repollDownstreamVerdicts(el: Computed<any>): void {
+/**
+ * Re-derive every verdict companion downstream of `el` (subs + firewall
+ * children, dedup'd). The affects() channel's poke walk: registration and
+ * re-ask flips use the live write path (companion setSignal — its own lane
+ * lets the wake escape an incomplete transition's effect stash, #2887);
+ * mark release passes `snap` because it runs inside queue finalization,
+ * where companion writes must land committed (a setSignal there would open
+ * a fresh override window that nothing settles).
+ */
+function repollDownstreamVerdicts(el: Computed<any>, snap: boolean = false): void {
+  const update = snap ? snapCompanionsToState : updatePendingSignal;
   const visited = new Set<Signal<any> | Computed<any>>();
   const visit = (node: Signal<any> | Computed<any>) => {
     if (visited.has(node)) return;
     visited.add(node);
-    if (node._pendingSignal || node._latestValueComputed) updatePendingSignal(node);
+    if (node._pendingSignal || node._latestValueComputed) update(node);
     for (let s = node._subs; s !== null; s = s._nextSub) visit(s._sub);
     for (
       let child: FirewallSignal<any> | null = (node as Computed<any>)._child ?? null;


### PR DESCRIPTION
Attribution probe for #2923's CodSpeed result (merge-mixed −28%, alongside merge-static ×2.2 / reconcile +92% / update1to1 +5.5% improvements). Isolates one spike. Closes after CodSpeed reports.