### PR TITLE
fix(signals): preserve sibling queues during traversal

### DIFF
--- a/.changeset/fix-scheduler-child-queue-removal.md
+++ b/.changeset/fix-scheduler-child-queue-removal.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Keep traversing sibling effect queues when a child queue removes itself or an earlier sibling during a flush. Previously, the shifted sibling could be skipped and leave its queued effects unexecuted.

--- a/packages/solid-signals/src/core/scheduler.ts
+++ b/packages/solid-signals/src/core/scheduler.ts
@@ -295,7 +295,12 @@ export class Queue implements IQueue {
       this._queues[type - 1] = [];
       runQueue(effects, type);
     }
-    for (let i = 0; i < this._children.length; i++) (this._children[i] as any).run?.(type);
+    for (let i = 0; i < this._children.length; ) {
+      const child = this._children[i];
+      (child as any).run?.(type);
+      // A child may remove itself or an earlier sibling while its effects run.
+      if (this._children[i] === child) i++;
+    }
   }
   enqueue(type: number, fn: QueueCallback): void {
     if (type) {

--- a/packages/solid-signals/tests/scheduler-livelock.test.ts
+++ b/packages/solid-signals/tests/scheduler-livelock.test.ts
@@ -1,6 +1,7 @@
 import { expect, it } from "vitest";
 import {
   createEffect,
+  createLoadingBoundary,
   createMemo,
   createRenderEffect,
   createRoot,
@@ -186,4 +187,48 @@ it("isPending(() => latest(x)) in a user effect does not loop on refetch (#2843)
 
   dispose();
   flush();
+});
+
+it("disposing the current boundary queue does not skip its sibling", () => {
+  const effects: string[] = [];
+  const disposers: (() => void)[] = [];
+
+  try {
+    createRoot(dispose => {
+      disposers.push(dispose);
+      createLoadingBoundary(
+        () => {
+          createEffect(
+            () => undefined,
+            () => {
+              effects.push("first");
+              dispose();
+            }
+          );
+        },
+        () => undefined
+      )();
+    });
+
+    createRoot(dispose => {
+      disposers.push(dispose);
+      createLoadingBoundary(
+        () => {
+          createEffect(
+            () => undefined,
+            () => {
+              effects.push("second");
+            }
+          );
+        },
+        () => undefined
+      )();
+    });
+
+    flush();
+    expect(effects).toEqual(["first", "second"]);
+  } finally {
+    for (const dispose of disposers) dispose();
+    flush();
+  }
 });


### PR DESCRIPTION
## The bug

`Queue.run()` traverses child queues with a monotonically increasing array index. A boundary effect can dispose its owner while its queue is running, which removes that queue from `_children`. The next sibling then shifts into the current index and is skipped, leaving its already-queued effects unexecuted with no later flush scheduled.

## The fix

Advance the traversal index only while the child that just ran still occupies that slot. If it removed itself or an earlier sibling, process the child that shifted into the current index before advancing.

A regression test creates two loading-boundary queues, disposes the first from its effect, and verifies that the second effect still runs in the same flush.

## Tests

- `vitest run`: 78 files, 1,147 tests passed
- `tsc -p tsconfig.build.json --noEmit`
- Prettier check for the changed source and test
- Changeset status validates an `@solidjs/signals` patch release