### PR TITLE
fix(signals): refresh() lifts a stale manual-write mask inside a transaction

### DIFF
--- a/.changeset/refresh-lifts-stale-manual-write-mask.md
+++ b/.changeset/refresh-lifts-stale-manual-write-mask.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Fix `refresh(store)` being silently swallowed inside an `action()` after a `setStore` in the same transaction (#3026). The derived-store manual-write mask (which lets a same-tick manual write win over a queued recompute, #2692) previously persisted for the whole transaction, so any setStore early in an action made every later `refresh()` a no-op. An explicit `refresh()` now lifts a mask stamped in an earlier tick and re-runs the source; a manual write in the same synchronous tick still wins in both orders, preserving the #2692 contract.

--- a/packages/solid-signals/src/core/core.ts
+++ b/packages/solid-signals/src/core/core.ts
@@ -1108,6 +1108,7 @@ export function suppressComputedRecompute(el: Computed<unknown>): void {
     schedule();
   }
   el._flags = (el._flags & ~(REACTIVE_DIRTY | REACTIVE_CHECK)) | REACTIVE_MANUAL_WRITE;
+  el._manualWriteTime = clock;
 }
 
 /**
@@ -1232,10 +1233,19 @@ export function refresh<T>(target: Refreshable<T>): void {
     });
     throw new Error(REACTIVE_WRITE_IN_OWNED_SCOPE_REFRESH_MESSAGE);
   }
-  if (
-    typeof node._fn === "function" &&
-    !(node._flags & (REACTIVE_DISPOSED | REACTIVE_MANUAL_WRITE))
-  ) {
+  if (typeof node._fn === "function" && !(node._flags & REACTIVE_DISPOSED)) {
+    if (node._flags & REACTIVE_MANUAL_WRITE) {
+      // A manual write in the CURRENT tick wins over the refresh (#2692).
+      // A mask stamped in an earlier tick only survives because a
+      // transaction (action) is holding the pending drain open; there the
+      // refresh is a later, explicit re-ask and lifts the mask — otherwise
+      // any setStore early in an action silently swallows every refresh()
+      // for the rest of the transaction (#3026).
+      if (node._manualWriteTime === clock) return;
+      node._flags &= ~REACTIVE_MANUAL_WRITE;
+      // No REASK below: the batch carries a manual value change, so the
+      // recompute is not a quiet re-ask of an unchanged question.
+    }
     // A refresh with no value-change dirt already queued is a re-ask of the
     // same question: mark it so the recompute classifies any resulting
     // pending window as quiet (not pending). If the node is already dirty
@@ -1243,7 +1253,7 @@ export function refresh<T>(target: Refreshable<T>): void {
     // REACTIVE_IN_HEAP counts as dirt: insertSubs schedules subscribers by
     // heap insertion alone (no DIRTY/CHECK flag), so a same-batch value
     // change followed by refresh() must not be laundered into a quiet re-ask.
-    if (!(node._flags & (REACTIVE_DIRTY | REACTIVE_CHECK | REACTIVE_IN_HEAP))) {
+    else if (!(node._flags & (REACTIVE_DIRTY | REACTIVE_CHECK | REACTIVE_IN_HEAP))) {
       node._flags |= REACTIVE_REASK;
       armReaskClear();
     }

--- a/packages/solid-signals/src/core/types.ts
+++ b/packages/solid-signals/src/core/types.ts
@@ -137,6 +137,14 @@ export interface Computed<T> extends RawSignal<T>, Owner {
    */
   _reask: boolean;
   /**
+   * Clock tick at which REACTIVE_MANUAL_WRITE was last applied
+   * (`suppressComputedRecompute`). Lets `refresh()` distinguish a same-tick
+   * manual write (which wins over the refresh, #2692) from a mask carried
+   * across ticks by a transaction (which an explicit refresh lifts, #3026).
+   * Only meaningful while REACTIVE_MANUAL_WRITE is set.
+   */
+  _manualWriteTime?: number;
+  /**
    * True while a `loadingValue` node's first real answer hasn't landed: the
    * node was born committed (commit #0 = the loading value) and `handleAsync`
    * serves that committed value instead of throwing NotReadyError, so first

--- a/packages/solid-signals/tests/action.test.ts
+++ b/packages/solid-signals/tests/action.test.ts
@@ -5,7 +5,9 @@ import {
   createRenderEffect,
   createRoot,
   createSignal,
-  flush
+  createStore,
+  flush,
+  refresh
 } from "../src/index.js";
 
 afterEach(() => flush());
@@ -575,6 +577,89 @@ describe("action", () => {
       expect($a()).toBe(10);
       expect($b()).toBe(20);
       expect($c()).toBe(30);
+    });
+  });
+
+  describe("refresh(store) inside an action (#3026)", () => {
+    // A setStore on a derived store masks its recompute for the tick
+    // (REACTIVE_MANUAL_WRITE, #2692). Inside an action the mask survives
+    // until the transaction commits, so a later explicit refresh() was
+    // silently swallowed and the store source never re-ran. refresh() now
+    // lifts a mask stamped in an earlier tick.
+    it("re-runs the source after a setStore absorbed into the action transaction", async () => {
+      const data = { messages: [] as number[] };
+      let evals = 0;
+      const [store, setStore] = createRoot(() => {
+        const [s, sStore] = createStore(
+          () => {
+            evals++;
+            return data;
+          },
+          { messages: [] as number[] }
+        );
+        createRenderEffect(
+          () => JSON.stringify(s.messages),
+          () => {}
+        );
+        return [s, sStore] as const;
+      });
+      flush();
+      expect(evals).toBe(1);
+
+      const myAction = action(function* () {
+        yield new Promise(r => setTimeout(r, 10));
+        refresh(store);
+      });
+
+      const p = myAction();
+      // The issue shape: a setStore write while the action's transition is
+      // still ambient, plus an external source mutation.
+      setStore(s => {
+        s.messages.push(1);
+      });
+      data.messages.push(2);
+      await p;
+      flush();
+      expect(evals).toBe(2);
+    });
+
+    it("reconciles a fresh source result over the draft write at action commit", async () => {
+      let fetched = { messages: [10] as number[] };
+      let evals = 0;
+      const [store, setStore] = createRoot(() => {
+        const [s, sStore] = createStore(
+          () => {
+            evals++;
+            return JSON.parse(JSON.stringify(fetched)) as typeof fetched;
+          },
+          { messages: [] as number[] }
+        );
+        createRenderEffect(
+          () => JSON.stringify(s.messages),
+          () => {}
+        );
+        return [s, sStore] as const;
+      });
+      flush();
+      expect(evals).toBe(1);
+      expect(store.messages).toEqual([10]);
+
+      const myAction = action(function* () {
+        yield new Promise(r => setTimeout(r, 10));
+        refresh(store);
+      });
+
+      const p = myAction();
+      setStore(s => {
+        s.messages.push(1);
+      });
+      fetched = { messages: [10, 20] };
+      await p;
+      flush();
+      // refresh() came after the setStore in program order: the re-derived
+      // result wins over the transaction draft.
+      expect(evals).toBe(2);
+      expect(store.messages).toEqual([10, 20]);
     });
   });
 

--- a/packages/solid-signals/tests/store/createStore.test.ts
+++ b/packages/solid-signals/tests/store/createStore.test.ts
@@ -15,6 +15,7 @@ import {
   merge,
   omit,
   reconcile,
+  refresh,
   snapshot,
   storePath,
   untrack
@@ -1321,6 +1322,65 @@ describe("derived store manual writes", () => {
     setSource({ count: 2 });
     flush();
     expect(store.count).toBe(2);
+  });
+
+  it("same-tick manual write wins over refresh() in both orders (#2692)", () => {
+    let evals = 0;
+    const [store, setStore] = createRoot(() => {
+      const [source] = createSignal({ count: 0 });
+      const [s, sStore] = createStore<{ count: number }>(
+        () => {
+          evals++;
+          return { count: source().count };
+        },
+        { count: 0 }
+      );
+      return [s, sStore] as const;
+    });
+    flush();
+    expect(evals).toBe(1);
+
+    setStore(s => {
+      s.count = 99;
+    });
+    refresh(store);
+    flush();
+    expect(evals).toBe(1);
+    expect(store.count).toBe(99);
+
+    refresh(store);
+    setStore(s => {
+      s.count = 100;
+    });
+    flush();
+    expect(evals).toBe(1);
+    expect(store.count).toBe(100);
+  });
+
+  it("refresh() on a later tick re-runs the derived store source (#3026)", () => {
+    let evals = 0;
+    const [store, setStore] = createRoot(() => {
+      const [source] = createSignal({ count: 0 });
+      const [s, sStore] = createStore<{ count: number }>(
+        () => {
+          evals++;
+          return { count: source().count };
+        },
+        { count: 0 }
+      );
+      return [s, sStore] as const;
+    });
+    flush();
+    setStore(s => {
+      s.count = 99;
+    });
+    flush();
+    expect(store.count).toBe(99);
+
+    refresh(store);
+    flush();
+    expect(evals).toBe(2);
+    expect(store.count).toBe(0);
   });
 });
 


### PR DESCRIPTION
Fixes #3026

## The bug

`refresh(store)` on a derived store (`createStore(fn, init)`) never re-ran the source function when called inside an `action()` — but only when a `setStore` had happened earlier in the same transaction (in the issue repro, the `setStore` right after `act1()` is absorbed into the still-ambient action transition).

Root cause: the derived-store setter calls `suppressComputedRecompute`, which sets `REACTIVE_MANUAL_WRITE` so a manual write wins over a queued recompute for the tick (#2692 / core R31). That mask is only cleared by the pending-node drain (`commitPendingNode`) — which inside a transaction doesn't run until the action commits. `refresh()` silently bailed on the mask, so any `setStore` early in an action swallowed every later `refresh()` for the rest of the transaction. That's why deferring the refresh in a `setTimeout` (after commit) worked.

## The fix

`suppressComputedRecompute` now stamps the current clock tick on the node (`_manualWriteTime`), and `refresh()` distinguishes the two cases:

- **Same synchronous tick**: the manual write still wins over the refresh, in both orders — the pinned #2692 contract ("manual memo writes win over refresh within the same tick", createMemo.test.ts) is unchanged.
- **Mask stamped in an earlier tick** (only possible when a transaction is holding the drain open): the explicit refresh lifts the mask, the source re-runs, and its result reconciles over the transaction draft at commit — one atomic reveal.

When lifting the mask, no `REACTIVE_REASK` (quiet re-ask) mark is set, since the batch carries a real manual value change.

## Tests

New tests in `action.test.ts` ("refresh(store) inside an action") cover the issue shape and the re-fetch shape (fresh object per derive — reconciled result wins over the draft at commit), and `store/createStore.test.ts` ("derived store manual writes") pins both #2692 precedence directions (same-tick setStore-then-refresh and refresh-then-setStore both keep the manual write) plus the cross-tick refresh. Full solid-signals and solid suites pass with no regressions.

One note on the issue's exact repro: the derive there returns the same object identity the store already adopted as its raw state, so the re-run's reconcile is an identity no-op (owned-raw model, pre-existing behavior). The source function re-running — the reported symptom — is fixed; realistic re-fetch derives that return fresh data get the full expected reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
