### PR TITLE
chore: update component types to accept ref array

### DIFF
--- a/.changeset/fuzzy-queens-retire.md
+++ b/.changeset/fuzzy-queens-retire.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Accept ref array in component ref type

--- a/packages/solid/src/client/component.ts
+++ b/packages/solid/src/client/component.ts
@@ -63,7 +63,7 @@ export type ComponentProps<T extends ValidComponent> = T extends Component<infer
  *
  * @example Component<{ref: Ref<Element>}>
  */
-export type Ref<T> = T | ((val: T) => void);
+export type Ref<T> = T | ((val: T) => void) | undefined | Ref<T>[];
 
 /**
  * Invokes a component, wrapping the call in `untrack` so that reactive reads


### PR DESCRIPTION
## Summary

Update the `Ref<T>` type to accept array of refs and move `undefined` into it (to allow arrays containing undefined, works in runtime).

Matching PR for dom-expressions: https://github.com/ryansolid/dom-expressions/pull/560
