### PR TITLE
Backfill in-flight value when latest() companion is created mid-transition

### DIFF
--- a/.changeset/latest-lazy-companion-backfill.md
+++ b/.changeset/latest-lazy-companion-backfill.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+`latest()` now returns the in-flight value when first called during a held transition. The latest-value companion is created lazily, and a write processed before its creation was never pushed into it, so the first `latest()` read inside a transition (e.g. a pending banner gated on `isPending()`) showed the committed value until the next write. The companion now backfills the pending value on creation, matching `isPending()`.

--- a/packages/solid-signals/src/core/verdict.ts
+++ b/packages/solid-signals/src/core/verdict.ts
@@ -338,6 +338,10 @@ function getLatestValueComputed<T>(el: Signal<T> | Computed<T>): Computed<T> {
     setContextInternal(null); // Detach from owner so it isn't disposed with effects
     el._latestValueComputed = optimisticComputed(() => read(el));
     el._latestValueComputed._parentSource = el; // Parent-child lane relationship
+    // Backfill an in-flight write (mirrors getPendingSignal): the companion is
+    // created lazily, possibly after the write was processed (#3041).
+    if (el._pendingValue !== NOT_PENDING && !hasActiveOverride(el))
+      setSignal(el._latestValueComputed, el._pendingValue as T);
     if (__DEV__) devTrackCompanionOwner(el);
     setContextInternal(prevContext);
     setPendingCheckActive(prevCheck);

--- a/packages/solid-signals/tests/latest-lazy-companion-backfill.test.ts
+++ b/packages/solid-signals/tests/latest-lazy-companion-backfill.test.ts
@@ -1,0 +1,78 @@
+/**
+ * #3041: latest() first called during a held transition returned the committed
+ * value. The latest-value companion is created lazily; syncCompanions only
+ * pushes an in-flight write into companions that already exist, and the
+ * companion's initial compute under a stale render effect sees _value.
+ * getLatestValueComputed now backfills _pendingValue, mirroring getPendingSignal.
+ */
+import {
+  createMemo,
+  createRenderEffect,
+  createRoot,
+  createSignal,
+  flush,
+  isPending,
+  latest
+} from "../src/index.js";
+
+it("latest() first read during a held transition sees in-flight value (#3041)", async () => {
+  let resolve!: (v: string) => void;
+  const fetch = (n: string) =>
+    new Promise<string>(r => {
+      resolve = r;
+    });
+  let seen: string[] = [];
+  createRoot(() => {
+    const [query, setQuery] = createSignal("pikachu");
+    const pokemon = createMemo(() => fetch(query()));
+    createRenderEffect(
+      () => {
+        const p = isPending(() => pokemon());
+        // latest() is NOT called until pending — companion created lazily inside transition
+        return p ? latest(() => query()) : "idle:" + (pokemon() as any);
+      },
+      v => {
+        seen.push(String(v));
+      }
+    );
+    (globalThis as any).setQuery = setQuery;
+  });
+  flush();
+  resolve("pikachu");
+  await new Promise(r => setTimeout(r, 0));
+  flush();
+  seen = [];
+  (globalThis as any).setQuery("charizard");
+  flush();
+  expect(seen).toEqual(["charizard"]);
+});
+
+it("control: companion pre-warmed before transition", async () => {
+  let resolve!: (v: string) => void;
+  const fetch = (n: string) =>
+    new Promise<string>(r => {
+      resolve = r;
+    });
+  let seen: string[] = [];
+  let setQuery!: (v: string) => void;
+  createRoot(() => {
+    const [query, s] = createSignal("pikachu");
+    setQuery = s;
+    const pokemon = createMemo(() => fetch(query()));
+    latest(() => query()); // warm
+    createRenderEffect(
+      () => (isPending(() => pokemon()) ? latest(() => query()) : "idle"),
+      v => {
+        seen.push(String(v));
+      }
+    );
+  });
+  flush();
+  resolve("pikachu");
+  await new Promise(r => setTimeout(r, 0));
+  flush();
+  seen = [];
+  setQuery("charizard");
+  flush();
+  expect(seen).toEqual(["charizard"]);
+});


### PR DESCRIPTION
Fixes #3041

## Problem

`latest(() => query())` first called *during* a held transition returned the committed value instead of the in-flight one. The reporter's case: a "Now loading: {latest(query)}" banner gated on `isPending()` showed the previous pokemon's name.

`getLatestValueComputed` creates the latest-value companion lazily with `optimisticComputed(() => read(el))` and no backfill. Under an optimistic lane with a stale (render-effect) reader, `read(el)` resolves to `_value`, so the companion captures the committed value. `syncCompanions` only pushes a pending write into companions that already exist at write time — so a companion born after the write never learns it. `getPendingSignal` already backfills on creation, which is why `isPending()` was correct on first use while `latest()` wasn't.

## Fix

Seed the companion from `_pendingValue` on creation (guarded by `!hasActiveOverride`, since overrides are already authoritative through `read()`'s A17 path), mirroring `getPendingSignal`.

## Test

`latest-lazy-companion-backfill.test.ts` — lazy-creation case (failed before, passes now) plus a pre-warmed control. Full solid-signals suite green (1336 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)