### PR TITLE
feat: expose server function call observers

### DIFF
--- a/.changeset/server-function-call-observers.md
+++ b/.changeset/server-function-call-observers.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/web": patch
+---
+
+Adopt `@dom-expressions/runtime` 0.50.0-next.44 and expose server-function call observers.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@changesets/cli": "^2.25.2",
     "@dom-expressions/babel-plugin-jsx": "0.50.0-next.43",
     "@dom-expressions/hyperscript": "0.50.0-next.43",
-    "@dom-expressions/runtime": "0.50.0-next.43",
+    "@dom-expressions/runtime": "0.50.0-next.44",
     "@dom-expressions/tagged-jsx": "0.50.0-next.43",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/packages/solid-web/test/server/server-functions-extensions.spec.tsx
+++ b/packages/solid-web/test/server/server-functions-extensions.spec.tsx
@@ -30,9 +30,10 @@ import {
   createServerReference,
   getServerFunctionMetadata,
   isServerFunction,
+  observeServerFunctionCalls,
   withMeta
 } from "@solidjs/web/server-functions/client";
-import type { PrepareRequestHook } from "@solidjs/web/server-functions/client";
+import type { PrepareRequestHook, ServerFunctionCall } from "@solidjs/web/server-functions/client";
 
 const RequestContext = Symbol.for("solid.RequestContext");
 
@@ -48,9 +49,11 @@ afterAll(() => {
 // handler — a full round trip through both published bundles.
 function connectTransport() {
   const original = globalThis.fetch;
-  globalThis.fetch = ((url: string, init?: RequestInit) =>
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) =>
     handleServerFunctionRequest(
-      new Request(new URL(url, "http://localhost"), init)
+      input instanceof Request
+        ? input
+        : new Request(new URL(input.toString(), "http://localhost"), init)
     )) as typeof fetch;
   return () => {
     globalThis.fetch = original;
@@ -160,6 +163,28 @@ describe("server-function extension surface (built bundles)", () => {
       expect(await plain()).toBe(null);
     } finally {
       configureServerFunctionsClient({ prepareRequest: null as any });
+      restore();
+    }
+  });
+
+  it("observes calls through the client bridge", async () => {
+    registerServerFunction("ext-observe-0", async (value: number) => value * 2);
+    const calls: ServerFunctionCall[] = [];
+    const stop = observeServerFunctionCalls(call => calls.push(call));
+    const restore = connectTransport();
+    try {
+      expect(await createServerReference("ext-observe-0")(21)).toBe(42);
+      expect(calls.map(call => call.type)).toEqual(["request", "response"]);
+      expect(calls[0]).toMatchObject({
+        id: "ext-observe-0",
+        instance: expect.any(String)
+      });
+      expect(calls[1]).toMatchObject({
+        id: "ext-observe-0",
+        instance: calls[0].instance
+      });
+    } finally {
+      stop();
       restore();
     }
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 0.50.0-next.43
         version: 0.50.0-next.43
       '@dom-expressions/runtime':
-        specifier: 0.50.0-next.43
-        version: 0.50.0-next.43(csstype@3.2.3)(seroval-plugins@1.5.5(seroval@1.5.5))(seroval@1.5.5)
+        specifier: 0.50.0-next.44
+        version: 0.50.0-next.44(csstype@3.2.3)(seroval-plugins@1.5.5(seroval@1.5.5))(seroval@1.5.5)
       '@dom-expressions/tagged-jsx':
         specifier: 0.50.0-next.43
         version: 0.50.0-next.43
@@ -1141,8 +1141,8 @@ packages:
   '@dom-expressions/hyperscript@0.50.0-next.43':
     resolution: {integrity: sha512-UtGx3s22K/kbTvPvWKdKk0RUXJuedcgqJ6kzUs81FZmL4Z8KL0mANq9W1Gvg36dN9eg+0txHhFcb8vIt8H4RZA==}
 
-  '@dom-expressions/runtime@0.50.0-next.43':
-    resolution: {integrity: sha512-x+TVqNuV0CD47R0KFLUqlLds5I6h4kL51t9YmVUV2RRSV3qO1DrClBcbVjpUTroBD8rz+0Xp+wG6NrAXQOjn1A==}
+  '@dom-expressions/runtime@0.50.0-next.44':
+    resolution: {integrity: sha512-XxYwKS7MsDelXAoQNz6YzSqaZfRqxIYIPBGwcYvatxn3DC7NKl6mQwJPt+8psHCvmu7h/nGGcEbIMp9mRI3WwQ==}
     hasBin: true
     peerDependencies:
       csstype: ^3.0
@@ -4680,7 +4680,7 @@ snapshots:
 
   '@dom-expressions/hyperscript@0.50.0-next.43': {}
 
-  '@dom-expressions/runtime@0.50.0-next.43(csstype@3.2.3)(seroval-plugins@1.5.5(seroval@1.5.5))(seroval@1.5.5)':
+  '@dom-expressions/runtime@0.50.0-next.44(csstype@3.2.3)(seroval-plugins@1.5.5(seroval@1.5.5))(seroval@1.5.5)':
     dependencies:
       babel-plugin-transform-rename-import: 2.3.0
       csstype: 3.2.3


### PR DESCRIPTION
## Summary

- update `@dom-expressions/runtime` to `0.50.0-next.44`
- expose `observeServerFunctionCalls` and its types through the existing `@solidjs/web/server-functions/client` re-export
- cover request and response observation through the built Solid Web bundles

## Context

This prepares Solid 2 for [dom-expressions#570](https://github.com/ryansolid/dom-expressions/pull/570) and enables the server-function inspector in [solid-vite-plugin#314](https://github.com/solidjs/solid-vite-plugin/pull/314).

The lockfile was prepared from the simulated `0.50.0-next.44` changeset release. CI installation will remain blocked until that version is published.

## Testing

- `@solidjs/web` build
- Solid and Solid Web type generation
- server-function extension suite, 6/6 tests
