### PR TITLE
fix(store): reconcile invokes function-valued leaves instead of storing them

### DIFF
--- a/.changeset/fix-reconcile-function-leaf-invocation.md
+++ b/.changeset/fix-reconcile-function-leaf-invocation.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Fix `reconcile` invoking a function-valued leaf instead of replacing it, once that leaf has a subscriber. `setSignal(node, v)` treats a function argument as an updater and calls it — correct for `setStore(draft => ...)`, wrong for a leaf replacement. Plain store writes already guard against this by wrapping a function-valued prop before calling `setSignal`; `reconcile`'s leaf-replace branches (`applyStateFast`, `applyStateSlow`, `wrapValue`, `shallowDiffNodes`) did not, so reconciling a store leaf holding a function ran that function as a side effect and committed its return value instead of the function itself.

--- a/packages/solid-signals/src/store/reconcile.ts
+++ b/packages/solid-signals/src/store/reconcile.ts
@@ -103,11 +103,20 @@ function getAllKeys(value, override, next) {
   return Array.from(set);
 }
 
+// `setSignal(node, v)` calls `v` when it's a function — that's the updater
+// overload, not a leaf replacement. A function-valued leaf (a store'd
+// callback prop) must be wrapped in an outer arrow so setSignal unwraps back
+// to the real function instead of invoking it and committing its return
+// value. Mirrors store.ts's own `notifyStoreProperty` guard for plain writes.
+function asSignalValue<T>(value: T): T | (() => T) {
+  return (typeof value === "function" ? () => value : value) as any;
+}
+
 // Array entries can be `null`/`undefined`/primitives, not just keyed objects.
 // These helpers keep the keyed paths from passing a non-object to `keyFn` (which
 // assumes an object) or to `wrap()` (which assumes a wrappable value).
 function wrapValue(value: any, target: any) {
-  return isWrappable(value) ? wrap(value, target) : value;
+  return asSignalValue(isWrappable(value) ? wrap(value, target) : value);
 }
 
 function itemKey(item: any, keyFn: (item: NonNullable<any>) => any) {
@@ -338,7 +347,7 @@ function shallowDiffNodes(
       const v = next[key];
       if (v !== prevAt(key)) {
         changed = true;
-        setSignal(nodes[key], v);
+        setSignal(nodes[key], asSignalValue(v));
       }
     } else {
       changed = true;
@@ -552,7 +561,7 @@ function applyStateFast(next: any, target: any, keyFn: (item: NonNullable<any>) 
           (keyFn(previousValue) != null && keyFn(previousValue) !== keyFn(nextValue))
         ) {
           tracked && setSignal(tracked, void 0);
-          node && setSignal(node, isWrappable(nextValue) ? wrap(nextValue, target) : nextValue);
+          node && setSignal(node, wrapValue(nextValue, target));
         } else applyStateChild(nextValue, previousValue, target, keyFn);
       }
     } else {
@@ -575,7 +584,7 @@ function applyStateFast(next: any, target: any, keyFn: (item: NonNullable<any>) 
           (keyFn(previousValue) != null && keyFn(previousValue) !== keyFn(nextValue))
         ) {
           tracked && setSignal(tracked, void 0);
-          node && setSignal(node, isWrappable(nextValue) ? wrap(nextValue, target) : nextValue);
+          node && setSignal(node, wrapValue(nextValue, target));
         } else applyStateChild(nextValue, previousValue, target, keyFn);
       }
     }
@@ -736,7 +745,7 @@ function applyStateSlow(next: any, target: any, keyFn: (item: NonNullable<any>) 
         (keyFn(previousValue) != null && keyFn(previousValue) !== keyFn(nextValue))
       ) {
         tracked && setSignal(tracked, void 0);
-        node && setSignal(node, isWrappable(nextValue) ? wrap(nextValue, target) : nextValue);
+        node && setSignal(node, wrapValue(nextValue, target));
       } else applyState(nextValue, wrap(previousValue, target), keyFn);
     }
   }

--- a/packages/solid-signals/tests/store/reconcile.test.ts
+++ b/packages/solid-signals/tests/store/reconcile.test.ts
@@ -834,6 +834,63 @@ describe("reconcile without a key (positional merge)", () => {
     expect(state.id).toBe(9);
     expect(state.v).toBe(3);
   });
