### PR TITLE
fix(signals): re-adopt the queue batch when an action completes

### DIFF
--- a/.changeset/action-done-window-batch-adoption.md
+++ b/.changeset/action-done-window-batch-adoption.md
@@ -1,0 +1,14 @@
+---
+"@solidjs/signals": patch
+---
+
+Re-adopt the queue batch when an action completes. `done()` restored the
+active transition with a bare `setActiveTransition`, leaving the global
+queue's batch as a detached ambient batch until the scheduled flush. Anything
+registered in that microtask window was stranded with nothing to finalize it:
+a completed action's held writes were silently lost when another action
+resumed in the window (its transition merge never transferred them), a bare
+optimistic write never reverted, and an `affects()` mark could leak — leaving
+`isPending` stuck true. Completing an action now goes through
+`initTransition`, the same batch-adoption path every other
+transition-resumption site already uses.

--- a/packages/solid-signals/src/core/action.ts
+++ b/packages/solid-signals/src/core/action.ts
@@ -4,7 +4,6 @@ import {
   flush,
   globalQueue,
   schedule,
-  setActiveTransition,
   type Transition
 } from "./scheduler.js";
 import { isThenable } from "./async.js";
@@ -122,7 +121,12 @@ export function action<Args extends any[], Y, R>(
         ctx = currentTransition(ctx);
         const i = ctx._actions.indexOf(it);
         if (i >= 0) ctx._actions.splice(i, 1);
-        setActiveTransition(ctx);
+        // Re-adopt through initTransition like every other resumption site:
+        // a bare setActiveTransition leaves globalQueue._batch as a detached
+        // ambient batch, and anything registered before the scheduled flush
+        // (held writes on a merging transition, optimistic overrides,
+        // affects() marks) lands there with nothing to ever finalize it.
+        globalQueue.initTransition(ctx);
         schedule();
         failed ? reject(e) : resolve(v!);
       };

