### PR TITLE
fix(frames): drain records when a fragment reveals into an adopted region (#2978 follow-up)

### DIFF
--- a/.changeset/fix-adopted-region-late-slot-records.md
+++ b/.changeset/fix-adopted-region-late-slot-records.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/web": patch
+---
+
+Drain hydration records when a fragment reveals into an adopted server-component region. A slot invoked inside a server `<Loading>` ships its `sc:slot:` record with the deferred fragment — about the async's own delay after the boundary adopted, long after the adopt-time drain ran. That record was then stranded: the classification gate's only other re-drain arms on `_$HY.fr.pending()`, and the very reveal that delivers the record is what flips it false (a revealed fragment is no longer pending). The occurrence stayed recordless, so the next full sync — a refetch's stream apply — classified the region's render prop as a direct-insert value and evaluated it as a zero-arg accessor, whose props read halted the reactive system.

--- a/packages/solid-web/frames/src/client.ts
+++ b/packages/solid-web/frames/src/client.ts
@@ -883,16 +883,30 @@ function adoptBoundary(
     }
   };
   claimRegionFragments(el);
-  // The cascade: a reveal into this region can itself carry a pl-* (nested
-  // server async). Scoped to the revealed parent, so each sweep is
-  // proportional to what just landed.
   const fr = (globalThis as any)._$HY?.fr;
