### PR TITLE
feat(signals): WIDE_WRITE attribution warning

### DIFF
--- a/.changeset/attribution-wide-write.md
+++ b/.changeset/attribution-wide-write.md
@@ -1,0 +1,14 @@
+---
+"@solidjs/signals": patch
+---
+
+Add the `WIDE_WRITE` dev attribution warning: a committed root invalidation
+(signal or store write, `refresh()`, async landing) reaching a node with at
+least 250 live subscribers (default) warns that every one re-runs this flush,
+and points at `createSelector`/`createProjection` for inverting keyed
+questions. Reads the dev-maintained subscriber count from the graph-size
+diagnostics — no new core sites — and is specced together with the always-on
+`HUGE_FAN_OUT` (link-time, 2000+) so the two never double-fire: once per node,
+re-warning only after the subscriber count doubles. Documented in the
+dev-diagnostics RFC. Configure or disable via
+`DEV.attribution.enable({ wideWrites })`.

--- a/documentation/solid-2.0/08-dev-diagnostics.md
+++ b/documentation/solid-2.0/08-dev-diagnostics.md
@@ -263,6 +263,8 @@ One source has grown an unusually large number of live subscribers (first warnin
 
 Always on in dev; maintained by the graph's link/unlink operations, so the counts reflect live edges (disposed subscribers don't count against the threshold).
 
+Related: `WIDE_WRITE` (below) fires at **write** time from a much lower threshold, but only while the attribution engine is enabled — static fan-out that never writes is harmless, so the write-time check can afford to be far more sensitive. `HUGE_FAN_OUT` is the always-on backstop for structure large enough to warn about even if it never changes.
+
 #### `HUGE_FAN_IN`
 
 **Message:** "Computation [name] has N sources. It will re-run when any of them change. …"
@@ -280,6 +282,16 @@ Perf-kind warnings emitted by the **attribution engine** — they only fire whil
 - `WIDE_SCOPE_DEPS`: a scope's dependency count reached 30 (re-warns after another 50% growth), with the source names listed.
 
 All three thresholds are configurable (or disable-able) through `enable()` options.
+
+#### `WIDE_WRITE`
+
+**Message:** "write to [name] reached N subscribers — every one re-runs this flush. …"
+
+A committed root invalidation — a signal or store write, a `refresh()`, or an async landing — reached a node with an unusually large number of live subscribers (default 250). Where the per-scope warnings above blame the *reader*, this one blames the *write*: it is the fan-out actually happening, priced at the moment it happens. The classic shape is many consumers asking keyed questions of one value (every row comparing against one selected id); the fix is inverting the subscription with `createSelector` or `createProjection` so only the keys whose answer flipped re-run.
+
+Attribution-engine only, like the trio above. Specced together with `HUGE_FAN_OUT` so the two never double-fire on one node: `HUGE_FAN_OUT` is always-on and fires at *link* time from 2000 subscribers up — structure so large it warns even if never written — while `WIDE_WRITE` fires at *write* time from a much lower bar, once per node, re-warning only after the subscriber count doubles. Unchanged writes never fire it (the source equality gate commits nothing and notifies no one). The check reads the same live `_subCount` the graph-size warnings maintain, so disposed subscribers don't count.
+
+Threshold configurable (or disable-able) via `enable({ wideWrites })`.
 
 ## Programmatic diagnostics API
 
@@ -367,7 +379,8 @@ DEV.attribution.enable({
   historyLimit: 200,  // ring buffer size
   hotRuns: { count: 120, windowMs: 1000 },   // or false
   hotTime: { budgetMs: 8, windowMs: 1000 },  // or false
-  wideDeps: 30                                // or false
+  wideDeps: 30,                               // or false
+  wideWrites: 250                             // or false
 });
 
 DEV.attribution.history();          // ring buffer of RerunEvents

