### PR TITLE
fix(signals): suspend stale readers on an uninitialized memo held by another transition

### DIFF
--- a/.changeset/stale-read-uninitialized-cross-transition.md
+++ b/.changeset/stale-read-uninitialized-cross-transition.md
@@ -1,0 +1,16 @@
+---
+"@solidjs/signals": patch
+---
+
+Suspend stale readers on an uninitialized async memo held by another
+transition. A render effect that switched onto an async memo still in flight
+under a *different* transaction took the "show the committed value, don't
+entangle" path — but an uninitialized memo has no committed value, so the
+reader was served `undefined` as if settled and left stamped into neither
+transaction. It never re-ran when either landed and stuck on its old value
+(e.g. a globally cached async memo shared by two inputs updated 300ms apart).
+Such reads now throw NotReady like the equivalent firewall-backed read already
+did, registering the reader with the active transaction so the two
+transactions merge and reveal together. Regression from the
+`needsPendingCommit` gate in 7d4d0c3a (beta.11), which removed the accidental
+pending-node stamp that used to entangle the reader.

--- a/packages/solid-signals/src/core/core.ts
+++ b/packages/solid-signals/src/core/core.ts
@@ -968,7 +968,17 @@ export function read<T>(el: Signal<T> | Computed<T>): T {
         if (!tracking && el !== c) link(el, c as Computed<any>);
         throw owner._error;
       }
-    } else if (c && owner !== el && owner._statusFlags & STATUS_UNINITIALIZED) {
+    } else if (c && owner._statusFlags & STATUS_UNINITIALIZED) {
+      // A stale (render) reader of a node held pending in ANOTHER transition
+      // normally keeps showing the node's committed value instead of
+      // entangling the two transactions — but an uninitialized node has no
+      // committed value to show. Suspend on it (firewall-backed store reads
+      // always took this branch; plain memos now do too): the reader
+      // registers as a reporter of that source, and its
+      // pending-node stamp ties it to the active transaction, so the two
+      // transactions merge when the source settles. Falling through served
+      // `undefined` as if settled and stranded the reader outside both
+      // transactions, so it never re-ran when either landed.
       if (!tracking && el !== c) link(el, c as Computed<any>);
       throw owner._error;
     } else if (!c && owner._statusFlags & STATUS_UNINITIALIZED) {

--- a/packages/solid-signals/tests/stale-read-uninitialized-cross-transition.test.ts
+++ b/packages/solid-signals/tests/stale-read-uninitialized-cross-transition.test.ts
@@ -1,0 +1,145 @@
+// A stale (render) reader that lands on an async memo which is pending in a
+// DIFFERENT transition normally keeps showing that memo's committed value
+// (no entanglement). An UNINITIALIZED memo has no committed value to show:
+// falling through served `undefined` as if settled and left the reader
+// stamped into neither transaction, so it never re-ran when either landed.
+//
+//   effA: a -> memo("foo" + a)          setA(1) opens T1 (memo foo1 in flight)
+//   effB: b -> memo("foo" + b)          setB(1) opens T2; effB now reads foo1,
+//   effC: b -> memo("bar" + b)            held in T1, while bar1 holds T2
+//
+// Memos are cached by key so effB picks up the very instance effA created.
+// Repro shape from the s.olid.uk playground report (cached async memo +
+// staggered clicks); regression bisected to 7d4d0c3a, whose needsPendingCommit
+// gate removed the accidental pending-node stamp that used to entangle effB.
+import { describe, expect, it } from "vitest";
+import {
+  createLoadingBoundary,
+  createMemo,
+  createRenderEffect,
+  createRoot,
+  createSignal,
+  flush
+} from "../src/index.js";
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>(r => (resolve = r));
+  return { promise, resolve };
+}
+
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+  flush();
+}
+
+describe("stale reader of an uninitialized memo held by another transition", () => {
+  it("suspends and entangles instead of serving undefined and stranding the reader", async () => {
+    const [a, setA] = createSignal(0);
+    const [b, setB] = createSignal(0);
+    const gates: Record<string, ReturnType<typeof deferred<void>>> = {};
+    const cache: Record<string, () => string> = {};
+    const get = (k: string) =>
+      (cache[k] ??= createMemo(async () => {
+        await (gates[k] ??= deferred<void>()).promise;
+        return k;
+      }));
+
+    const outA: unknown[] = [];
+    const outB: unknown[] = [];
+    const outC: unknown[] = [];
+    createRoot(() => {
+      createLoadingBoundary(
+        () => {
+          createRenderEffect(
+            () => get("foo" + a())(),
+            v => void outA.push(v)
+          );
+          createRenderEffect(
+            () => get("foo" + b())(),
+            v => void outB.push(v)
+          );
+          createRenderEffect(
+            () => get("bar" + b())(),
+            v => void outC.push(v)
+          );
+        },
+        () => "fallback"
+      );
+    });
+    flush();
+    gates.foo0.resolve();
+    gates.bar0.resolve();
+    await settle();
+    expect([outA, outB, outC]).toEqual([["foo0"], ["foo0"], ["bar0"]]);
+
+    // T1: effA moves onto the in-flight foo1 memo.
+    setA(1);
+    flush();
+    // T2: effC moves onto bar1; effB moves onto foo1 — uninitialized, held by T1.
+    setB(1);
+    flush();
+    // No "settled undefined" leaks out of the hold.
+    expect([outA, outB, outC]).toEqual([["foo0"], ["foo0"], ["bar0"]]);
+
+    // foo1 lands while bar1 still holds: effB is entangled, nothing reveals yet.
+    gates.foo1.resolve();
+    await settle();
+    expect([outA, outB, outC]).toEqual([["foo0"], ["foo0"], ["bar0"]]);
+
+    gates.bar1.resolve();
+    await settle();
+    expect(outA).toEqual(["foo0", "foo1"]);
+    expect(outB).toEqual(["foo0", "foo1"]);
+    expect(outC).toEqual(["bar0", "bar1"]);
+  });
+
+  it("still shows the committed value (no entanglement) when the held memo is initialized", async () => {
+    // Control: the reader's new dependency already has a committed value, so
+    // the stale-read rule applies and the transitions stay independent.
+    const [a, setA] = createSignal(0);
+    const [pick, setPick] = createSignal(0);
+    const gate = deferred<void>();
+    let resolveNow = true;
+    const shared = createMemo(async () => {
+      const v = a();
+      if (!resolveNow) await gate.promise;
+      return "v" + v;
+    });
+    const other = createMemo(() => "other");
+
+    const out: unknown[] = [];
+    createRoot(() => {
+      createLoadingBoundary(
+        () =>
+          createRenderEffect(
+            () => (pick() ? shared() : other()),
+            v => void out.push(v)
+          ),
+        () => "fallback"
+      );
+    });
+    flush();
+    expect(out).toEqual(["other"]);
+    // Initialize `shared` by reading it once through a reader.
+    createRoot(() =>
+      createRenderEffect(
+        () => shared(),
+        () => {}
+      )
+    );
+    await settle();
+
+    resolveNow = false;
+    setA(1); // T1: shared goes pending (in flight) holding "v0".
+    flush();
+    setPick(1); // T2: reader switches onto shared — shows committed "v0", no suspend.
+    flush();
+    expect(out).toEqual(["other", "v0"]);
+
+    gate.resolve();
+    await settle();
+    expect(out).toEqual(["other", "v0", "v1"]);
+  });
+});


