### PR TITLE
Adopted claims derive their prefix from the wire id, not the call address

### DIFF
--- a/.changeset/adopt-claim-scope-wire-id.md
+++ b/.changeset/adopt-claim-scope-wire-id.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/web": patch
+---
+
+Thread the document wire id down as the adopted frame's claim scope. The identity split binds the frame to the call ADDRESS (function id + args hash), but the document producer stamps `_hk` hydration keys and region fids under the bare wire id — so every adopted claim on an args-bearing call (e.g. a note list keyed by search text) derived a `:hash`-suffixed prefix, missed the registry, and re-rendered fresh clones whose inserts moved the server-rendered `{$frame}` regions into a discarded detached tree: streamed content flashed and went blank. `claimScope` is the runtime's existing seam for exactly this (nested region frames already thread the root's scope down); adoptBoundary now passes the wire id through it.

--- a/packages/solid-web/frames/src/client.ts
+++ b/packages/solid-web/frames/src/client.ts
@@ -689,7 +689,14 @@ function adoptBoundary(
         const hy = (globalThis as any)._$HY;
         return !!(hy && hy.fr && hy.fr.pending());
       },
-      drainRecords
+      drainRecords,
+      // The identity split binds the frame to the call ADDRESS (id + args
+      // hash), but the document producer stamped `_hk` keys and region fids
+      // under the wire name — the bare function id. Hydration-claim prefixes
+      // must derive from what the producer wrote, so thread the wire id down
+      // as the claim scope; without it every adopted claim misses and the
+      // occurrence re-renders fresh clones that cannibalize the server DOM.
+      claimScope: id
     } as {})
   });
   if (binding) followBinding(frame, binding);


### PR DESCRIPTION
## Summary

The identity split (bcbe7e5b) rebound adopted document frames to the call's **address** (function id + args hash), but the document producer still stamps `_hk` hydration keys and region fids under the bare **wire id**. `ctx.frame` falls back to the frame's id when no `claimScope` is provided (`frame-client.js`: `claimScope ?? id`), so every adopted claim on an **args-bearing** call derived a `:hash`-suffixed prefix (`sc-…-noteListView:28y-item#0-1` vs the stamped `sc-…-noteListView-item#0-1`), missed the registry, and re-rendered fresh template clones. The clones' `insert(props.children)` then **moved** the adopted `{$frame}` region elements — the server-rendered interiors — out of the live document into the discarded detached tree: streamed content flashed on screen and went blank at hydration, leaving the gutted server markup in place.

Argless calls (address === id) masked the break, which is why simple pages kept working.

## Fix

`claimScope` is the runtime's existing seam for exactly this — nested region frames already thread the root boundary's scope down (`claimScope ?? id` at both consumption sites). `adoptBoundary` now passes the wire id through it, next to the other unpublished FrameOptions in the spread-cast.

## Repro / verification

`examples/notes` in dev: sidebar note titles stream in, then blank out at hydration (every `item#N.children` / `item#N.expandedChildren` region frame is reparented into a detached clone and dropped). With this change the items claim the server DOM in place (`_hk` markup retained, region frames intact) and titles persist; navigation and selection behave.

Diagnosed by instrumenting `getNextElement` to log miss-key vs registry — the `:28y` args-hash suffix on every requested key against hash-less registry keys pins the mismatch. The removal itself was invisible to removal-API patches because it's a connected→detached `insertBefore`/`appendChild` move by `reconcileArrays`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)