-  const unsubscribe =
-    fr && fr.claim
-      ? fr.subscribe((_fragId: string, parent?: ParentNode) => {
-          if (parent && el.contains(parent as Node)) claimRegionFragments(parent);
-        })
-      : undefined;
+  const unsubscribe = fr
+    ? fr.subscribe((_fragId: string, parent?: ParentNode) => {
+        // The cascade: a reveal into this region can itself carry a pl-*
+        // (nested server async). Scoped to the revealed parent, so each
+        // sweep is proportional to what just landed.
+        if (fr.claim && parent && el.contains(parent as Node)) claimRegionFragments(parent);
+        // A revealed fragment also brings its occurrences' ARGS RECORDS: a
+        // slot invoked inside a server `<Loading>` ships its `sc:slot:`
+        // script with the fragment, ~the async's own delay after this
+        // boundary adopted — long after the adopt-time drain below ran. The
+        // reveal is the one moment that record is both present and newly
+        // relevant, and it is NOT self-healing: the #2968 defer loop is the
+        // only other re-drain, and it arms on `recordsPending()`, which this
+        // very reveal flips false (a revealed fragment is no longer
+        // pending). Without a drain here the record stays stranded in
+        // hydration data, and the next full sync — a refetch's stream apply
+        // — finds a recordless occurrence, classifies the render prop as
+        // direct-insert, and evaluates it as a zero-arg accessor: a props
+        // read that halts the reactive system. Re-drainable by design (each
+        // key applies once), so this is a cheap no-op once caught up.
+        drainRecords();
+      })
+    : undefined;
   onCleanup(() => {
     unsubscribe && unsubscribe();
     if (fr && fr.release) for (const fragId of claimedFragments) fr.release(fragId);

--- a/packages/solid-web/test/frames-adopted-region-fragments.spec.tsx
+++ b/packages/solid-web/test/frames-adopted-region-fragments.spec.tsx
@@ -139,6 +139,7 @@ describe("deferred fragments inside an adopted region (#2978)", () => {
       boundaryHtml("deadlock/page", "11", "loading-fallback") +
       boundaryHtml("deadlock/nested", "21", "outer-fallback") +
       boundaryHtml("deadlock/replaced", "31", "replaced-fallback") +
+      boundaryHtml("deadlock/records", "41", "records-fallback") +
       "</div>";
     (window as any)._$HY = { r: {}, fe() {} };
     enableHydration();
@@ -265,6 +266,52 @@ describe("deferred fragments inside an adopted region (#2978)", () => {
     expect(frameEl.textContent).toContain("refetched-content");
     expect(frameEl.textContent).not.toContain("stale-content");
     expect((window as any)._$HY.fr.pending()).toBe(false);
+
+    dispose();
+  });
+
+  // A slot invoked inside the server `<Loading>` ships its args record with
+  // the FRAGMENT — long after the adopt-time drain ran. The reveal is the one
+  // moment that record is both present and newly relevant, and it is not
+  // self-healing: the classification gate's only other re-drain arms on
+  // `fr.pending()`, which this very reveal flips false. Undrained, the
+  // occurrence reads recordless and a render prop classifies as a
+  // direct-insert VALUE — evaluated as a zero-arg accessor, whose props read
+  // halts the reactive system.
+  test("a record delivered with the fragment reaches the frame, so its render prop keeps its args", async () => {
+    declareFragment("41");
+
+    const Page = (window as any)._$SC.r("deadlock/records");
+    const appEl = document.getElementById("app") as HTMLElement;
+    let mount!: HTMLDivElement;
+    const dispose = createRoot(d => {
+      <div ref={mount}>
+        <Loading fallback={<span>shell-fallback</span>}>
+          <Page row={(p: { label: string }) => <b>row:{p.label}</b>} />
+        </Loading>
+      </div>;
+      appEl.appendChild(mount);
+      return d;
+    });
+    flush();
+    await settle();
+    flush();
+
+    completeHydrationPass();
+    await settle();
+
+    // The fragment's chunk carries BOTH the occurrence's markers and the
+    // record naming its args — the producer writes the data script with the
+    // markup it belongs to.
+    (window as any)._$HY.r["sc:slot:deadlock/records:row#0"] = { label: "settled" };
+    deliverFragment("41", "<!--slot:row#0:start--><!--slot:row#0:end-->");
+    flush();
+    await settle();
+    flush();
+
+    const frameEl = document.querySelector('[data-fid="deadlock/records"]') as HTMLElement;
+    expect(frameEl.textContent).toContain("row:settled");
+    expect(frameEl.textContent).not.toContain("records-fallback");
 
     dispose();
   });


### PR DESCRIPTION
Follow-up to #2978. A `<Loading>` inside a server component now reveals correctly, but the **first refetch after that reveal crashes the page**:

```
TypeError: Cannot read properties of undefined (reading 'text2')
[REACTIVITY_HALTED] An uncaught error halted the reactive system.
```

## Repro

`examples/playground`, a server component whose slot is invoked inside its own `<Loading>`:

```tsx
export const getServerComp = async (count: number) => {
  "use server";
  return (props: { text: (p: { text2: number }) => any }) => {
    const test = createMemo(async () => {
      await new Promise(r => setTimeout(r, 1000));
      return Math.random();
    });
    return (
      <div>
        <h1>Playground2</h1>
        <Loading fallback={<div>loading new value…</div>}>
          <props.text text2={test()} />
        </Loading>
      </div>
    );
  };
};
```

Load the page, wait for the value, click a button that switches the call's args. The reactive system halts.

## Root cause: the delivery disarms its own pickup

A slot invoked inside a server `<Loading>` ships its `sc:slot:` args record **with the deferred fragment** — about the async's own delay after the boundary adopted, long after `adoptBoundary`'s drain ran. (Confirmed on the wire: in the document the record's script sits at byte 2708, its `$df(...)` reveal at 2785 — the record is present and unread.)

Nothing ever picks it up:

- `drainRecords()` runs at **adopt time** — too early, the fragment hasn't streamed.
- The only other re-drain is inside the **#2968 classification defer loop**, which arms on `_$HY.fr.pending()`.
- Post-#2978, a **revealed fragment is no longer pending** — so the very reveal that *delivers* the record is what flips `recordsPending()` false.

The event that makes the record available is the event that disarms the mechanism that would fetch it. The record strands in `_$HY.r` for the life of the page, and the next full sync — a refetch's stream apply — finds a recordless occurrence, classifies the region's render prop as a direct-insert **value**, and hands it to `insert` as a zero-arg accessor. `props.text2` on `undefined` halts everything.

## Fix

The reveal callback already exists in `adoptBoundary` for the nested-placeholder cascade; it now drains there too. A revealed fragment brings its occurrences' records with it, so the reveal is exactly the right moment. `drainRecords` is re-drainable by design (each key applies once), so this is a cheap no-op once caught up. The subscription is also no longer gated on `fr.claim` — the drain is useful whether or not the ledger exposes claiming.

## Verification

- New test in `frames-adopted-region-fragments.spec.tsx`, red without the fix and green with it: a record delivered alongside its fragment reaches the frame, so the region's render prop keeps its args.
- `@solidjs/web` suite: 400/400. dom-expressions runtime suite: 1114/1114.
- Live playground: before, every increment halted the page; after, five consecutive increments run clean.

Note two things this does **not** fix, both filed/PR'd separately:

1. The render prop's async arg (`text2={test()}`) is the DR-2 value tier, and the frame-client mishandles it on repeat responses — ryansolid/dom-expressions#565.
2. The document's occurrence counter drifts across render attempts (doc ships `text#1`, a fresh stream ships `text#0`), so the first switch re-mounts instead of updating and blanks for the server's wait. `$key` on the slot avoids it entirely; the underlying determinism question looks like a design call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
