### PR TITLE
feat(signals): UNSTABLE_MEMO_OUTPUT attribution warning

### DIFF
--- a/.changeset/attribution-unstable-memo-output.md
+++ b/.changeset/attribution-unstable-memo-output.md
@@ -1,0 +1,13 @@
+---
+"@solidjs/signals": patch
+---
+
+Add the `UNSTABLE_MEMO_OUTPUT` dev attribution warning. A memo that commits a
+referentially-new but shallowly-equivalent plain object or array on
+consecutive runs (default 4) has an equality gate that never closes, so every
+subscriber re-runs on every upstream change — the fan-out amplifier that was
+previously only findable by profiling. Engine-side only: the check compares
+the value snapshotted at `recomputeStart` against the committed value at
+`recomputeEnd`, skips non-plain shapes (a fresh Promise per run is a genuinely
+new value) and overlay runs, and warns once per streak. Configure or disable
+via `DEV.attribution.enable({ unstableMemos })`.

--- a/packages/solid-signals/src/core/attribution.ts
+++ b/packages/solid-signals/src/core/attribution.ts
@@ -1,5 +1,5 @@
 import { setAttributionHooks, type AttributionHooks } from "./attribution-hooks.js";
-import { $REFRESH } from "./constants.js";
+import { $REFRESH, NOT_PENDING } from "./constants.js";
 // Cycle note: dev.ts imports this module for the `attribution` object, and we
 // import its hoisted emitDiagnostic back — safe (only called at runtime) and
 // treeshake-neutral (dev.ts is already reachable from the core).