+
+  test("replaces a TRACKED function-valued object leaf without invoking it", () => {
+    // The replace path only runs against a leaf that already has a signal
+    // node — i.e. something already read it, same as a component's JSX
+    // reading a store'd callback prop before a later reconcile swaps it out.
+    const before = () => "before";
+    const calls: string[] = [];
+    const after = () => calls.push("after");
+    const [state, setState] = createStore<{ fn: () => unknown }>({ fn: before });
+    let seen: (() => unknown) | undefined;
+    createRoot(() => {
+      createEffect(
+        () => state.fn,
+        v => {
+          seen = v;
+        }
+      );
+    });
+    flush();
+    expect(seen).toBe(before);
+
+    setState(reconcile({ fn: after }, null));
+    flush();
+    // A naive replace calls setSignal(node, after), and setSignal treats a
+    // function argument as an updater — invoking `after` and committing its
+    // return value instead of storing `after` itself.
+    expect(seen).toBe(after);
+    expect(state.fn).toBe(after);
+    expect(calls).toEqual([]);
+    state.fn();
+    expect(calls).toEqual(["after"]);
+  });
+
+  test("replaces a TRACKED function-valued array item without invoking it", () => {
+    const calls: string[] = [];
+    const before = [() => calls.push("a"), () => calls.push("b")];
+    const after = [() => calls.push("c"), () => calls.push("d")];
+    const [state, setState] = createStore<Array<() => unknown>>(before);
+    let seen: (() => unknown) | undefined;
+    createRoot(() => {
+      createEffect(
+        () => state[0],
+        v => {
+          seen = v;
+        }
+      );
+    });
+    flush();
+    expect(seen).toBe(before[0]);
+
+    setState(reconcile(after, null));
+    flush();
+    expect(seen).toBe(after[0]);
+    expect(state[0]).toBe(after[0]);
+    expect(state[1]).toBe(after[1]);
+    expect(calls).toEqual([]);
+  });
 });
 // type tests
 


### PR DESCRIPTION
## Summary

`reconcile()` calls a function-valued leaf instead of replacing it, when that leaf already has a live subscriber.

**SSCCE:**

```ts
import { createStore, reconcile, createRoot, createEffect, flush } from "solid-js";

const [state, setState] = createStore({ onClick: () => "original" });

// Something has to have read the leaf once — a <button onClick={state.onClick}>
// in real code. Reproduced here with a bare effect.
createRoot(() => {
  createEffect(() => state.onClick, () => {});
});
flush();

let called = false;
setState(reconcile({ onClick: () => (called = true) }));
flush();

console.log(called);        // true  — the NEW function got called
console.log(state.onClick); // true  — its RETURN VALUE got stored, not the function
```

Expected: `called` is `false`, `state.onClick` is the new function. Actual: `reconcile` called the callback as a side effect, then wrote the callback's return value into the leaf instead of the callback itself.

**Root cause:** a store write can mean one of two things — "here is the new value" or "here is a function that computes the new value from the old one." Solid decides which one it is by checking `typeof value === "function"`: if it's a function, it assumes the second meaning and calls it. Plain writes to the store already handle this case — if you assign a function as a value, they wrap it first, so it is recognized as "a value," not as "a rule for computing one." `reconcile`'s code path for replacing a leaf never got that same handling, so a function passed there is always treated as the second meaning and gets called.

**I hit this building [Dunky](https://github.com/dunky-dev/state-machine)'s Solid target.** I keep an object with both plain values and callback functions synced to a store, refreshing it with `reconcile` on every update. Once a component read one of those functions, the next refresh called it instead of replacing it — running unrelated application code as a side effect of a routine data sync, and leaving the function's return value in the store instead of the function. I worked around it for now: [`packages/solid/src/use-machine.ts#L39-L47`](https://github.com/dunky-dev/state-machine/blob/43d8f932985a4cce46ba38a079007fbf4c46337b/packages/solid/src/use-machine.ts#L39-L47). This PR removes the need for that workaround.

**Fix:** added `asSignalValue`, mirroring the existing `notifyStoreProperty` guard, and routed every leaf-replace call site in `reconcile.ts` through it.

## How did you test this change?

Added two new cases in `tests/store/reconcile.test.ts` (object leaf, array item), both checking the old function is never called and the new one lands by identity. Verified they fail against `next` today (the callback gets invoked, its return value gets stored) and pass with the fix.

```
cd packages/solid-signals
npx vitest run tests/store/reconcile.test.ts   # 41 passed
npx vitest run tests/store                     # 386 passed
npx vitest run                                 # 1262 passed, 2 skipped — no regressions
```