### PR TITLE
ci probe: tier1-spike4 isolation (do not merge)

### DIFF
--- a/packages/solid-signals/src/core/core.ts
+++ b/packages/solid-signals/src/core/core.ts
@@ -861,9 +861,7 @@ export function read<T>(el: Signal<T> | Computed<T>): T {
     });
 
   if (el._overrideValue !== undefined && el._overrideValue !== NOT_PENDING) {
-    // An active override means the engine is installed (A17: the override IS
-    // the value for every reader — that check itself stays right here).
-    if (c && stale && GlobalQueue._readStashed!(el as Signal<any>)) return el._value as T;
+    // A17: the override IS the value for every reader.
     return unwrapOverride<T>(el._overrideValue);
   }
 

--- a/packages/solid-signals/src/core/optimistic.ts
+++ b/packages/solid-signals/src/core/optimistic.ts
@@ -12,9 +12,7 @@
  * once the gate holds — the same late-binding contract as verdict.ts.
  */
 import {
-  CONFIG_OWNED_WRITE,
   EFFECT_RENDER,
-  EFFECT_TRACKED,
   EFFECT_USER,
   NOT_PENDING,
   OVERRIDE_UNDEFINED,
@@ -27,7 +25,6 @@ import {
 } from "./constants.js";
 import { currentOptimisticLane, latestReadActive, stale } from "./core.js";
 import { NotReadyError } from "./error.js";
-import { enqueueSub } from "./heap.js";
 import { devCheckMergedLaneEmpty, devTrackOptimistic } from "./invariants.js";
 import {
   activeLanes,
@@ -43,23 +40,16 @@ import {
 import {
   activeTransition,
   clock,
-  dirtyQueue,
-  finalizePureQueue,
   GlobalQueue,
   globalQueue,
   insertSubs,
   schedule,
-  zombieQueue,
   type QueueCallback,
   type Transition
 } from "./scheduler.js";
 import type { Computed, Link, Signal } from "./types.js";
 
 type OptimisticNode = Signal<any> | Computed<any>;
-
-// When a background transition is stashed, plain optimistic signals need one
-// committed-view rerun. Keep that override local to the stash flush.
-let stashedOptimisticReads: Set<Signal<any>> | null = null;
 
 /** The optimistic half of setSignal, fired when `_overrideValue !== undefined`. */
 function optimisticWrite<T>(el: Signal<T> | Computed<T>, v: T | ((prev: T) => T)): T {
@@ -108,37 +98,6 @@ function optimisticWrite<T>(el: Signal<T> | Computed<T>, v: T | ((prev: T) => T)
   insertSubs(el, true);
   schedule();
   return v;
-}
-
-function readStashed(node: Signal<any>): boolean {
-  return !!stashedOptimisticReads?.has(node);
-}
-
-function queueStashedOptimisticEffects(node: Signal<any>): void {
-  for (let s = node._subs; s !== null; s = s._nextSub) {
-    const sub = s._sub as any;
-    if (!sub._type) continue;
-    enqueueSub(sub);
-  }
-}
-
-/**
- * Incomplete-transition finalization when the stashed transition holds
- * optimistic nodes: give plain optimistic signals one committed-view rerun.
- */
-function stashOptimistic(stashedTransition: Transition): void {
-  stashedOptimisticReads = new Set();
-  for (let i = 0; i < stashedTransition._optimisticNodes.length; i++) {
-    const node = stashedTransition._optimisticNodes[i];
-    if ((node as any)._fn || node._config & CONFIG_OWNED_WRITE) continue;
-    stashedOptimisticReads.add(node as Signal<any>);
-    queueStashedOptimisticEffects(node as Signal<any>);
-  }
-  try {
-    finalizePureQueue(null, true);
-  } finally {
-    stashedOptimisticReads = null;
-  }
 }
 
 /**
@@ -334,11 +293,9 @@ export function installOptimisticEngine(): void {
   if (GlobalQueue._optimisticWrite !== null) return;
   GlobalQueue._optimisticWrite = optimisticWrite;
   GlobalQueue._resolveOptimistic = resolveOptimisticNodes;
-  GlobalQueue._stashOptimistic = stashOptimistic;
   GlobalQueue._transitionBlocked = transitionBlocked;
   GlobalQueue._cleanupLanes = cleanupCompletedLanes;
   GlobalQueue._runLaneEffects = runLaneEffects;
-  GlobalQueue._readStashed = readStashed;
   GlobalQueue._gatedRead = gatedRead;
   GlobalQueue._laneSuspends = laneSuspends;
   GlobalQueue._laneReadsCommitted = laneReadsCommitted;

--- a/packages/solid-signals/src/core/scheduler.ts
+++ b/packages/solid-signals/src/core/scheduler.ts
@@ -398,11 +398,9 @@ export class GlobalQueue extends Queue {
   static _optimisticWrite: (<T>(el: Signal<T> | Computed<T>, v: T | ((prev: T) => T)) => T) | null =
     null;
   static _resolveOptimistic: ((nodes: OptimisticNode[]) => void) | null = null;
-  static _stashOptimistic: ((stashedTransition: Transition) => void) | null = null;
   static _transitionBlocked: ((transition: Transition) => boolean) | null = null;
   static _cleanupLanes: ((completingTransition: Transition | null) => void) | null = null;
   static _runLaneEffects: ((type: number) => void) | null = null;
-  static _readStashed: ((el: Signal<any>) => boolean) | null = null;
   static _gatedRead:
     | ((el: Signal<any>, owner: OptimisticNode, c: Computed<any>) => boolean)
     | null = null;
@@ -447,18 +445,7 @@ export class GlobalQueue extends Queue {
           scheduled = dirtyQueue._max >= dirtyQueue._min || this._batch._pendingNodes.length > 0;
           reassignPendingTransition(stashedTransition._pendingNodes);
           activeTransition = null;
-          // The stash pass (committed-view rerun of plain optimistic signals)
-          // wraps finalizePureQueue in the engine; a non-empty _optimisticNodes
-          // means _optimisticWrite ran, which installed the hook.
-          if (
-            !stashedTransition._actions.length &&
-            !stashedTransition._asyncReporters.size &&
-            stashedTransition._optimisticNodes.length
-          ) {
-            GlobalQueue._stashOptimistic!(stashedTransition);
-          } else {
-            finalizePureQueue(null, true);
-          }
+          finalizePureQueue(null, true);
           return;
         }
         const completingTransition = activeTransition;


### PR DESCRIPTION
Attribution probe for #2923's CodSpeed result (merge-mixed −28%, alongside merge-static ×2.2 / reconcile +92% / update1to1 +5.5% improvements). Isolates one spike. Closes after CodSpeed reports.