### PR TITLE
fix(reactive): make createSelector transition-aware

### DIFF
--- a/.changeset/witty-crabs-search.md
+++ b/.changeset/witty-crabs-search.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+make createSelector transition-aware

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -851,7 +851,8 @@ export function createSelector<T, U = T>(
       for (const [key, val] of subs.entries())
         if (fn(key, v) !== fn(key, p!)) {
           for (const c of val.values()) {
-            c.state = STALE;
+            if (Transition && Transition.running) c.tState = STALE;
+            else c.state = STALE;
             if (c.pure) Updates!.push(c);
             else Effects!.push(c);
           }

--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -19,8 +19,10 @@ import {
   useContext,
   getOwner,
   runWithOwner,
-  children
+  children,
+  startTransition
 } from "../src/index.js";
+import { getSuspenseContext } from "../src/reactive/signal.js";
 
 import "./MessageChannel";
 
@@ -811,6 +813,36 @@ describe("createSelector", () => {
         });
       });
     }));
+
+  test("selection made inside a transition", async () => {
+    // startTransition only creates a real Transition once a SuspenseContext exists
+    getSuspenseContext();
+
+    await createRoot(async () => {
+      const [s, set] = createSignal<number>(-1),
+        isSelected = createSelector<number, number>(s);
+      let count = 0;
+      const list = Array.from({ length: 3 }, (_, i) =>
+        createMemo(() => {
+          count++;
+          return isSelected(i) ? "selected" : "no";
+        })
+      );
+      expect(count).toBe(3);
+      expect(list[1]()).toBe("no");
+
+      count = 0;
+      await startTransition(() => set(1));
+      expect(count).toBe(1);
+      expect(list[1]()).toBe("selected");
+
+      count = 0;
+      await startTransition(() => set(2));
+      expect(count).toBe(2);
+      expect(list[1]()).toBe("no");
+      expect(list[2]()).toBe("selected");
+    });
+  });
 });
 
 describe("create and use context", () => {


### PR DESCRIPTION
This is an Opus 5 solution, to this solid 1 bug that was reported in the solid-start repo

- closes https://github.com/solidjs/solid-start/issues/2114
- closes https://github.com/solidjs/solid/issues/2940

### Problem

`createSelector` does not update its subscribers when the source changes inside a transition. The subscribed computation is silently skipped, so a `<Show>` or `classList` driven by the selector never re-renders, even though a `createEffect` reading the same selector fires with the correct value.

The most common way to hit this is `@solidjs/router`: every navigation (including `setSearchParams`) is wrapped in `startTransition`, and `startTransition` only creates a `Transition` when `Scheduler || SuspenseContext` is set. So any app with a `<Suspense>` boundary and a router-driven selector is affected. SolidStart's default template ships exactly that shape, which is why it tends to surface as "my selector broke when I added SSR".

Fixes https://github.com/solidjs/solid/issues/2940. Very likely the same underlying cause as #666.

### Cause

Inside a transition, Solid tracks staleness on `tState`, not `state`. `writeSignal` handles this:

```js
if (!TransitionRunning) o.state = STALE;
else o.tState = STALE;
