### PR TITLE
fix(core): clear cached promise in lazy() on rejection (#2999)

### DIFF
--- a/packages/solid/src/render/component.ts
+++ b/packages/solid/src/render/component.ts
@@ -359,13 +359,27 @@ export function lazy<T extends Component<any>>(
 ): T & { preload: () => Promise<{ default: T }> } {
   let comp: (() => T | undefined) | undefined;
   let p: Promise<{ default: T }> | undefined;
+  const load = () => {
+    if (!p) {
+      const cur = (p = fn());
+      cur.then(
+        mod => {
+          comp = () => mod.default;
+        },
+        () => {
+          if (p === cur) p = undefined;
+        }
+      );
+    }
+    return p;
+  };
   const wrap: T & { preload?: () => void } = ((props: any) => {
     const ctx = sharedConfig.context;
     if (ctx) {
       const [s, set] = createSignal<T>();
       sharedConfig.count || (sharedConfig.count = 0);
       sharedConfig.count++;
-      (p || (p = fn())).then(mod => {
+      load().then(mod => {
         !sharedConfig.done && setHydrateContext(ctx);
         sharedConfig.count!--;
         set(() => mod.default);
@@ -373,7 +387,7 @@ export function lazy<T extends Component<any>>(
       });
       comp = s;
     } else if (!comp) {
-      const [s] = createResource<T>(() => (p || (p = fn())).then(mod => mod.default));
+      const [s] = createResource<T>(() => load().then(mod => mod.default));
       comp = s;
       onCleanup(() => (comp = undefined));
     }
@@ -392,7 +406,7 @@ export function lazy<T extends Component<any>>(
         : ""
     ) as unknown as JSX.Element;
   }) as T;
-  wrap.preload = () => p || ((p = fn()).then(mod => (comp = () => mod.default)), p);
+  wrap.preload = () => load();
   return wrap as T & { preload: () => Promise<{ default: T }> };
 }
 

--- a/packages/solid/src/server/rendering.ts
+++ b/packages/solid/src/server/rendering.ts
@@ -556,12 +556,17 @@ export function createResource<T, S>(
 export function lazy<T extends Component<any>>(
   fn: () => Promise<{ default: T }>
 ): T & { preload: () => Promise<{ default: T }> } {
-  let p: Promise<{ default: T }> & { resolved?: T };
+  let p: (Promise<{ default: T }> & { resolved?: T }) | undefined;
   let load = (id?: string) => {
     if (!p) {
-      p = fn();
-      p.then(mod => (p.resolved = mod.default));
-      if (id) sharedConfig.context!.lazy[id] = p;
+      const cur = (p = fn() as Promise<{ default: T }> & { resolved?: T });
+      cur.then(
+        mod => (cur.resolved = mod.default),
+        () => {
+          if (p === cur) p = undefined;
+        }
+      );
+      if (id) sharedConfig.context!.lazy[id] = cur;
     }
     return p;
   };

--- a/packages/solid/web/test/lazy.spec.tsx
+++ b/packages/solid/web/test/lazy.spec.tsx
@@ -58,4 +58,29 @@ describe("lazy() disposal", () => {
     expect(routeImports).toBe(1);
     second.dispose();
   });
+
+  test("lazy() retries import function on subsequent load if previous promise rejected", async () => {
+    let attempts = 0;
+    let shouldFail = true;
+    const Child: Component<{ label: string }> = props => <span>{props.label}</span>;
+
+    const LazyComp = lazy(async () => {
+      attempts++;
+      if (shouldFail) {
+        throw new Error("network error");
+      }
+      return { default: Child };
+    });
+
+    // First attempt fails
+    await expect(LazyComp.preload()).rejects.toThrow("network error");
+    expect(attempts).toBe(1);
+
+    // After failure condition clears, second attempt retries fn() instead of returning cached rejection
+    shouldFail = false;
+    const res = await LazyComp.preload();
+    expect(attempts).toBe(2);
+    expect(res.default).toBe(Child);
+  });
 });
+


### PR DESCRIPTION
## Summary

Clears the cached promise in `lazy()` on rejection, allowing dynamic imports that fail due to transient network or chunk-load errors to be retried on subsequent renders/preloads without requiring a hard page reload or permanently poisoning SSR.

## Problem

In both client (`packages/solid/src/render/component.ts`) and server (`packages/solid/src/server/rendering.ts`) implementations of `lazy()`, the promise returned by `fn()` was cached permanently in closure variable `p`.

If `fn()` rejected:
1. **Client:** An Error Boundary retry flow (e.g. `<Errored fallback={(_, reset) => <button onClick={reset}>Retry</button>}>`) could never recover. Resetting/remounting the boundary simply re-observed the cached rejected promise without invoking `fn()` again.
2. **Server:** Module-scoped lazy promises that rejected would poison all subsequent SSR requests for the process lifetime.
3. **Unhandled Rejections:** The internal `.then()` calls lacked a rejection handler, emitting unhandled promise rejections.

## Solution

1. In both client and server `lazy()`, attach a rejection callback to the active promise `cur` that clears `p` (`if (p === cur) p = undefined`).
2. Subsequent `load()` / `preload()` invocations will call `fn()` afresh.
3. If `fn()` succeeds on retry, `comp` / `resolved` is populated normally.
4. Added regression unit test in `packages/solid/web/test/lazy.spec.tsx` verifying that `lazy().preload()` retries `fn()` after an initial rejection.

Fixes #2999