@@ -121,6 +121,15 @@ export interface AttributionOptions {
    * scope that run counts miss. `false` disables.
    */
   hotTime?: { budgetMs: number; windowMs: number } | false;
+  /**
+   * Unstable-output warning: emit a diagnostic when a memo commits a
+   * referentially-new but shallowly-equivalent plain object/array on this
+   * many consecutive runs (default 4). Such a memo's equality gate never
+   * closes — every subscriber re-runs on every upstream change — which makes
+   * it a fan-out amplifier that is otherwise only findable by profiling.
+   * `false` disables.
+   */
+  unstableMemos?: number | false;
 }
 
 interface AttributedNode {
@@ -134,6 +143,8 @@ interface AttributedNode {
   _devTimeWinStart?: number;
   _devTimeWinMs?: number;
   _devTimeWarned?: boolean;
+  _devUnstableRuns?: number;
+  _devUnstableWarned?: boolean;
 }
 
 let attributionActive = false;
@@ -146,7 +157,8 @@ const defaultOptions = {
   historyLimit: 200,
   hotRuns: { count: 120, windowMs: 1000 } as { count: number; windowMs: number } | false,
   wideDeps: 30 as number | false,
-  hotTime: { budgetMs: 8, windowMs: 1000 } as { budgetMs: number; windowMs: number } | false
+  hotTime: { budgetMs: 8, windowMs: 1000 } as { budgetMs: number; windowMs: number } | false,
+  unstableMemos: 4 as number | false
 };
 let options: typeof defaultOptions = { ...defaultOptions };
 const listeners = new Set<(event: RerunEvent) => void>();
@@ -164,6 +176,8 @@ interface RunFrame {
   childMs: number;
   causes: ChangeRecord[] | null; // null on create runs
   prevDeps: unknown[] | null;
+  /** Committed value before this run — baseline for the unstable-output check. */
+  prevValue: unknown;
 }
 const frames: RunFrame[] = [];
 
@@ -529,6 +543,83 @@ export interface Attribution {
   format: typeof formatRerun;
 }
 
+/**
+ * Values eligible for the unstable-output check: plain objects and arrays
+ * only. Promises, iterators, Dates, Maps, class instances etc. all have no
+ * (or unrepresentative) own enumerable keys, so a shallow compare would
+ * false-positive on them — a fresh Promise is a genuinely new value.
+ */
+function isPlainShape(v: unknown): v is object {
+  if (v === null || typeof v !== "object") return false;
+  if (Array.isArray(v)) return true;
+  const proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
+}
+
+/** Shallow structural equivalence, capped so hot paths stay cheap. */
+const UNSTABLE_KEY_CAP = 64;
+function shallowEquivalent(a: object, b: object): boolean {
+  const aArr = Array.isArray(a);
+  if (aArr !== Array.isArray(b)) return false;
+  if (aArr) {
+    const arrA = a as unknown[];
+    const arrB = b as unknown[];
+    if (arrA.length !== arrB.length || arrA.length > UNSTABLE_KEY_CAP) return false;
+    for (let i = 0; i < arrA.length; i++) if (arrA[i] !== arrB[i]) return false;
+    return true;
+  }
+  const keys = Object.keys(a);
+  if (keys.length > UNSTABLE_KEY_CAP || keys.length !== Object.keys(b).length) return false;
+  for (const key of keys) {
+    if (!(key in b) || (a as Record<string, unknown>)[key] !== (b as Record<string, unknown>)[key])
+      return false;
+  }
+  return true;
+}
+
+/**
+ * Unstable-output warning — the fan-out amplifier signature: a memo whose
+ * committed value is referentially new but structurally identical run after
+ * run has an equality gate that never closes, so ALL its subscribers re-run
+ * on EVERY upstream change. Checked only on plain (non-overlay) changed runs;
+ * a genuinely different value (or a non-plain shape) resets the streak.
+ */
+function checkUnstableOutput(el: Computed<any>, prevValue: unknown, newValue: unknown): void {
+  const limit = options.unstableMemos;
+  // typeof guard: an explicit `unstableMemos: undefined` in enable() options
+  // clobbers the default through the spread — treat any non-number as off.
+  if (typeof limit !== "number") return;
+  const node = el as AttributedNode;
+  if (
+    prevValue === newValue || // paranoia: changed runs should never hit this
+    !isPlainShape(prevValue) ||
+    !isPlainShape(newValue) ||
+    !shallowEquivalent(prevValue, newValue)
+  ) {
+    node._devUnstableRuns = 0;
+    node._devUnstableWarned = false;
+    return;
+  }
+  node._devUnstableRuns = (node._devUnstableRuns ?? 0) + 1;
+  if (node._devUnstableWarned || node._devUnstableRuns < limit) return;
+  node._devUnstableWarned = true;
+  const shape = Array.isArray(newValue) ? "array" : "object";
+  const message =
+    `[UNSTABLE_MEMO_OUTPUT] memo "${nodeName(el)}" produced a new-but-equivalent ${shape} on ` +
+    `${node._devUnstableRuns} consecutive runs — its equality gate never closes, so every ` +
+    `subscriber re-runs on every upstream change. Return stable references or pass an ` +
+    `\`equals\` option.`;
+  emitDiagnostic({
+    code: "UNSTABLE_MEMO_OUTPUT",
+    kind: "perf",
+    severity: "warn",
+    message,
+    nodeName: nodeName(el),
+    data: { runs: node._devUnstableRuns, shape }
+  });
+  console.warn(message);
+}
+
 // The engine's implementation of the core's dev hook points. Installed by
 // enable(), uninstalled by disable() — while uninstalled the core pays one
 // null check per site and nothing else.
@@ -541,7 +632,10 @@ const engineHooks: AttributionHooks = {
       start: now(),
       childMs: 0,
       causes: create ? null : collectCauses(el),
-      prevDeps: create ? null : captureDeps(el)
+      prevDeps: create ? null : captureDeps(el),
+      // Mirror recompute's own prev-value resolution: an earlier run in the
+      // same flush may still be holding in _pendingValue.
+      prevValue: el._pendingValue !== NOT_PENDING ? el._pendingValue : el._value
     });
   },
   derivedChanged(el) {
@@ -555,6 +649,23 @@ const engineHooks: AttributionHooks = {
     const totalMs = now() - frame.start;
     if (frames.length > 0) frames[frames.length - 1].childMs += totalMs;
     const selfMs = Math.max(0, totalMs - frame.childMs);
+    // Unstable-output check: memos only, non-create, plain runs with a
+    // committed change. The fresh value sits in `_pendingValue` for held
+    // plain-flush memo commits and in `_value` for direct ones. Overlay runs
+    // are excluded — an optimistic re-derive legitimately produces fresh
+    // equivalents while the lane settles.
+    if (
+      frame.causes !== null &&
+      changed &&
+      !optimistic &&
+      !transition &&
+      !(el as { _type?: number })._type
+    )
+      checkUnstableOutput(
+        el,
+        frame.prevValue,
+        el._pendingValue !== NOT_PENDING ? el._pendingValue : el._value
+      );
     if (frame.causes !== null)
       recordRerun(
         el,

--- a/packages/solid-signals/src/core/dev.ts
+++ b/packages/solid-signals/src/core/dev.ts
@@ -35,7 +35,8 @@ export type DiagnosticCode =
   | "HUGE_FAN_IN"
   | "HOT_SCOPE_RERUNS"
   | "HOT_SCOPE_TIME"
-  | "WIDE_SCOPE_DEPS";
+  | "WIDE_SCOPE_DEPS"
+  | "UNSTABLE_MEMO_OUTPUT";
 
 export type DiagnosticKind =
   | "strict-read"

--- a/packages/solid-signals/tests/attribution-unstable-memo.test.ts
+++ b/packages/solid-signals/tests/attribution-unstable-memo.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEffect, createMemo, createRoot, createSignal, DEV, flush } from "../src/index.js";
+import type { DiagnosticEvent } from "../src/core/dev.js";
+
+afterEach(() => {
+  DEV!.attribution.disable();
+  flush();
+  vi.restoreAllMocks();
+});
+
+/** Enable quietly and capture UNSTABLE_MEMO_OUTPUT diagnostics. */
+function captureUnstable(unstableMemos: number | false = 4) {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  DEV!.attribution.enable({ log: false, hotRuns: false, hotTime: false, unstableMemos });
+  const events: DiagnosticEvent[] = [];
+  DEV!.diagnostics.subscribe(e => {
+    if (e.code === "UNSTABLE_MEMO_OUTPUT") events.push(e);
+  });
+  return events;
+}
+
+describe("UNSTABLE_MEMO_OUTPUT", () => {
+  it("warns when a memo produces new-but-equivalent objects on consecutive runs", () => {
+    const [n, setN] = createSignal(1, { name: "n" });
+    const view = createMemo(
+      // Fresh object every run, content never actually varies:
+      () => ({ positive: n() > 0, label: "user" }),
+      { name: "view" }
+    );
+    createRoot(() =>
+      createEffect(
+        () => view(),
+        () => {},
+        { name: "consumer" }
+      )
+    );
+    flush();
+
+    const events = captureUnstable();
+    for (let i = 2; i <= 8; i++) {
+      setN(i);
+      flush();
+    }
+
+    expect(events).toHaveLength(1); // warned once at the threshold, then muted
+    expect(events[0].nodeName).toBe("view");
+    expect(events[0].data).toMatchObject({ runs: 4, shape: "object" });
+    expect(events[0].message).toContain("equality gate never closes");
+    expect(events[0].message).toContain("`equals` option");
+  });
+
+  it("warns for equivalent fresh arrays", () => {
+    const [n, setN] = createSignal(1, { name: "n" });
+    const list = createMemo(() => ["a", "b", n() > 0], { name: "list" });
+    createRoot(() =>
+      createEffect(
+        () => list(),
+        () => {},
+        { name: "consumer" }
+      )
+    );
+    flush();
+
+    const events = captureUnstable();
+    for (let i = 2; i <= 6; i++) {
+      setN(i);
+      flush();
+    }
+
+    expect(events).toHaveLength(1);
+    expect(events[0].data).toMatchObject({ shape: "array" });
+  });
+
+  it("resets the streak when the output genuinely changes", () => {
+    const [n, setN] = createSignal(0, { name: "n" });
+    // Content changes every third run — streak never reaches the threshold.
+    const view = createMemo(() => ({ bucket: Math.floor(n() / 3) }), { name: "resetting" });
+    createRoot(() =>
+      createEffect(
+        () => view(),
+        () => {},
+        { name: "consumer" }
+      )
+    );
+    flush();
+
+    const events = captureUnstable(3);
+    for (let i = 1; i <= 12; i++) {
+      setN(i);
+      flush();
+    }
+
+    expect(events).toHaveLength(0);
+  });
+
+  it("stays quiet for stable references, primitives, and non-plain shapes", () => {
+    const [n, setN] = createSignal(1, { name: "n" });
+    const stable = { fixed: true };
+    createRoot(() => {
+      const a = createMemo(() => (n(), stable), { name: "stable-ref" });
+      const b = createMemo(() => n() % 2, { name: "primitive" });
+      const c = createMemo(() => (n(), new Date(0)), { name: "date" });
+      createEffect(
+        () => (a(), b(), c()),
+        () => {},
+        { name: "consumer" }
+      );
+    });
+    flush();
+
+    const events = captureUnstable();
+    for (let i = 2; i <= 10; i++) {
+      setN(i);
+      flush();
+    }
+
+    expect(events).toHaveLength(0);
+  });
+
+  it("can be disabled", () => {
+    const [n, setN] = createSignal(1, { name: "n" });
+    const view = createMemo(() => ({ on: n() > 0 }), { name: "view" });
+    createRoot(() =>
+      createEffect(
+        () => view(),
+        () => {},
+        { name: "consumer" }
+      )
+    );
+    flush();
+
+    const events = captureUnstable(false);
+    for (let i = 2; i <= 10; i++) {
+      setN(i);
+      flush();
+    }
+
+    expect(events).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Follow-up to #3018 (the "spec now" item from the warnings discussion): the fan-out amplifier detector.

## What it catches

A memo that commits a referentially-new but shallowly-equivalent plain object/array on N consecutive runs (default 4) has an equality gate that never closes — every subscriber re-runs on every upstream change. A wide memo with fresh object output is the single worst fan-out machine in real apps, and until now was only findable by profiling.

```
[UNSTABLE_MEMO_OUTPUT] memo "view" produced a new-but-equivalent object on 4
consecutive runs — its equality gate never closes, so every subscriber re-runs
on every upstream change. Return stable references or pass an `equals` option.
```

## Implementation — engine-side only, no new core hook sites

- `recomputeStart` snapshots the node's committed value into the existing per-run frame (mirroring recompute's own pending-aware prev resolution, since an earlier run in the same flush may still be holding in `_pendingValue`).
- The compare runs at `recomputeEnd`, not `derivedChanged`: that hook fires before the commit branches, when the new value is still a local inside `recompute`. By `recomputeEnd` it is observable via `_pendingValue`/`_value`, and the phase facts are in hand.
- **Plain objects and arrays only.** Promises, Dates, Maps, class instances have no representative own enumerable keys — a fresh Promise per run is a genuinely new value, not instability. Pinned by a test.
- **Phase-aware:** overlay (optimistic/transition) runs are excluded — a lane re-derive legitimately produces fresh equivalents while it settles.
- Key-capped at 64 so hot paths stay cheap; once per streak; a genuinely different value resets the streak (so a later regression warns again).
- Opt-out via `enable({ unstableMemos: false })`, threshold configurable.

One robustness fix surfaced by the tests: an explicit `undefined` in `enable()` options clobbers defaults through the spread, so the check treats any non-number as disabled rather than warning on run 1.

## Tests

5 new in `tests/attribution-unstable-memo.test.ts`: warns once at threshold (`runs: 4`) for fresh-equivalent objects; arrays; streak resets on genuine change; silence for stable refs / primitives / Dates; opt-out. solid-signals suite green (1323).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
