### PR TITLE
perf(solid): hint lazy JS/CSS from preload

### DIFF
--- a/.changeset/lazy-preload-assets.md
+++ b/.changeset/lazy-preload-assets.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+`lazy().preload()` now registers the module's client JS/CSS as head hints on the server, not just its import. Registration used to wait for the component to render, so a router warming a matched route imported the module without emitting any `<link>` for it. The import is never gated on asset resolution, the per-request resolution cache is shared with the render path, and `registerModule` stays with the render — its hydration key is only known there.

--- a/packages/solid-web/test/server/ssr-stream.spec.tsx
+++ b/packages/solid-web/test/server/ssr-stream.spec.tsx
@@ -17,6 +17,7 @@ import {
   Dynamic
 } from "@solidjs/web";
 import {
+  NoHydration,
   createEffect,
   createMemo,
   createRenderEffect,
@@ -1249,6 +1250,78 @@ describe("SSR Streaming — Asset Discovery", () => {
     expect(shell).toContain('<link rel="modulepreload" href="/assets/Home-abc.js">');
     expect(shell).toContain('<link rel="modulepreload" href="/assets/shared-def.js">');
     expect(shell).toContain("Home Content");
+  });
+
+  test("preload() hints a matched route that has not rendered yet", async () => {
+    // The router's warm-up shape: the route is known from the URL and preloaded
+    // before anything renders it, so its whole static graph rides the shell.
+    const manifest = {
+      "./Route.tsx": {
+        file: "assets/Route-abc.js",
+        css: ["assets/Route.css"],
+        imports: ["_dep"]
+      },
+      _dep: { file: "assets/dep-def.js" }
+    };
+
+    const Route = (props: any) => <div>route body</div>;
+    const LazyRoute = lazy(() => asyncValue({ default: Route }), undefined, "./Route.tsx");
+
+    function App() {
+      LazyRoute.preload!();
+      return (
+        <html>
+          <head>
+            <title>Test</title>
+          </head>
+          <body>
+            <div>shell</div>
+          </body>
+        </html>
+      );
+    }
+
+    const { shell } = await collectChunks(() => <App />, { manifest });
+    expect(shell).toContain('<link rel="modulepreload" href="/assets/Route-abc.js">');
+    expect(shell).toContain('<link rel="modulepreload" href="/assets/dep-def.js">');
+    expect(shell).toContain('<link rel="stylesheet" href="/assets/Route.css">');
+    // Hints only — the component itself never rendered.
+    expect(shell).not.toContain("route body");
+  });
+
+  test("preload() under NoHydration hints css but not the module", async () => {
+    const manifest = {
+      "./Aside.tsx": { file: "assets/Aside-abc.js", css: ["assets/Aside.css"] }
+    };
+
+    const Aside = (props: any) => <div>aside</div>;
+    const LazyAside = lazy(() => asyncValue({ default: Aside }), undefined, "./Aside.tsx");
+
+    function Warm() {
+      LazyAside.preload!();
+      return null;
+    }
+
+    function App() {
+      return (
+        <html>
+          <head>
+            <title>Test</title>
+          </head>
+          <body>
+            <NoHydration>
+              <Warm />
+            </NoHydration>
+          </body>
+        </html>
+      );
+    }
+
+    const { shell } = await collectChunks(() => <App />, { manifest });
+    // The server markup still needs its styles; nothing in there hydrates, so
+    // the client never fetches the module.
+    expect(shell).toContain('<link rel="stylesheet" href="/assets/Aside.css">');
+    expect(shell).not.toContain("Aside-abc.js");
   });
 
   test("lazy with no manifest throws during render", async () => {

--- a/packages/solid/src/server/component.ts
+++ b/packages/solid/src/server/component.ts
@@ -69,6 +69,64 @@ export function createComponent<T extends Record<string, any>>(
   return Comp(props || ({} as T));
 }
 
+type AssetContext = NonNullable<typeof sharedConfig.context>;
+
+/**
+ * Resolves a module's client assets once per request and hands them to
+ * `apply`. Shared by the render path and `preload()` so the cache, the
+ * settle-and-upgrade dance and the boundary restore stay in one place.
+ */
+function resolveLazyAssets(
+  ctx: AssetContext,
+  id: string,
+  apply: (assets: ResolvedAssets | null | undefined) => void
+): Promise<void> | undefined {
+  // One resolver call per module per request. The component body — and with it
+  // its registration — re-runs on every re-creation across suspended render
+  // passes, and dev-server resolvers answer from the live module graph with
+  // real work per call, so re-asking multiplied that work by the retry count
+  // (and by every lazy() on the page). Only the RESOLUTION is memoized:
+  // `apply` still runs per call, so per-boundary attribution is unchanged.
+  const cache = (ctx._lazyAssets ??= new Map());
+  let assets;
+  if (cache.has(id)) {
+    assets = cache.get(id);
+  } else {
+    assets = ctx.resolveAssets!(id);
+    cache.set(id, assets);
+  }
+  if (assets && typeof (assets as Promise<ResolvedAssets | null>).then === "function") {
+    // Restore the boundary that owned this call — by the time the resolver
+    // settles, other boundaries may be rendering.
+    const boundary = ctx._currentBoundaryId;
+    return (assets as Promise<ResolvedAssets | null>).then(
+      resolved => {
+        // Upgrade the memoized entry to the settled VALUE. Leaving the promise
+        // in the cache made every post-settle re-creation mint a fresh pending
+        // gate (a `.then` of an already-resolved promise: pending at the render
+        // memo's compute, settled one microtask later), so the memo threw
+        // NotReadyError on every suspended-render retry pass and the boundary
+        // resume loop never converged — an unbounded microtask livelock that
+        // ground dev streaming SSR into heap exhaustion (async dev resolvers
+        // only; sync manifests never enter this branch).
+        cache.set(id, resolved ?? null);
+        const current = ctx._currentBoundaryId;
+        ctx._currentBoundaryId = boundary;
+        try {
+          apply(resolved);
+        } finally {
+          ctx._currentBoundaryId = current;
+        }
+      },
+      err => {
+        cache.set(id, null);
+        console.warn(`lazy() asset resolution failed for "${id}":`, err);
+      }
+    );
+  }
+  apply(assets as ResolvedAssets | null);
+}
+
 /**
  * Lazy load a function component asynchronously.
  * On server, returns a createMemo that throws NotReadyError until the module resolves,
@@ -192,55 +250,8 @@ export function lazy<T extends Component<any>>(
           if (hydrationKey != null) ctx.registerModule?.(hydrationKey, assets.js[0]);
         }
       };
-      const registerLazyAssets = (id: string): Promise<void> | undefined => {
-        // One resolver call per module per request. The component body — and
-        // with it this registration — re-runs on every re-creation across
-        // suspended render passes, and dev-server resolvers answer from the
-        // live module graph with real work per call, so re-asking multiplied
-        // that work by the retry count (and by every lazy() on the page).
-        // Only the RESOLUTION is memoized: applyAssets below still runs per
-        // creation, so per-boundary asset attribution is unchanged.
-        const cache = (ctx._lazyAssets ??= new Map());
-        let assets;
-        if (cache.has(id)) {
-          assets = cache.get(id);
-        } else {
-          assets = ctx.resolveAssets!(id);
-          cache.set(id, assets);
-        }
-        if (assets && typeof (assets as Promise<ResolvedAssets | null>).then === "function") {
-          // Restore the boundary that owned this render around the deferred
-          // registration — by the time the resolver settles, other
-          // boundaries may be rendering.
-          const boundary = ctx._currentBoundaryId;
-          return (assets as Promise<ResolvedAssets | null>).then(
-            resolved => {
-              // Upgrade the memoized entry to the settled VALUE. Leaving the
-              // promise in the cache made every post-settle re-creation mint a
-              // fresh `assetsPending` (a `.then` of an already-resolved
-              // promise: pending at the render memo's compute, settled one
-              // microtask later), so the memo threw NotReadyError on every
-              // suspended-render retry pass and the boundary resume loop never
-              // converged — an unbounded microtask livelock that ground dev
-              // streaming SSR into heap exhaustion (async dev resolvers only;
-              // sync manifests never enter this branch).
-              cache.set(id, resolved ?? null);
-              const current = ctx._currentBoundaryId;
-              ctx._currentBoundaryId = boundary;
-              try {
-                applyAssets(resolved);
-              } finally {
-                ctx._currentBoundaryId = current;
-              }
-            },
-            err => {
-              cache.set(id, null);
-              console.warn(`lazy() asset resolution failed for "${id}":`, err);
-            }
-          );
-        }
-        applyAssets(assets as ResolvedAssets | null);
-      };
+      const registerLazyAssets = (id: string): Promise<void> | undefined =>
+        resolveLazyAssets(ctx, id, applyAssets);
       if (moduleUrl) {
         assetsPending = registerLazyAssets(moduleUrl);
       } else if (!noHydrate) {
@@ -321,7 +332,62 @@ export function lazy<T extends Component<any>>(
       { sync: true }
     ) as unknown as SolidElement;
   };
-  wrap.preload = load;
+  // Hints the module's assets now instead of at its render, so a router
+  // warming a matched route gets the links into the head earlier. The import
+  // is never gated on resolution; a resolver failure only warns.
+  wrap.preload = () => {
+    const cur = load();
+    const ctx = sharedConfig.context;
+    if (!ctx?.resolveAssets || !ctx.registerAsset) return cur;
+    // As in the render path, a no-hydrate subtree needs its CSS but never
+    // fetches the module. Reading the context needs an owner.
+    const owner = getOwner();
+    const noHydrate = owner ? getContext(NoHydrateContext, owner) : false;
+    const hint = (assets: ResolvedAssets | null | undefined) => {
+      if (!assets) return;
+      for (let i = 0; i < assets.css.length; i++) {
+        const css = assets.css[i];
+        if (typeof css === "string") ctx.registerAsset!("style", css);
+        else ctx.registerAsset!("inline-style", css);
+      }
+      // Hint-only: registerModule files the module into the serialized
+      // hydration map, whose key only the render that creates it knows.
+      if (!noHydrate)
+        for (let i = 0; i < assets.js.length; i++) ctx.registerAsset!("module", assets.js[i]);
+    };
+    const hintFor = (id: string) => {
+      try {
+        resolveLazyAssets(ctx, id, hint);
+      } catch (err) {
+        console.warn(`lazy() asset resolution failed for "${id}":`, err);
+      }
+    };
+    if (moduleUrl) hintFor(moduleUrl);
+    else {
+      // As in the render path: an already-loaded module exposes its specifier
+      // synchronously, so only an in-flight import has to wait a microtask.
+      const known = (cur.mod as any)?.$$moduleUrl;
+      if (typeof known === "string") hintFor(known);
+      else {
+        const boundary = ctx._currentBoundaryId;
+        cur.then(
+          (mod: any) => {
+            const id = mod?.$$moduleUrl;
+            if (typeof id !== "string") return;
+            const current = ctx._currentBoundaryId;
+            ctx._currentBoundaryId = boundary;
+            try {
+              hintFor(id);
+            } finally {
+              ctx._currentBoundaryId = current;
+            }
+          },
+          () => {}
+        );
+      }
+    }
+    return cur;
+  };
   Object.defineProperty(wrap, "moduleUrl", {
     get() {
       const ctx = sharedConfig.context;

--- a/packages/solid/test/server/ssr-async.spec.ts
+++ b/packages/solid/test/server/ssr-async.spec.ts
@@ -3874,6 +3874,8 @@ describe("Asset Manifest + lazy()", () => {
     const Comp = (props: any) => "Hello";
     const LazyComp = lazy(() => Promise.resolve({ default: Comp }), undefined, "./MyComp.tsx");
     await LazyComp.preload!();
+    // preload() now hints the module too; this case covers the render pass.
+    registered.length = 0;
 
     createRoot(
       () => {
@@ -3892,6 +3894,69 @@ describe("Asset Manifest + lazy()", () => {
     expect(modules).toEqual({ t0: "/assets/MyComp-abc123.js" });
   });
 
+  test("preload() hints the module's assets without rendering it", async () => {
+    const { lazy } = await import("../../src/server/component.js");
+
+    const registered: Array<{ type: string; url: string }> = [];
+    const modules: Record<string, string> = {};
+    const { context } = createMockSSRContext();
+    context.registerAsset = (type: string, url: string) => registered.push({ type, url });
+    context.registerModule = (moduleUrl: string, entryUrl: string) => {
+      modules[moduleUrl] = entryUrl;
+    };
+    context.resolveAssets = (id: string) =>
+      id === "./Route.tsx"
+        ? { js: ["/assets/Route.js", "/assets/shared.js"], css: ["/assets/Route.css"] }
+        : null;
+    sharedConfig.context = context;
+
+    const LazyRoute = lazy(
+      () => Promise.resolve({ default: () => "route" }),
+      undefined,
+      "./Route.tsx"
+    );
+    await LazyRoute.preload!();
+
+    expect(registered).toEqual([
+      { type: "style", url: "/assets/Route.css" },
+      { type: "module", url: "/assets/Route.js" },
+      { type: "module", url: "/assets/shared.js" }
+    ]);
+    // Hint-only: the hydration mapping belongs to the render that creates the
+    // component, which knows the hydration key.
+    expect(modules).toEqual({});
+  });
+
+  test("preload() resolves each module once per request", async () => {
+    const { lazy } = await import("../../src/server/component.js");
+
+    let calls = 0;
+    const registered: Array<{ type: string; url: string }> = [];
+    const { context } = createMockSSRContext();
+    context.registerAsset = (type: string, url: string) => registered.push({ type, url });
+    context.resolveAssets = (id: string) => {
+      calls++;
+      return { js: ["/assets/Once.js"], css: [] };
+    };
+    sharedConfig.context = context;
+
+    const LazyOnce = lazy(
+      () => Promise.resolve({ default: (_props: any) => "once" }),
+      undefined,
+      "./Once.tsx"
+    );
+    await LazyOnce.preload!();
+    await LazyOnce.preload!();
+    createRoot(
+      () => {
+        LazyOnce({});
+      },
+      { id: "t" }
+    );
+
+    expect(calls).toBe(1);
+  });
+
   test("lazy() with moduleUrl classifies .css URLs as style", async () => {
     const { lazy } = await import("../../src/server/component.js");
 
@@ -3908,6 +3973,8 @@ describe("Asset Manifest + lazy()", () => {
     const Comp = (props: any) => "styled";
     const LazyComp = lazy(() => Promise.resolve({ default: Comp }), undefined, "./Styled.tsx");
     await LazyComp.preload!();
+    // preload() now hints the module too; this case covers the render pass.
+    registered.length = 0;
 
     createRoot(
       () => {
@@ -4031,6 +4098,8 @@ describe("Asset Manifest + lazy()", () => {
     const Comp = (props: any) => "dev";
     const LazyComp = lazy(() => Promise.resolve({ default: Comp }), undefined, "./Dev.tsx");
     await LazyComp.preload!();
+    // preload() now hints the module too; this case covers the render pass.
+    registered.length = 0;
 
     createRoot(
       () => {
@@ -4067,6 +4136,8 @@ describe("Asset Manifest + lazy()", () => {
     const Comp = (props: any) => "async-dev";
     const LazyComp = lazy(() => Promise.resolve({ default: Comp }), undefined, "./AsyncDev.tsx");
     await LazyComp.preload!();
+    // preload() now hints the module too; this case covers the render pass.
+    registered.length = 0;
 
     let thunk: any;
     createRoot(
@@ -4091,7 +4162,15 @@ describe("Asset Manifest + lazy()", () => {
     await resolverDeferred.promise;
     await Promise.resolve();
 
+    // Both the preload hint and the render registration settle here, and both
+    // must restore the owning boundary.
     expect(registered).toEqual([
+      {
+        type: "inline-style",
+        value: { id: "/src/AsyncDev.css", content: ".a{}" },
+        boundary: "b-owner"
+      },
+      { type: "module", value: "/src/AsyncDev.tsx", boundary: "b-owner" },
       {
         type: "inline-style",
         value: { id: "/src/AsyncDev.css", content: ".a{}" },
@@ -4168,7 +4247,11 @@ describe("Asset Manifest + lazy()", () => {
     // macrotask instead of counting ticks.
     await new Promise(r => setTimeout(r));
 
+    // The glob fallback now hints from preload() as well, once the import
+    // exposes $$moduleUrl, and again from the render.
     expect(registered).toEqual([
+      { type: "inline-style", value: { id: "/src/Glob.css", content: ".g{}" } },
+      { type: "module", value: "/src/Glob.tsx" },
       { type: "inline-style", value: { id: "/src/Glob.css", content: ".g{}" } },
       { type: "module", value: "/src/Glob.tsx" }
     ]);


### PR DESCRIPTION
## Summary

This follows up on [dom-expressions#573](https://github.com/ryansolid/dom-expressions/pull/573), which added `modulepreload` links for the entry's static import graph.

The remaining gap was lazy route modules. On the server, `lazy().preload()` started the dynamic import but did not register any client assets. JS and CSS links only appeared once the component rendered, so route preloading could not make those assets available to the initial document.

`preload()` now also registers the module's full static JS/CSS closure with the SSR asset pipeline.

When a router knows the matched route chain before rendering, those modulepreload and stylesheet links can be included in the first shell, letting the browser discover the whole chain together.

This keeps the existing behavior around hydration and streaming:

- `registerModule` stays in the render path because its hydration key is only known there
- `NoHydration` still registers CSS, but skips client modulepreloads
- asset resolution never delays or replaces the import promise; resolver failures only warn
- async resolution keeps the boundary that initiated it
- manifest results are resolved once per module per request and shared with the render path

Assets are registered again when the component renders so CSS keeps the correct boundary attribution. Duplicate links are removed by the existing asset registry.

Only static JS and CSS imports are included. Dynamic imports remain demand-driven, so code splitting is unchanged.

This targets `next`, where the Solid 2.0 SSR asset pipeline lives.

Media assets such as fonts and images are intentionally out of scope. They can be added separately once `ResolvedAssets` has a typed hint format for `as`, `type`, and `crossorigin`.

## How did you test this change?

Added unit coverage for:

- preloading assets without rendering the component
- keeping `registerModule` in the render path
- sharing one manifest resolution across repeated `preload()` calls and a later render
- `$$moduleUrl`, async resolution, boundary restoration, and resolver failure handling

Added end-to-end streaming coverage for:

- a preloaded route that never renders still contributing its modulepreload and stylesheet links to the shell
- the same flow under `NoHydration` contributing CSS without client JS

Validation:

- Full test and typecheck run with Turbo `--force` — 27/27 tasks passed, 0 cached
- Solid — 19 files, 556 tests passed
- Solid Web browser — 40 files, 416 tests passed
- Solid Web server — 30 files, 282 tests passed, 2 skipped
- Solid Web hydration — 20 files, 137 tests passed
- TypeScript, Prettier, and `git diff --check` passed