### PR DESCRIPTION
## Summary
- A render effect that switches onto an async memo still in flight under a *different* transaction hit the "stale reader shows the committed value, don't entangle" path in `read()`. An uninitialized memo has no committed value, so the reader got `undefined` as if settled, direct-committed outside both transactions, and never re-ran when either landed — stuck on its old value forever.
- Repro shape (s.olid.uk playground report): a global `cache[k] ??= createMemo(async …)` shared by several inserts, `setA` then `setB` 300ms later where B's new key is the memo A already put in flight. Worked on beta.10, broke in beta.11.
- Fix: drop `owner !== el` from the `STATUS_UNINITIALIZED` throw branch so plain memos suspend the way firewall-backed store reads already did. The reader registers as a reporter and the two transactions merge and reveal together.
- Regression bisected to 7d4d0c3a: its (correct) `needsPendingCommit` gate removed an accidental pending-node push that `initTransition` had been stamping with `_transition`, which was what entangled the reader before.

## Test plan
- [x] New `tests/stale-read-uninitialized-cross-transition.test.ts` — fails without the fix; includes a control showing an *initialized* held memo still shows its committed value without entangling
- [x] `@solidjs/signals` suite: 1336 pass
- [x] `solid-js` suite: 561 pass
- [x] Original DOM repro (three `<div>` inserts under `<Loading>`) and variants end `foo1 foo1 bar1`

Note: 5 solid-web tests (`frames-behavior-claims`, `server-functions-csrf/extensions`, `welcome-status-loaded/streamed`) fail identically with and without this change on the published dom-expressions `0.50.0-next.43` — the committed `link:../dom-expressions-dr2/...` overrides in `pnpm-workspace.yaml`/lockfile from 515ff561 only resolve on a machine with that checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)