--- a/packages/solid-signals/src/core/attribution.ts
+++ b/packages/solid-signals/src/core/attribution.ts
@@ -121,6 +121,19 @@ export interface AttributionOptions {
    * scope that run counts miss. `false` disables.
    */
   hotTime?: { budgetMs: number; windowMs: number } | false;
+  /**
+   * Written-fan-out warning: emit a diagnostic when a committed root
+   * invalidation (write, refresh, async landing) reaches a node with at
+   * least this many subscribers (default 250). Complements the always-on
+   * HUGE_FAN_OUT graph-size warning, specced against it deliberately:
+   * HUGE_FAN_OUT fires at LINK time from GRAPH_SIZE_WARN_AT (2000) up —
+   * static structure so large it warns even if never written — while this
+   * fires at WRITE time from a much lower bar, because fan-out only costs
+   * anything when the node actually changes. Once per node, re-warning only
+   * on 2x subscriber growth, so the two never spam the same node. `false`
+   * disables.
+   */
+  wideWrites?: number | false;
 }
 
 interface AttributedNode {
@@ -134,6 +147,7 @@ interface AttributedNode {
   _devTimeWinStart?: number;
   _devTimeWinMs?: number;
   _devTimeWarned?: boolean;
+  _devWideWriteWarnedAt?: number;
 }
 
 let attributionActive = false;
@@ -146,7 +160,8 @@ const defaultOptions = {
   historyLimit: 200,
   hotRuns: { count: 120, windowMs: 1000 } as { count: number; windowMs: number } | false,
   wideDeps: 30 as number | false,
-  hotTime: { budgetMs: 8, windowMs: 1000 } as { budgetMs: number; windowMs: number } | false
+  hotTime: { budgetMs: 8, windowMs: 1000 } as { budgetMs: number; windowMs: number } | false,
+  wideWrites: 250 as number | false
 };
 let options: typeof defaultOptions = { ...defaultOptions };
 const listeners = new Set<(event: RerunEvent) => void>();
@@ -268,6 +283,44 @@ function captureStack(): string[] | undefined {
 const NO_VALUES = Symbol("no-values");
 
 /** Record a root change (setSignal / refresh / async landing) on the node. */
+/**
+ * Written-fan-out warning — the write-time complement of the always-on
+ * HUGE_FAN_OUT link-time warning (see dev.ts). Static fan-out that never
+ * writes is harmless; a committed root invalidation reaching hundreds of
+ * subscribers re-runs all of them this flush. Uses the dev-maintained
+ * `_subCount` from the graph-size diagnostics — no core sites touched.
+ * Once per node; re-warns only when the subscriber count has doubled since
+ * the last warning, so it cannot spam alongside HUGE_FAN_OUT's own
+ * 2000-and-up milestones.
+ */
+function checkWideWrite(
+  node: Signal<any> | Computed<any>,
+  kind: Exclude<ChangeKind, "derived">
+): void {
+  const limit = options.wideWrites;
+  if (typeof limit !== "number") return;
+  const subs = node._subCount ?? 0;
+  const attributed = node as AttributedNode;
+  if (subs < limit || subs < (attributed._devWideWriteWarnedAt ?? 0) * 2) return;
+  attributed._devWideWriteWarnedAt = subs;
+  const verb =
+    kind === "refresh" ? "refresh of" : kind === "async" ? "async landing on" : "write to";
+  const message =
+    `[WIDE_WRITE] ${verb} "${nodeName(node)}" reached ${subs} subscribers — every one ` +
+    `re-runs this flush. If consumers ask keyed questions of this value (for example every ` +
+    `row comparing against one selected id), invert with createSelector or createProjection ` +
+    `so only the keys whose answer flipped update.`;
+  emitDiagnostic({
+    code: "WIDE_WRITE",
+    kind: "perf",
+    severity: "warn",
+    message,
+    nodeName: nodeName(node),
+    data: { subscribers: subs, write: kind }
+  });
+  console.warn(message);
+}
+
 function stampWrite(
   node: Signal<any> | Computed<any>,
   kind: Exclude<ChangeKind, "derived">,
@@ -281,6 +334,10 @@ function stampWrite(
   }
   record.stack = captureStack();
   (node as AttributedNode)._devChange = record;
+  // stampWrite is the single funnel for committed root invalidations (sync
+  // writes, refresh(), async landings), which makes it the one place the
+  // written-fan-out check needs to live.
+  checkWideWrite(node, kind);
 }
 
 /** Record a derived change (memo produced a new value) with its causes. */

--- a/packages/solid-signals/src/core/dev.ts
+++ b/packages/solid-signals/src/core/dev.ts
@@ -35,7 +35,8 @@ export type DiagnosticCode =
   | "HUGE_FAN_IN"
   | "HOT_SCOPE_RERUNS"
   | "HOT_SCOPE_TIME"
-  | "WIDE_SCOPE_DEPS";
+  | "WIDE_SCOPE_DEPS"
+  | "WIDE_WRITE";
 
 export type DiagnosticKind =
   | "strict-read"

--- a/packages/solid-signals/tests/attribution-wide-write.test.ts
+++ b/packages/solid-signals/tests/attribution-wide-write.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createEffect,
+  createMemo,
+  createRoot,
+  createSignal,
+  DEV,
+  flush,
+  refresh
+} from "../src/index.js";
+import type { DiagnosticEvent } from "../src/core/dev.js";
+
+afterEach(() => {
+  DEV!.attribution.disable();
+  flush();
+  vi.restoreAllMocks();
+});
+
+/** Enable quietly and capture WIDE_WRITE diagnostics. */
+function captureWideWrites(wideWrites: number | false = 250) {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  DEV!.attribution.enable({ log: false, hotRuns: false, hotTime: false, wideWrites });
+  const events: DiagnosticEvent[] = [];
+  DEV!.diagnostics.subscribe(e => {
+    if (e.code === "WIDE_WRITE") events.push(e);
+  });
+  return events;
+}
+
+function subscribeN(read: () => unknown, n: number): void {
+  createRoot(() => {
+    for (let i = 0; i < n; i++) {
+      createEffect(read, () => {});
+    }
+  });
+  flush();
+}
+
+describe("WIDE_WRITE", () => {
+  it("warns once when a write reaches the subscriber threshold", () => {
+    const [selectedId, setSelectedId] = createSignal(0, { name: "selectedId" });
+    subscribeN(() => selectedId(), 30);
+
+    const events = captureWideWrites(25);
+    setSelectedId(1);
+    flush();
+    setSelectedId(2); // same node, same size — muted
+    flush();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].nodeName).toBe("selectedId");
+    expect(events[0].data).toMatchObject({ subscribers: 30, write: "write" });
+    expect(events[0].message).toContain("createSelector or createProjection");
+  });
+
+  it("re-warns only after the subscriber count doubles", () => {
+    const [n, setN] = createSignal(0, { name: "n" });
+    subscribeN(() => n(), 30);
+
+    const events = captureWideWrites(25);
+    setN(1);
+    flush();
+    expect(events).toHaveLength(1);
+
+    subscribeN(() => n(), 25); // 55 total — under 2x of 30
+    setN(2);
+    flush();
+    expect(events).toHaveLength(1);
+
+    subscribeN(() => n(), 10); // 65 total — past 2x of 30
+    setN(3);
+    flush();
+    expect(events).toHaveLength(2);
+    expect(events[1].data!.subscribers as number).toBeGreaterThanOrEqual(60);
+  });
+
+  it("fires for refresh() invalidations of wide memos", () => {
+    const [n] = createSignal(1, { name: "n" });
+    const doubled = createMemo(() => n() * 2, { name: "doubled" });
+    subscribeN(() => doubled(), 30);
+
+    const events = captureWideWrites(25);
+    refresh(doubled);
+    flush();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].nodeName).toBe("doubled");
+    expect(events[0].data).toMatchObject({ write: "refresh" });
+    expect(events[0].message).toContain('refresh of "doubled"');
+  });
+
+  it("stays quiet under the threshold and for unchanged writes", () => {
+    const [n, setN] = createSignal(0, { name: "n" });
+    subscribeN(() => n(), 30);
+
+    const events = captureWideWrites(31);
+    setN(1); // 30 subscribers < 31
+    flush();
+    expect(events).toHaveLength(0);
+
+    const wide = captureWideWrites(25);
+    setN(1); // equality gate: same value commits nothing, stamps nothing
+    flush();
+    expect(wide).toHaveLength(0);
+  });
+
+  it("can be disabled", () => {
+    const [n, setN] = createSignal(0, { name: "n" });
+    subscribeN(() => n(), 30);
+
+    const events = captureWideWrites(false);
+    setN(1);
+    flush();
+    expect(events).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Follow-up to #3018: the written-fan-out warning, implemented per the review guidance — via the dev-maintained `_subCount` from the graph-size diagnostics, no core sites touched, specced together with `HUGE_FAN_OUT` so the two never double-fire.

## What it catches

A committed root invalidation — sync write, `refresh()`, or async landing — reaching a node with ≥ 250 live subscribers (default). Where the per-scope warnings blame the *reader*, this one blames the *write*: the fan-out actually happening, priced at the moment it happens.

```
[WIDE_WRITE] write to "selectedId" reached 1000 subscribers — every one re-runs
this flush. If consumers ask keyed questions of this value (for example every row
comparing against one selected id), invert with createSelector or createProjection
so only the keys whose answer flipped update.
```

## Reconciliation with `HUGE_FAN_OUT`

- `HUGE_FAN_OUT`: always-on, fires at **link** time from `GRAPH_SIZE_WARN_AT` (2000) up — structure so large it warns even if never written.
- `WIDE_WRITE`: attribution-only, fires at **write** time from a much lower bar (250), because fan-out only costs anything when the node actually changes. Once per node, re-warning only after the subscriber count doubles — so a node that trips both gets at most one `WIDE_WRITE` alongside `HUGE_FAN_OUT`'s own milestones.
- Documented in `documentation/solid-2.0/08-dev-diagnostics.md`, with a `Related:` cross-reference under `HUGE_FAN_OUT` that mirrors the existing `HUGE_FAN_IN` ↔ `WIDE_SCOPE_DEPS` pairing.

## Implementation

One placement decision worth a look: the check lives in the engine's `stampWrite` rather than directly in the `write` hook. `stampWrite` is the single funnel for all committed root invalidations (writes, `refresh()`, async landings), so one call site covers all three — and inherits a correctness property for free: `setSignal` only stamps after the equality gate, so unchanged writes (which notify nobody) can never warn. The message's verb (`write to` / `refresh of` / `async landing on`) and `data.write` carry the kind.

## Tests

5 new in `tests/attribution-wide-write.test.ts`: warns once at threshold with muting on repeat writes; re-warns only after 2× subscriber growth (30 → 55 silent, → 65 warns); fires for `refresh()` of a wide memo; quiet under threshold and for equality-gated unchanged writes; opt-out. solid-signals suite green (1323).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
