### PR TITLE
fix(solid): ssrSource "client" projections/stores don't leak their seed before first resolution (#2981)

### DIFF
--- a/.changeset/fix-ssr-source-client-seed-leak.md
+++ b/.changeset/fix-ssr-source-client-seed-leak.md
@@ -1,0 +1,7 @@
+---
+"solid-js": patch
+---
+
+Fix `createProjection`/`createStore(fn)` with `ssrSource: "client"` leaking their seeded draft value on the client's initial render (#2981).
+
+A `"client"` source is gated behind a `hydrated` signal during hydration so the derive runs only after hydration completes. The gate previously returned `undefined`, which settled the projection against its seed — leaving the seed readable ("Initial Value" rendered before the async source resolved) instead of staying pending. The gate now throws `NotReady` while hydration is incomplete, so reads stay pending (the `Loading` fallback shows) exactly like `ssrSource: "server"`/`"hybrid"` sources, and the seed is never observable before first resolution (#2897).

--- a/packages/solid/src/client/hydration.ts
+++ b/packages/solid/src/client/hydration.ts
@@ -6,6 +6,7 @@ import {
   runWithOwner,
   onCleanup,
   isDisposed,
+  NotReadyError,
   getNextChildId,
   peekNextChildId,
   createRevealOrder as coreRevealOrder,
@@ -726,7 +727,12 @@ function hydrateStoreLikeFn(
     const [hydrated, setHydrated] = coreSignal(false, { ownedWrite: true });
     const result = coreFn(
       (draft: any) => {
-        if (!hydrated()) return;
+        // The seeded draft value is never observable before the derive first
+        // resolves (#2897). While hydration is still gating the client-owned
+        // source, reads must stay pending (NotReady) — returning `undefined`
+        // settled the projection against its seed, leaking "Initial Value"
+        // on the initial render instead of showing the Loading fallback.
+        if (!hydrated()) throw new NotReadyError(getOwner()!);
         return fn(draft);
       },
       initialValue,

--- a/packages/solid/test/client-hydration.spec.ts
+++ b/packages/solid/test/client-hydration.spec.ts
@@ -6,6 +6,7 @@ import {
   createRoot,
   flush,
   getOwner,
+  NotReadyError,
   createSignal as coreSignal,
   createMemo as coreMemo
 } from "@solidjs/signals";
@@ -1063,7 +1064,7 @@ describe("ssrSource client modes — createProjection", () => {
     expect(store.count).toBe(7);
   });
 
-  test("ssrSource 'client' uses initialValue during hydration", () => {
+  test("ssrSource 'client' does not leak the seeded value during hydration", () => {
     startHydration({});
 
     let store: any;
@@ -1081,8 +1082,46 @@ describe("ssrSource client modes — createProjection", () => {
     );
     flush();
 
-    // "client" mode uses identity fn during hydration — returns initialValue unchanged
-    expect(store.name).toBe("init");
+    // The seeded draft is never observable before the derive first resolves:
+    // a "client" source is pending until hydration completes, so reads throw
+    // NotReady instead of leaking the initial value (#2981).
+    expect(() => store.name).toThrow(NotReadyError);
+
+    stopHydration();
+    flush();
+
+    // Once hydration resumes, the derive runs and the store reflects it.
+    expect(store.name).toBe("computed");
+  });
+
+  test("ssrSource 'client' async projection does not leak its seed on initial render", async () => {
+    startHydration({});
+
+    let store: any;
+    createRoot(
+      () => {
+        store = createProjection(
+          async (draft: any) => {
+            await new Promise(r => setTimeout(r, 0));
+            draft.name = "resolved";
+          },
+          { name: "seed" },
+          { ssrSource: "client" }
+        );
+      },
+      { id: "t" }
+    );
+
+    // Before the async source resolves, the seeded "seed" value must not be
+    // readable — the read is pending, exactly like ssrSource "server"/
+    // "hybrid" sources waiting on the server value (#2981).
+    expect(() => store.name).toThrow(NotReadyError);
+
+    stopHydration();
+    await new Promise(r => setTimeout(r, 10));
+    flush();
+
+    expect(store.name).toBe("resolved");
   });
 });
 
@@ -1134,7 +1173,7 @@ describe("ssrSource client modes — createStore(fn)", () => {
     expect(store.name).toBe("hybrid-val");
   });
 
-  test("ssrSource 'client' uses initialValue during hydration", () => {
+  test("ssrSource 'client' does not leak the seeded value during hydration", () => {
     startHydration({});
 
     let store: any;
@@ -1152,7 +1191,14 @@ describe("ssrSource client modes — createStore(fn)", () => {
     );
     flush();
 
-    expect(store.name).toBe("init");
+    // Same contract as the projection form: the seeded draft is not readable
+    // until hydration resumes (#2981).
+    expect(() => store.name).toThrow(NotReadyError);
+
+    stopHydration();
+    flush();
+
+    expect(store.name).toBe("computed");
   });
 });
 
@@ -1792,8 +1838,9 @@ describe("ssrSource 'client' — post-hydration transition", () => {
     );
     flush();
 
-    // During hydration, fn is suppressed — initialValue used
-    expect(store.name).toBe("init");
+    // During hydration, fn is suppressed — reads stay pending (NotReady)
+    // rather than leaking the seeded value (#2981).
+    expect(() => store.name).toThrow(NotReadyError);
 
     stopHydration();
     flush();
@@ -1821,7 +1868,7 @@ describe("ssrSource 'client' — post-hydration transition", () => {
     );
     flush();
 
-    expect(store.name).toBe("init");
+    expect(() => store.name).toThrow(NotReadyError);
 
     stopHydration();
     flush();


### PR DESCRIPTION
## What

`createProjection`/`createStore(fn)` with `ssrSource: "client"` leaked their seeded draft value on the client's initial render — `<Loading>` showed the seed ("Initial Value") instead of the fallback until the async source resolved.

## Why

A `"client"` source is gated behind a `hydrated` signal during hydration so the derive runs only after hydration completes. The gate previously returned `undefined`, which settled the projection against its seed (the #2897 guard cleared `STATUS_UNINITIALIZED`), leaving the seed readable. `ssrSource: "server"`/`"hybrid"` sources stay pending (NotReady) during this window, so "client" was inconsistent.

## Fix

The gate now throws `NotReady` while hydration is incomplete, keeping the projection in its pending/uninitialized state. Reads stay pending (the `Loading` fallback shows) and the seed is never observable before first resolution — matching the #2897 rule that a derived store's seed is a draft, never an observable value. The fix is in `hydrateStoreLikeFn`, so it applies symmetrically to `createProjection`, `createStore(fn)`, and `createOptimisticStore(fn)`.

## Tests

Updated every `ssrSource "client"` hydration test that asserted the seed was readable during hydration (two in the "ssrSource client modes" block and two in the "post-hydration transition" block, covering both `createProjection` and `createStore(fn)`), and added an async projection test reproducing the exact issue scenario.