### PR TITLE
perf(signals): skip empty companion walks

### DIFF
--- a/.changeset/calm-signals-walk.md
+++ b/.changeset/calm-signals-walk.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Improve store update performance when async companion signals are not observed.

--- a/packages/solid-signals/src/core/async.ts
+++ b/packages/solid-signals/src/core/async.ts
@@ -710,7 +710,7 @@ export function clearStatus(el: Computed<any>, clearUninitialized: boolean = fal
   // Update pending signal for isPending() reactivity (companions only exist
   // once the verdict layer created them, which installs the hooks).
   if (el._pendingSignal || el._latestValueComputed) GlobalQueue._updatePendingSignal!(el);
-  if (el._child && GlobalQueue._updateChildCompanions !== null)
+  if (el._hasChildCompanions && GlobalQueue._updateChildCompanions !== null)
     GlobalQueue._updateChildCompanions(el);
   if (el._notifyStatus) el._notifyStatus();
 }
@@ -751,7 +751,7 @@ export function notifyStatus(
       el._error = error;
     }
     GlobalQueue._updatePendingSignal !== null && GlobalQueue._updatePendingSignal(el);
-    if (el._child && GlobalQueue._updateChildCompanions !== null)
+    if (el._hasChildCompanions && GlobalQueue._updateChildCompanions !== null)
       GlobalQueue._updateChildCompanions(el);
   }
 

--- a/packages/solid-signals/src/core/core.ts
+++ b/packages/solid-signals/src/core/core.ts
@@ -297,7 +297,7 @@ export function recompute(el: Computed<any>, create: boolean = false): void {
       el._pendingSources !== undefined ||
       el._pendingSignal !== undefined ||
       el._latestValueComputed !== undefined ||
-      el._child !== null
+      el._hasChildCompanions
     )
       clearStatus(el, create);
     // _optimisticLane is only ever assigned by engine paths.
@@ -562,6 +562,7 @@ export function computed<T>(
     _value: (loading ? options!.loadingValue : undefined) as T,
     _height: 0,
     _child: null,
+    _hasChildCompanions: false,
     _nextHeap: undefined,
     _prevHeap: null as any,
     _deps: null,
@@ -622,6 +623,7 @@ export function createEffectNode<T>(
     _value: undefined as T,
     _height: 0,
     _child: null,
+    _hasChildCompanions: false,
     _nextHeap: undefined,
     _prevHeap: null as any,
     _deps: null,

--- a/packages/solid-signals/src/core/types.ts
+++ b/packages/solid-signals/src/core/types.ts
@@ -136,6 +136,8 @@ export interface Computed<T> extends RawSignal<T>, Owner {
   _fn: (prev?: T) => T;
   _inFlight: PromiseLike<T> | AsyncIterable<T> | null;
   _child: FirewallSignal<any> | null;
+  /** True once a firewall child creates an isPending() or latest() companion. */
+  _hasChildCompanions: boolean;
   _notifyStatus?: (status?: number, error?: any) => void;
   /**
    * Question-scoped pending classification of the node's CURRENT pending

--- a/packages/solid-signals/src/core/verdict.ts
+++ b/packages/solid-signals/src/core/verdict.ts
@@ -68,6 +68,12 @@ interface PendingProbe {
 }
 let pendingProbe: PendingProbe | null = null;
 
+function registerChildCompanion(el: Signal<any> | Computed<any>): void {
+  const firewall = (el as FirewallSignal<any>)._firewall;
+  if (firewall && !el._pendingSignal && !el._latestValueComputed)
+    firewall._hasChildCompanions = true;
+}
+
 /**
  * Probes whose verdict was suppressed by the fresh-read pairing rule while
  * the held write's fate was still undecided (see recordFreshRead /
@@ -82,6 +88,7 @@ const suppressedProbes: Map<Signal<any> | Computed<any>, Set<Computed<any>>> = n
  */
 function getPendingSignal(el: Signal<any> | Computed<any>): Signal<boolean> {
   if (!el._pendingSignal) {
+    registerChildCompanion(el);
     // Start false, write true if pending - ensures reversion returns to false
     el._pendingSignal = optimisticSignal(false, { ownedWrite: true });
     el._pendingSignal._parentSource = el;
@@ -330,6 +337,7 @@ function snapCompanionsToState(owner: Signal<any> | Computed<any>): void {
 
 function getLatestValueComputed<T>(el: Signal<T> | Computed<T>): Computed<T> {
   if (!el._latestValueComputed) {
+    registerChildCompanion(el);
     const prevPending = latestReadActive;
     setLatestReadActive(false);
     const prevCheck = pendingCheckActive;

--- a/packages/solid-signals/tests/child-companion-walk.test.ts
+++ b/packages/solid-signals/tests/child-companion-walk.test.ts
@@ -1,0 +1,38 @@
+import { computed, read, recompute, signal } from "../src/core/core.js";
+import { isPending, latest } from "../src/core/verdict.js";
+import type { FirewallSignal } from "../src/core/types.js";
+
+function countChildWalks<T>(child: FirewallSignal<T>): () => number {
+  let walks = 0;
+  Object.defineProperty(child, "_nextChild", {
+    configurable: true,
+    get() {
+      walks++;
+      return null;
+    }
+  });
+  return () => walks;
+}
+
+it("skips firewall children without verdict companions", () => {
+  const firewall = computed(() => 0);
+  const child = signal(0, undefined, firewall);
+  const walks = countChildWalks(child);
+
+  recompute(firewall);
+  expect(walks()).toBe(0);
+
+  expect(isPending(() => read(child))).toBe(false);
+  recompute(firewall);
+  expect(walks()).toBe(1);
+});
+
+it("walks firewall children after latest creates a companion", () => {
+  const firewall = computed(() => 0);
+  const child = signal(0, undefined, firewall);
+  const walks = countChildWalks(child);
+
+  expect(latest(() => read(child))).toBe(0);
+  recompute(firewall);
+  expect(walks()).toBe(1);
+});


### PR DESCRIPTION
## Summary

- track whether a firewall child has ever materialized an async companion
- skip the child-chain companion walk while no `isPending()` or `latest()` reader exists
- keep the walk enabled once either companion is created, with regression coverage for both paths

Fixes #3038

## How did you test this change?

- `pnpm --filter @solidjs/signals build`
- `pnpm --filter @solidjs/signals test`
- `pnpm --filter solid-js build`
- `pnpm --filter solid-js test`
- `pnpm --filter solid-js test-types`
- Prettier check for the changed files
- Re-ran the issue benchmark across no-reader, narrow, and wide/deep store shapes; the no-reader path no longer scales with the materialized child chain