### PR TITLE
chore: sync pnpm-lock.yaml with examples/chat

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,9 +144,6 @@ importers:
       marked:
         specifier: ^12.0.2
         version: 12.0.2
-      marked-highlight:
-        specifier: ^2.2.4
-        version: 2.2.4(marked@12.0.2)
       solid-js:
         specifier: workspace:*
         version: link:../../packages/solid
@@ -2717,11 +2714,6 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
-
-  marked-highlight@2.2.4:
-    resolution: {integrity: sha512-PZxisNMJDduSjc0q6uvjsnqqHCXc9s0eyzxDO9sB1eNGJnd/H1/Fu+z6g/liC1dfJdFW4SftMwMlLvsBhUPrqQ==}
-    peerDependencies:
-      marked: '>=4 <19'
 
   marked@12.0.2:
     resolution: {integrity: sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==}
@@ -6113,10 +6105,6 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
-
-  marked-highlight@2.2.4(marked@12.0.2):
-    dependencies:
-      marked: 12.0.2
 
   marked@12.0.2: {}
 


### PR DESCRIPTION
`aa3b9fe3` removed `marked-highlight` from `examples/chat/package.json` without regenerating `pnpm-lock.yaml`, so CI's `pnpm install --frozen-lockfile` fails at the install step for every PR against `next` right now (#3034 and #3035 are both red for this reason alone, before any of their own checks run).

Regenerated with `pnpm install --lockfile-only`; the delta is exactly the 12 stale `marked-highlight` lockfile lines, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
