### PR TITLE
fix: preserve errors while loading retries are parked

### DIFF
--- a/.changeset/preserve-parked-loading-error.md
+++ b/.changeset/preserve-parked-loading-error.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Preserve a loading-value memo's settled error while a retry is parked on an unready dependency. The parked retry remains verdict-quiet and resumes when its dependency settles instead of exposing a `NotReadyError` in place of the original error.

--- a/packages/solid-signals/src/core/async.ts
+++ b/packages/solid-signals/src/core/async.ts
@@ -79,7 +79,10 @@ function retryReaches(el: Computed<any>, source: any): boolean {
 export function parkLoadingWindow(el: Computed<any>, e: NotReadyError): void {
   el._blocked = true;
   if (e.source) addPendingSource(el, e.source as Computed<any>);
-  setPendingError(el, e.source as Computed<any>, e);
+  // An errored node keeps its settled error as the read-visible answer while
+  // the retry is parked. `_pendingSources` and `_blocked` are sufficient to
+  // schedule it again when the dependency settles.
+  if (!(el._statusFlags & STATUS_ERROR)) setPendingError(el, e.source as Computed<any>, e);
 }
 
 export function setPendingError(el: Computed<any>, source?: Computed<any>, error?: any): void {

--- a/packages/solid-signals/tests/loading-value.test.ts
+++ b/packages/solid-signals/tests/loading-value.test.ts
@@ -311,6 +311,56 @@ describe("createMemo with loadingValue", () => {
     expect(isPending(user)).toBe(false);
   });
 
+  it("keeps the settled error while a retry is parked on an unready dependency", async () => {
+    const first = deferred<string>();
+    const dependency = deferred<number>();
+    const originalError = new Error("boom");
+    let setRetry!: (retry: boolean) => void;
+    let user!: () => string;
+
+    createRoot(() => {
+      const [retry, set] = createSignal(false);
+      setRetry = set;
+      const dep = createMemo(() => dependency.promise);
+      user = createMemo<string>(
+        () => (retry() ? `dep:${dep()}` : (first.promise as Promise<string>)),
+        { loadingValue: "placeholder" }
+      );
+      createEffect(() => user(), { effect: () => {}, error: () => {} });
+    });
+    flush();
+
+    first.reject(originalError);
+    await tick();
+    flush();
+    let settledError: unknown;
+    try {
+      untrackedRead(user);
+    } catch (error) {
+      settledError = error;
+    }
+    expect(settledError).toBeInstanceOf(Error);
+    expect(settledError).not.toBeInstanceOf(NotReadyError);
+    expect((settledError as Error).message).toBe("boom");
+
+    setRetry(true);
+    flush();
+    let parkedError: unknown;
+    try {
+      untrackedRead(user);
+    } catch (error) {
+      parkedError = error;
+    }
+    expect(parkedError === settledError).toBe(true);
+    expect(isPending(user)).toBe(false);
+
+    dependency.resolve(7);
+    await tick();
+    flush();
+    expect(user()).toBe("dep:7");
+    expect(isPending(user)).toBe(false);
+  });
+
   it("drops superseded first-flight results and keeps serving until the live flight lands", async () => {
     const d1 = deferred<string>();
     const d2 = deferred<string>();


### PR DESCRIPTION
## Summary

Fixes #2989.

When a `loadingValue` memo is settled at an error and a reactive retry parks on
an unready dependency, `parkLoadingWindow` currently replaces the memo's
read-visible settled error with the dependency's `NotReadyError`. This change
keeps the settled error while `STATUS_ERROR` is active. The existing
`_pendingSources` and `_blocked` bookkeeping still schedules the retry when the
dependency settles.

The regression test covers all parts of the window contract:

- the settled error remains the same object while the retry is parked;
- `isPending` stays false during the parked window;
- settling the dependency retries the memo;
- the retry commits the final value successfully.

## How did you test this change?

- `pnpm --filter @solidjs/signals exec vitest run tests/loading-value.test.ts`
  (28 tests passed)
- `pnpm --filter @solidjs/signals test`
  (86 test files, 1231 tests passed)
- `pnpm --filter @solidjs/signals types`
- `pnpm --filter @solidjs/signals build`
- `pnpm exec prettier --check .changeset/preserve-parked-loading-error.md packages/solid-signals/src/core/async.ts packages/solid-signals/tests/loading-value.test.ts`

The repository-wide `pnpm build` and `pnpm test` currently stop in the unchanged
`@solidjs/web#types` task because the locked
`@dom-expressions/runtime@0.50.0-next.40` package does not contain
`src/serializer-decode.d.ts`, which that package's script tries to copy. The
`@solidjs/signals` build, type check, and complete test suite pass independently.