--- a/packages/solid-signals/tests/action-done-window.test.ts
+++ b/packages/solid-signals/tests/action-done-window.test.ts
@@ -1,0 +1,170 @@
+/**
+ * The post-action done() window (#2916 shape): an async-generator action's
+ * done() runs from an iterator-result microtask, restoring activeTransition
+ * with no synchronous flush after it. Until the scheduled flush runs,
+ * globalQueue._batch was a detached ambient batch — so anything registered in
+ * that window (ordinary writes held by a merged transition, optimistic
+ * overrides, affects() marks) landed in a batch that nothing ever finalized.
+ * done() now re-adopts the batch through initTransition, the same path every
+ * other transition-resumption site uses.
+ *
+ * Each test polls microtasks until it observes the restored transition
+ * (scheduler.activeTransition !== null) and injects its work exactly there.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  action,
+  affects,
+  createMemo,
+  createOptimistic,
+  createRenderEffect,
+  createRoot,
+  createSignal,
+  flush,
+  isPending
+} from "../src/index.js";
+import * as scheduler from "../src/core/scheduler.js";
+
+const tick = () => Promise.resolve();
+
+describe("post-action done() window", () => {
+  it("a completed action's write survives another action resuming in its done-window", async () => {
+    const [x, setX] = createSignal(0);
+
+    let resolveA!: () => void;
+    const pA = new Promise<void>(r => (resolveA = r));
+
+    const A = action(async function* () {
+      setX(1);
+      yield pA;
+    });
+
+    // B yields a custom thenable so the test controls exactly when B resumes.
+    let resumeB!: (v?: any) => void;
+    let hasResumeB = false;
+    const thenB = {
+      then(onFulfilled: (v: any) => void) {
+        resumeB = onFulfilled;
+        hasResumeB = true;
+      }
+    };
+    const B = action(function* () {
+      yield thenB as any;
+    });
+
+    const aDone = A();
+    flush(); // stash T_A
+    await tick();
+    const bDone = B(); // fresh transition T_B (T_A stashed, activeTransition null)
+    flush(); // stash T_B
+
+    resolveA();
+
+    // Land in A's done-window and resume B there, so initTransition(T_B)
+    // merges the restored T_A into T_B. T_A's held write must survive the
+    // merge and commit when T_B settles.
+    let resumed = false;
+    for (let i = 0; i < 16; i++) {
+      await tick();
+      if (!resumed && scheduler.activeTransition !== null && hasResumeB) {
+        resumed = true;
+        resumeB(undefined);
+      }
+    }
+    expect(resumed).toBe(true);
+
+    await Promise.all([aDone, bDone]);
+    await new Promise(r => setTimeout(r, 0));
+    flush();
+
+    expect(x()).toBe(1);
+
+    // And the signal must remain writable afterwards.
+    setX(9);
+    flush();
+    expect(x()).toBe(9);
+  });
+
+  it("a bare optimistic write in the done-window still reverts", async () => {
+    const [opt, setOpt] = createOptimistic(0);
+    let dispose!: () => void;
+    createRoot(d => {
+      dispose = d;
+      const m = createMemo(() => opt() * 2);
+      createRenderEffect(m, () => {});
+    });
+    flush();
+
+    let resolveA!: () => void;
+    const pA = new Promise<void>(r => (resolveA = r));
+    const A = action(async function* () {
+      yield pA;
+    });
+    const aDone = A();
+    flush();
+
+    resolveA();
+
+    let wrote = false;
+    for (let i = 0; i < 16; i++) {
+      await tick();
+      if (!wrote && scheduler.activeTransition !== null) {
+        wrote = true;
+        setOpt(5);
+      }
+    }
+    expect(wrote).toBe(true);
+
+    await aDone;
+    await new Promise(r => setTimeout(r, 0));
+    flush();
+    flush();
+
+    // Every batch that could own the write has settled: it must have reverted.
+    expect(opt()).toBe(0);
+    dispose();
+  });
+
+  it("an affects() mark in the done-window is released by the settling flush", async () => {
+    const [count] = createSignal(1);
+    let dispose!: () => void;
+    createRoot(d => {
+      dispose = d;
+      const m = createMemo(() => count() * 2);
+      createRenderEffect(m, () => {});
+    });
+    flush();
+
+    let resolveA!: () => void;
+    const pA = new Promise<void>(r => (resolveA = r));
+    const A = action(async function* () {
+      yield pA;
+    });
+    const aDone = A();
+    flush();
+
+    resolveA();
+
+    let marked = false;
+    for (let i = 0; i < 16; i++) {
+      await tick();
+      if (!marked && scheduler.activeTransition !== null) {
+        marked = true;
+        affects(count);
+      }
+    }
+    expect(marked).toBe(true);
+
+    await aDone;
+    await new Promise(r => setTimeout(r, 0));
+    flush();
+    flush();
+
+    // The mark now belongs to the restored transaction and releases at its
+    // settle; before the fix it landed in the detached ambient batch, where
+    // (in combination with other pending work) it could leak forever
+    // (isPending stuck true, INV-10 on the next quiescent flush).
+    expect(isPending(() => count())).toBe(false);
+    dispose();
+  });
+});


### PR DESCRIPTION
## Summary

When an async-generator action completes, `done()` restored the active transition with a bare `setActiveTransition(ctx)`, leaving `globalQueue._batch` as a **detached ambient batch** until the scheduled flush ran. Anything registered in that microtask window landed in a batch nothing would ever finalize (the same window as the #2916 race, whose fix only protected that batch's `_pendingNodes`):

- **A completed action's writes were silently lost** when another in-flight action resumed inside the window: `mergeTransitionState` moves every list except `_pendingNodes` (relying on the batch-adoption pass in `initTransition`, which only sees the queue's batch — here the detached ambient one), so the restored transition's held writes were orphaned. Dev invariant INV-7 ("value can never commit", #2827 class).
- **A bare optimistic write in the window never reverted** — it landed in the detached batch's `_optimisticNodes`, which the completing flush never resolves and the end-of-flush reschedule check never sees. Dev invariant INV-6.
- **An `affects()` mark registered in the window could leak forever**, leaving `isPending` stuck `true` with an explicit `flush()` as a no-op. Dev invariant INV-10.

## Fix

One line (plus a comment): `done()` now goes through `globalQueue.initTransition(ctx)` — the same merge-and-adopt path every other transition-resumption site (async resolution, optimistic replay, zombie recompute) already uses. That adopts the ambient batch into the restored transition, so window registrations land somewhere that settles. With the batch adopted, the *next* action's `initTransition` also transfers and re-stamps the restored transition's pending nodes, which closes the merge orphan without touching `mergeTransitionState`.

One deliberate semantic alignment: an ordinary write landing after `done()` but before the flush now joins the active transaction — the normal rule everywhere else a transaction is active — instead of staying ambient. The #2916 keep-the-ambient-batch branch in `flush` still passes its race test and remains as insurance.

## Tests

`tests/action-done-window.test.ts` covers all three symptoms by polling microtasks until the restored transition is observable and injecting the work exactly in the window. The first two fail deterministically on `next` without the fix (INV-7 firing); the third symptom needs additional in-flight work to become observable but is guarded here as well. Full `@solidjs/signals` suite (1,149 tests) and `test-types` pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)