### PR TITLE
fix: re-subscribe to ordinary external source after a transition

### DIFF
--- a/.changeset/external-source-transition-subscription.md
+++ b/.changeset/external-source-transition-subscription.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+fix: re-establish the ordinary external source subscription after a transition

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -1486,11 +1486,20 @@ function createComputation<Next, Init = unknown>(
     const ordinary = ExternalSourceConfig.factory(sourceFn, trigger);
     onCleanup(() => ordinary.dispose());
     let inTransition: ExternalSource | undefined;
+    let trackedOrdinary = false;
     const triggerInTransition: () => void = () =>
       startTransition(trigger).then(() => {
         if (inTransition) {
           inTransition.dispose();
           inTransition = undefined;
+          // A computation created while a transition was running only ever
+          // tracked the transition-scoped source, so its ordinary source has no
+          // recorded dependencies. Now that the transition is over, re-trigger
+          // once so the computation runs through `ordinary` again and
+          // re-subscribes; otherwise it would never receive further external
+          // updates. If the computation was disposed in the meantime this is a
+          // no-op because it is no longer an observer of `track`.
+          if (!trackedOrdinary) trigger();
         }
       });
     c.fn = x => {
@@ -1500,6 +1509,7 @@ function createComputation<Next, Init = unknown>(
           inTransition = ExternalSourceConfig!.factory(sourceFn, triggerInTransition);
         return inTransition.track(x);
       }
+      trackedOrdinary = true;
       return ordinary.track(x);
     };
   }

--- a/packages/solid/test/external-source.spec.ts
+++ b/packages/solid/test/external-source.spec.ts
@@ -128,6 +128,40 @@ describe("external source", () => {
     });
   });
 
+  it("should keep receiving external updates after being created during a transition", async () => {
+    // Initialize SuspenseContext so startTransition creates a real Transition
+    getSuspenseContext();
+
+    const flush = () => new Promise(resolve => setTimeout(resolve));
+
+    await createRoot(async dispose => {
+      const e = new ExternalSource(0);
+      let memo: (() => number) | undefined;
+
+      // Create the memo while a transition is running. Its first run tracks
+      // dependencies on the transition-scoped external source, never on the
+      // ordinary one.
+      await startTransition(() => {
+        memo = createMemo(() => e.get());
+      });
+      expect(memo!()).toBe(0);
+
+      // First external update is delivered through the transition-scoped source.
+      e.update(1);
+      await flush();
+      expect(memo!()).toBe(1);
+
+      // Second external update must still be delivered. Before the fix the
+      // transition-scoped source had been disposed and the ordinary source was
+      // never subscribed, so this update was silently lost.
+      e.update(2);
+      await flush();
+      expect(memo!()).toBe(2);
+
+      dispose();
+    });
+  });
+
   afterEach(() => {
     vi.resetModules();
   });


### PR DESCRIPTION
## Problem

A computation created while a `startTransition` is pending never receives more than one external update when `enableExternalSource` is enabled. In an app this shows up as a subtree that renders correctly, updates once, then stays stale until something else forces it to re-run.

## Root cause

When `ExternalSourceConfig` is set, `createComputation` (in `packages/solid/src/reactive/signal.ts`) wraps the computation's fn so that a run while a transition is pending tracks the computation on a transition-scoped external source (`inTransition`) instead of the ordinary one. A computation created during a transition only ever has `inTransition.track()` called, so its ordinary source records zero dependencies. After the transition completes, `triggerInTransition`'s `.then()` disposes the transition-scoped source and nothing ever re-registers the computation on the ordinary source — the external system can no longer invalidate it.

## Fix

Track whether the computation has ever run through the ordinary external source. When the transition-scoped source is disposed, if it never did, fire the computation's trigger once so it re-runs through the ordinary source and re-subscribes. If the computation was disposed in the meantime the trigger is a no-op, because the computation is no longer an observer of the internal `track` signal.

## Test

Adds a regression test to `packages/solid/test/external-source.spec.ts` that creates a memo inside a transition, applies two external updates, and asserts both are delivered. On `main` the second update is lost and the test fails.

Fixes #2953