### PR TITLE
fix(signals): isPending in a wrapper memo survives the fresh-read race (#3028)

### DIFF
--- a/.changeset/ispending-wrapper-fresh-hold.md
+++ b/.changeset/ispending-wrapper-fresh-hold.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+`isPending(a)` inside a memo — including a `<Show when={isPending(a)}>` outside any `<Loading>` boundary — now reports true while an async memo derived from `a` is refetching (#3028). The wrapper memo recomputes during the write's flush and reads the held value fresh, which the fresh-read pairing rule (#2831) treated as "this reader already sees the answer" and silenced the verdict; with the downstream async not yet registered, nothing ever re-asked, so the indicator never showed. The pairing rule now only silences landed answers awaiting reveal — a held input whose transaction still has async in flight stays pending for every reader — and a probe that was silenced before the async registered is re-woken at the registration site, flushing the corrected verdict immediately.

--- a/packages/solid-signals/src/core/scheduler.ts
+++ b/packages/solid-signals/src/core/scheduler.ts
@@ -428,6 +428,9 @@ export class GlobalQueue extends Queue {
   static _applyReask: ((el: Computed<any>, hadReask: boolean) => boolean) | null = null;
   static _repollVerdicts: ((el: Computed<any>, snap?: boolean) => void) | null = null;
   static _witnessAffects: ((node: OptimisticNode) => void) | null = null;
+  // Re-asks probes whose verdict was provisionally suppressed by a fresh read
+  // of a held value, once the transaction gains an async blocker (#3028).
+  static _wakeSuppressedProbes: ((transition: Transition) => void) | null = null;
   // Optimistic-engine hooks (wired by core/optimistic.ts via
   // installOptimisticEngine(), called from verdict.ts / createOptimistic /
   // createOptimisticStore — every module that can create optimistic state).
@@ -586,7 +589,10 @@ export class GlobalQueue extends Queue {
           if (__DEV__) endAsyncReporterWrites();
           const prevSize = reporters.size;
           reporters.add(node);
-          if (reporters.size !== prevSize) schedule();
+          if (reporters.size !== prevSize) {
+            schedule();
+            GlobalQueue._wakeSuppressedProbes?.(activeTransition);
+          }
         }
         if (__DEV__ && _enforceLoadingBoundary) _hitUnhandledAsync = true;
       }

--- a/packages/solid-signals/src/core/verdict.ts
+++ b/packages/solid-signals/src/core/verdict.ts
@@ -10,6 +10,7 @@ import {
   REACTIVE_DIRTY,
   REACTIVE_DISPOSED,
   REACTIVE_MANUAL_WRITE,
+  REACTIVE_OPTIMISTIC_DIRTY,
   REACTIVE_RECOMPUTING_DEPS,
   REACTIVE_ZOMBIE,
   STATUS_ERROR,
@@ -36,19 +37,21 @@ import {
 } from "./core.js";
 import { NotReadyError } from "./error.js";
 import { link } from "./graph.js";
-import { insertIntoHeap, markHeap, queueFor } from "./heap.js";
+import { enqueueSub, insertIntoHeap, markHeap, queueFor } from "./heap.js";
 import { devTrackCompanionOwner, InvariantHooks } from "./invariants.js";
-import { findLane, hasActiveOverride } from "./lanes.js";
+import { assignOrMergeLane, findLane, hasActiveOverride } from "./lanes.js";
 import { installOptimisticEngine } from "./optimistic.js";
 import {
   activeAffectsMarks,
   activeTransition,
   clock,
+  currentTransition,
   dirtyQueue,
   GlobalQueue,
   insertSubs,
   schedule,
-  zombieQueue
+  zombieQueue,
+  type Transition
 } from "./scheduler.js";
 import type { Computed, FirewallSignal, Signal } from "./types.js";
 
@@ -61,8 +64,17 @@ interface PendingProbe {
   found: boolean;
   sources: Set<Signal<any> | Computed<any>>;
   freshReads: Set<Signal<any> | Computed<any>>;
+  suppressed: Array<Signal<any> | Computed<any>>;
 }
 let pendingProbe: PendingProbe | null = null;
+
+/**
+ * Probes whose verdict was suppressed by the fresh-read pairing rule while
+ * the held write's fate was still undecided (see recordFreshRead /
+ * wakeSuppressedProbes): held node → the wrapper computeds that probed it.
+ * Entries die with the hold — the commit/revert snap clears them.
+ */
+const suppressedProbes: Map<Signal<any> | Computed<any>, Set<Computed<any>>> = new Map();
 
 /**
  * Get or create the pending signal for a node (lazy).
@@ -251,7 +263,43 @@ function repollDownstreamVerdicts(el: Computed<any>, snap: boolean = false): voi
   visit(el);
 }
 
+/**
+ * The correction half of the provisional fresh-read suppression (see
+ * collectPending): fired from the sanctioned async-registration site
+ * (GlobalQueue.notify) when a transaction gains an in-flight async blocker.
+ * Every probe that returned "not pending" purely because it read a held
+ * value belonging to that transaction re-runs — its re-probe now sees the
+ * live blocker through heldAwaitingAsync and lands the true verdict. The
+ * wake mirrors a companion write's own notification (optimistic-dirty on the
+ * companion's lane) so the corrected verdict commits and flushes immediately
+ * instead of being held with the transaction it reports on.
+ */
+function wakeSuppressedProbes(transition: Transition): void {
+  if (suppressedProbes.size === 0) return;
+  let woke = false;
+  for (const [node, probes] of suppressedProbes) {
+    const t = node._transition ? currentTransition(node._transition) : null;
+    if (!t) {
+      suppressedProbes.delete(node);
+      continue;
+    }
+    if (t !== transition) continue;
+    suppressedProbes.delete(node);
+    const lane = node._pendingSignal?._optimisticLane;
+    for (const p of probes) {
+      if (p._flags & REACTIVE_DISPOSED) continue;
+      p._flags |= REACTIVE_OPTIMISTIC_DIRTY;
+      if (lane) assignOrMergeLane(p, lane);
+      else p._optimisticLane = undefined;
+      enqueueSub(p);
+      woke = true;
+    }
+  }
+  if (woke) schedule();
+}
+
 function snapCompanionsToState(owner: Signal<any> | Computed<any>): void {
+  suppressedProbes.size !== 0 && suppressedProbes.delete(owner);
   const sig = owner._pendingSignal;
   if (sig && (sig._overrideValue === undefined || sig._overrideValue === NOT_PENDING)) {
     const pending = computePendingState(owner);
@@ -376,9 +424,33 @@ function pendingCheckRead(
   setPendingCheckActive(true);
 }
 
+/**
+ * A held node whose transaction still has an async question in flight. The
+ * probe's fresh-read pairing rule (#2831 — "a reader that sees the fresh
+ * value must not also be told it is pending") only applies to LANDED answers
+ * awaiting reveal; while the answer is still computing, the fresh value the
+ * reader saw is an input, and pending remains the truth for every reader
+ * (#3028).
+ */
+function heldAwaitingAsync(el: Signal<any> | Computed<any>): boolean {
+  const t = el._transition ? currentTransition(el._transition) : null;
+  if (!t || t._done) return false;
+  for (const [source, reporters] of t._asyncReporters) {
+    if (
+      reporters.size &&
+      source._statusFlags & STATUS_PENDING &&
+      (source._error as NotReadyError | undefined)?.source === source
+    )
+      return true;
+  }
+  return false;
+}
+
 function recordFreshRead(el: Signal<any> | Computed<any>, value: any): void {
-  if (pendingProbe !== null && el._pendingValue !== NOT_PENDING && value === el._pendingValue)
+  if (pendingProbe !== null && el._pendingValue !== NOT_PENDING && value === el._pendingValue) {
+    if (heldAwaitingAsync(el)) return;
     pendingProbe.freshReads.add(el);
+  }
 }
 
 function applyReask(el: Computed<any>, hadReask: boolean): boolean {
@@ -406,7 +478,8 @@ export function isPending(fn: () => any): boolean {
   const probe: PendingProbe = (pendingProbe = {
     found: false,
     sources: new Set(),
-    freshReads: new Set()
+    freshReads: new Set(),
+    suppressed: []
   });
   const collectPending = () => {
     setPendingCheckActive(false);
@@ -414,11 +487,31 @@ export function isPending(fn: () => any): boolean {
     if (__DEV__) setStrictRead(false);
     try {
       probe.sources.forEach(source => {
-        if (read(getPendingSignal(source)) && !probe.freshReads.has(source)) probe.found = true;
+        if (read(getPendingSignal(source))) {
+          if (!probe.freshReads.has(source)) probe.found = true;
+          else probe.suppressed.push(source);
+        }
       });
     } finally {
       if (__DEV__) setStrictRead(prevStrictRead);
       setPendingCheckActive(true);
+    }
+    // A "not pending" verdict that exists only because this reader saw the
+    // fresh held value is provisional: if the write turns out NOT to commit
+    // this flush (a downstream async pends and holds it), the suppression was
+    // wrong and the wrapper must re-ask (#3028). Remember who to wake — the
+    // async registration (GlobalQueue.notify) triggers wakeSuppressedProbes.
+    if (
+      !probe.found &&
+      probe.suppressed.length &&
+      context &&
+      typeof (context as Partial<Computed<unknown>>)._fn === "function"
+    ) {
+      for (const source of probe.suppressed) {
+        let probes = suppressedProbes.get(source);
+        if (!probes) suppressedProbes.set(source, (probes = new Set()));
+        probes.add(context as Computed<any>);
+      }
     }
   };
   try {
@@ -452,6 +545,7 @@ GlobalQueue._recordFresh = recordFreshRead;
 GlobalQueue._applyReask = applyReask;
 GlobalQueue._repollVerdicts = repollDownstreamVerdicts;
 GlobalQueue._witnessAffects = witnessAffects;
+GlobalQueue._wakeSuppressedProbes = wakeSuppressedProbes;
 
 if (__DEV__) {
   InvariantHooks.pendingProbeActive = () => pendingProbe !== null;

--- a/packages/solid-signals/tests/latest-isPending-consistency.test.ts
+++ b/packages/solid-signals/tests/latest-isPending-consistency.test.ts
@@ -197,3 +197,218 @@ describe("latest/isPending consistency (#2831)", () => {
     expect(log).toEqual(["sig=[latest=2 pend=false] memo=[latest=20 pend=false]"]);
   });
 });
+
+/**
+ * #3028 — a wrapper memo probing `isPending(a)` without also reading the
+ * async memo derived from `a`.
+ *
+ * The failing shape: `createMemo(() => isPending(a))` (what `<Show
+ * when={isPending(a)}>` compiles to) recomputes during the write's flush,
+ * BEFORE the downstream async memo pends. Its probe read `a`'s held value
+ * fresh, so the fresh-read pairing rule above suppressed the verdict — and
+ * with no transaction registered yet, nothing ever re-asked, so the wrapper
+ * stayed false for the whole flight.
+ *
+ * The fix is two-sided: the pairing rule only suppresses for landed answers
+ * awaiting reveal (a held INPUT whose transaction still has async in flight
+ * stays pending for every reader), and a probe suppressed before the async
+ * registered is recorded and re-woken at the registration site.
+ */
+describe("isPending wrapper memo over a signal with async downstream (#3028)", () => {
+  const tick = async () => {
+    await new Promise(r => setTimeout(r, 0));
+    flush();
+  };
+
+  function makeAsyncDouble(a: () => number) {
+    const resolvers: Array<() => void> = [];
+    const double = createMemo(async () => {
+      const x = a();
+      await new Promise<void>(r => resolvers.push(r));
+      return x * 2;
+    });
+    return { double, resolveAll: () => resolvers.splice(0).forEach(r => r()) };
+  }
+
+  it("memo of bare isPending(a) flips true while downstream async is in flight", async () => {
+    const [a, setA] = createSignal(0);
+    let resolveAll!: () => void;
+    let dispose!: () => void;
+    const pendingLog: boolean[] = [];
+    const doubleLog: number[] = [];
+    createRoot(d => {
+      dispose = d;
+      const source = makeAsyncDouble(a);
+      resolveAll = source.resolveAll;
+      const m = createMemo(() => isPending(a));
+      createRenderEffect(
+        () => source.double(),
+        v => {
+          doubleLog.push(v);
+        }
+      );
+      createRenderEffect(
+        () => m(),
+        v => {
+          pendingLog.push(v);
+        }
+      );
+    });
+    flush();
+    resolveAll();
+    await tick();
+    expect(doubleLog).toEqual([0]);
+    expect(pendingLog).toEqual([false]);
+
+    setA(1);
+    flush();
+    // async in flight: a's new question is unanswered — isPending(a) must be true
+    expect(pendingLog).toEqual([false, true]);
+
+    resolveAll();
+    await tick();
+    expect(doubleLog).toEqual([0, 2]);
+    expect(pendingLog).toEqual([false, true, false]);
+    dispose();
+  });
+
+  it("memo reading both a() and isPending(a) flips true (issue variant B)", async () => {
+    const [a, setA] = createSignal(0);
+    let resolveAll!: () => void;
+    let dispose!: () => void;
+    const pendingLog: boolean[] = [];
+    createRoot(d => {
+      dispose = d;
+      const source = makeAsyncDouble(a);
+      resolveAll = source.resolveAll;
+      createRenderEffect(
+        () => source.double(),
+        () => {}
+      );
+      const m = createMemo(() => (a(), isPending(a)));
+      createRenderEffect(
+        () => m(),
+        v => {
+          pendingLog.push(v);
+        }
+      );
+    });
+    flush();
+    resolveAll();
+    await tick();
+    expect(pendingLog).toEqual([false]);
+
+    setA(1);
+    flush();
+    expect(pendingLog).toEqual([false, true]);
+
+    resolveAll();
+    await tick();
+    expect(pendingLog).toEqual([false, true, false]);
+    dispose();
+  });
+
+  it("control: memo reading double() too flips true (issue's workaround)", async () => {
+    const [a, setA] = createSignal(0);
+    let resolveAll!: () => void;
+    let dispose!: () => void;
+    const pendingLog: boolean[] = [];
+    createRoot(d => {
+      dispose = d;
+      const source = makeAsyncDouble(a);
+      resolveAll = source.resolveAll;
+      const m = createMemo(() => (source.double(), isPending(a)));
+      createRenderEffect(
+        () => {
+          try {
+            return m();
+          } catch {
+            return false;
+          }
+        },
+        v => {
+          pendingLog.push(v);
+        }
+      );
+    });
+    flush();
+    resolveAll();
+    await tick();
+
+    setA(1);
+    flush();
+    expect(pendingLog[pendingLog.length - 1]).toBe(true);
+
+    resolveAll();
+    await tick();
+    expect(pendingLog[pendingLog.length - 1]).toBe(false);
+    dispose();
+  });
+
+  it("plain sync write (no async downstream) never glitches the wrapper true", () => {
+    const [a, setA] = createSignal(0);
+    let dispose!: () => void;
+    const pendingLog: boolean[] = [];
+    createRoot(d => {
+      dispose = d;
+      const m = createMemo(() => isPending(a));
+      createRenderEffect(
+        () => m(),
+        v => {
+          pendingLog.push(v);
+        }
+      );
+    });
+    flush();
+    expect(pendingLog).toEqual([false]);
+
+    setA(1);
+    flush();
+    // The held-write companion churn inside the flush must not surface: a
+    // plain write commits this flush, so the wrapper never reports pending.
+    expect(pendingLog).toEqual([false]);
+    dispose();
+  });
+
+  it("second write during an open flight keeps the wrapper true", async () => {
+    const [a, setA] = createSignal(0);
+    let resolveAll!: () => void;
+    let dispose!: () => void;
+    const pendingLog: boolean[] = [];
+    createRoot(d => {
+      dispose = d;
+      const source = makeAsyncDouble(a);
+      resolveAll = source.resolveAll;
+      createRenderEffect(
+        () => source.double(),
+        () => {}
+      );
+      const m = createMemo(() => isPending(a));
+      createRenderEffect(
+        () => m(),
+        v => {
+          pendingLog.push(v);
+        }
+      );
+    });
+    flush();
+    resolveAll();
+    await tick();
+    expect(pendingLog).toEqual([false]);
+
+    setA(1);
+    flush();
+    expect(pendingLog).toEqual([false, true]);
+
+    setA(2);
+    flush();
+    expect(pendingLog).toEqual([false, true]);
+
+    resolveAll();
+    await tick();
+    resolveAll();
+    await tick();
+    expect(pendingLog).toEqual([false, true, false]);
+    dispose();
+  });
+});

--- a/packages/solid-web/test/show.spec.tsx
+++ b/packages/solid-web/test/show.spec.tsx
@@ -3,7 +3,7 @@
  * @vitest-environment jsdom
  */
 import { describe, expect, test } from "vitest";
-import { createRoot, createSignal, Show, flush, isPending } from "solid-js";
+import { createMemo, createRoot, createSignal, Show, flush, isPending } from "solid-js";
 import { render } from "../src/index.js";
 
 describe("Testing an only child show control flow", () => {
@@ -436,5 +436,85 @@ describe("Sibling Shows with isPending in a fragment (#2963)", () => {
     expect(div.textContent).toBe("result:ok");
 
     dispose();
+  });
+});
+
+describe("isPending in Show `when` outside a Loading boundary (#3028)", () => {
+  // `<Show when={isPending(a)}>` compiles to a memo of the bare probe. That
+  // memo recomputes during the write's flush before the downstream async memo
+  // pends, reads a's held value fresh, and the fresh-read pairing rule
+  // (#2831) suppressed the verdict — the indicator never showed for the
+  // whole flight even though an untracked isPending(a) read true.
+  const tick = async () => {
+    await new Promise(r => setTimeout(r, 0));
+    flush();
+  };
+
+  function setup(when: (a: () => number) => boolean) {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const [a, setA] = createSignal(0);
+    const resolvers: Array<() => void> = [];
+    const double = createMemo(async () => {
+      const x = a();
+      await new Promise<void>(r => resolvers.push(r));
+      return x * 2;
+    });
+    const dispose = render(
+      () => (
+        <div>
+          Count: {a()} {double()}
+          <Show when={when(a)}>...</Show>
+        </div>
+      ),
+      container
+    );
+    return {
+      container,
+      setA,
+      resolveAll: () => resolvers.splice(0).forEach(r => r()),
+      cleanup() {
+        dispose();
+        document.body.removeChild(container);
+      }
+    };
+  }
+
+  test("shows the pending indicator while the async memo refetches", async () => {
+    const t = setup(a => isPending(a));
+    flush();
+    t.resolveAll();
+    await tick();
+    expect(t.container.textContent).toBe("Count: 0 0");
+
+    t.setA(1);
+    flush();
+    // refetch in flight: stale view plus the pending indicator
+    expect(t.container.textContent).toBe("Count: 0 0...");
+
+    t.resolveAll();
+    await tick();
+    expect(t.container.textContent).toBe("Count: 1 2");
+    t.cleanup();
+  });
+
+  test("variant B from the issue: when reads a() before isPending(a)", async () => {
+    const t = setup(a => {
+      a();
+      return isPending(a);
+    });
+    flush();
+    t.resolveAll();
+    await tick();
+    expect(t.container.textContent).toBe("Count: 0 0");
+
+    t.setA(1);
+    flush();
+    expect(t.container.textContent).toBe("Count: 0 0...");
+
+    t.resolveAll();
+    await tick();
+    expect(t.container.textContent).toBe("Count: 1 2");
+    t.cleanup();
   });
 });


### PR DESCRIPTION
Fixes #3028.

## The bug

`isPending(a)` inside a memo — the shape `<Show when={isPending(a)}>` compiles to — never reported true while an async memo derived from `a` was refetching, even though a ternary in JSX or the same probe inside a `<Loading>` boundary worked. @mizulu's narrowing in the issue is exactly the mechanism: a wrapper that also reads `double()` works, a wrapper that reads only `a()`/`isPending(a)` is dead for the whole flight.

## Root cause

Two interacting pieces:

1. **Wrong suppression class.** The wrapper memo recomputes during the write's flush, and memo reads of a written signal see its *held* fresh value. The probe's fresh-read pairing rule (#2831 — "a reader that already observes the fresh value must not also be told it is pending") then discarded the true verdict. That rule is correct for a **landed answer awaiting reveal**; here the fresh value was just the held *input* — the async answer didn't exist anywhere yet, so pending was still the truth for every reader. (This is also why the ternary worked: render effects read committed values, so the rule never fired for them.)
2. **Unwinnable race.** The wrapper runs *before* the async memo throws `NotReady` — at probe time no transaction exists, so the system cannot yet know the write will be held past the flush. Once it finds out, nothing re-notified the wrapper (the companion signal's value never changed — the suppression was reader-local), so the false verdict stood for the whole flight.

## The fix

Both halves live in the verdict layer, with one hook in the scheduler:

- `heldAwaitingAsync`: the fresh-read suppression now only applies to landed answers awaiting reveal. A held node whose transaction still has a live async blocker (an `_asyncReporters` source that is still self-pending) stays pending for every reader.
- `wakeSuppressedProbes`: a verdict silenced by a fresh read while the write's fate was still undecided is provisional — the silenced prober is recorded against the held node, and the sanctioned async-registration site (`GlobalQueue.notify`) wakes it when the transaction gains a blocker. The re-probe now sees the live blocker through `heldAwaitingAsync` and lands true, riding the companion's optimistic lane so the corrected verdict commits and flushes immediately instead of being held with the transaction it reports on. Entries die with the hold (cleared by the commit/revert snap).

## What is preserved

- The #2831 forbidden pair — `[isPending(x), x()]` must never read `[true, newValue]` for a landed answer while its action is still open — all three pinned consistency tests pass unchanged (that moment has no live async blocker, so suppression still applies).
- Plain sync writes never glitch the wrapper true: the held-write companion churn inside the flush stays invisible (no transaction ever gains a blocker, so the suppression stands and the write commits the same flush).

## Tests

- `tests/latest-isPending-consistency.test.ts`: new #3028 describe with the issue's two failing variants (`isPending(a)` bare, and `a()` + `isPending(a)`), the `double()` workaround as a control, the plain-sync-write no-glitch pin, and a second write during an open flight.
- `packages/solid-web/test/show.spec.tsx`: two DOM tests reproducing the issue's `<Show>` markup end to end (stale view + `...` during the flight, reveal on landing).

Full suites green: solid-signals 1292, solid 555, solid-web 418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)