### PR TITLE
fix(solid): guard devComponent against undefined owner

### DIFF
--- a/packages/solid/src/client/core.ts
+++ b/packages/solid/src/client/core.ts
@@ -190,11 +190,18 @@ export function devComponent<P, V>(Comp: (props: P) => V, props: P): V {
   return createRoot(
     () => {
       const owner: any = getOwner();
-      owner._component = {
-        fn: Comp,
-        props,
-        name: Comp.name
-      };
+      // `owner` can be undefined when this component is rendered inside a root
+      // that has no enclosing owner (e.g. a nested transparent root created by
+      // another library/router, or a manually nested createRoot). The _component
+      // metadata is dev-only decoration — skip it gracefully instead of crashing
+      // the whole reactive system with "Cannot read properties of undefined".
+      if (owner) {
+        owner._component = {
+          fn: Comp,
+          props,
+          name: Comp.name
+        };
+      }
       Object.assign(Comp, { [$DEVCOMP]: true });
       return untrack(() => Comp(props), IS_DEV && `<${Comp.name || "Anonymous"}>`);
     },


### PR DESCRIPTION
## Summary
`devComponent` (in `packages/solid/src/client/core.ts`) unconditionally dereferenced `getOwner()` and assigned `owner._component`, throwing **"Cannot read properties of undefined (reading '[something]')"** — surfacing as `REACTIVITY_HALTED` — whenever a component is rendered inside a root that has **no enclosing owner**.

This happens with a **legally nested root**: e.g. a component rendered inside a router's `Provider`/transparent root that is itself created within another owner. In dev builds this hard-crashes the entire reactive system. Production builds never hit this path.

## Fix
The `_component` metadata is dev-only decoration. Guard it with `if (owner)` so it is skipped gracefully when there is no enclosing owner.

## Reproduction
Render any component through a nested transparent root (`createRoot(() => createRoot(() => <Comp/>, {transparent:true}), {transparent:true})`, or a router `Provider` nested inside another root) in a dev build → `devComponent` throws. With the guard, it renders fine.

## Scope
- Dev builds only (`devComponent` is dev instrumentation).
- No change to production behavior or public APIs.
- 1 file changed, +12 −5.

This was found while running vitest browser-mode tests against a Solid 2.0 app where a router `Provider` is nested inside a test `render()` root.