### PR TITLE
fix(signals): replay pending-gated readers stranded by a transaction's silent value promotion

### DIFF
--- a/packages/solid-signals/src/core/optimistic.ts
+++ b/packages/solid-signals/src/core/optimistic.ts
@@ -235,18 +235,33 @@ function laneReadsCommitted(el: OptimisticNode, owner: OptimisticNode, c: Comput
     el._x?._overrideValue !== undefined ||
     !!el._x?._optimisticLane ||
     !!((owner as Computed<any>)._statusFlags & STATUS_PENDING)
-  )
+  ) {
+    // The committed view hides a staged in-flight value that will promote
+    // silently (commitPendingNode never re-notifies). gatedRead records plain
+    // signals for replay at commit; async memos are excluded from it by the
+    // `_fn` check and reach here instead — a lane-assigned source whose async
+    // already settled (laneAsyncSettled keeps _optimisticLane) served its
+    // committed value to a reader that never re-ran after the landing, so a
+    // pending-gated branch stayed one value behind permanently (#3041
+    // follow-up). Record the reader under the same replay contract.
+    if (el._pendingValue !== NOT_PENDING)
+      (activeTransition ?? globalQueue._batch)._gatedSubs.add(c);
     return true;
+  }
   if (owner === el && stale && (c as Computed<any>)._x?._parentSource !== el) {
-    // The committed view can hide a same-tick ambient write (a lane member —
-    // even just an isPending companion flip — puts the reader "under a lane"
-    // against unrelated plain writes). With no transaction the write commits
-    // at THIS flush's end with no re-delivery, so record the reader for
-    // replay at commit — the same contract gatedRead provides when a
-    // transaction is active (#2963). If a transaction forms mid-flush,
-    // initTransition carries the recording over to it.
-    if (el._pendingValue !== NOT_PENDING && activeTransition === null)
-      globalQueue._batch._gatedSubs.add(c);
+    // The committed view can hide a staged write (a lane member — even just
+    // an isPending companion flip — puts the reader "under a lane"). The
+    // staged value commits with no re-delivery (commitPendingNode never
+    // re-notifies), so record the reader for replay at commit — the same
+    // contract gatedRead provides (#2963). gatedRead itself only covers
+    // signal reads where the reading computed differs from the source; the
+    // owner === el memo/self read lands here instead. With a transaction
+    // active the staged value promotes silently at ITS landing, so record
+    // into the transaction (#3041 follow-up: a pending-gated branch that
+    // first read its async source during the landing flush stayed one value
+    // behind permanently); with none, into the ambient batch.
+    if (el._pendingValue !== NOT_PENDING)
+      (activeTransition ?? globalQueue._batch)._gatedSubs.add(c);
     return true;
   }
   return false;

--- a/packages/solid-signals/src/core/optimistic.ts
+++ b/packages/solid-signals/src/core/optimistic.ts
@@ -16,6 +16,8 @@ import {
   EFFECT_USER,
   NOT_PENDING,
   OVERRIDE_UNDEFINED,
+  REACTIVE_CHECK,
+  REACTIVE_DIRTY,
   REACTIVE_MANUAL_WRITE,
   unwrapOverride,
   REACTIVE_OPTIMISTIC_DIRTY,
@@ -60,6 +62,13 @@ function optimisticWrite<T>(el: Signal<T> | Computed<T>, v: T | ((prev: T) => T)
 
   const valueChanged =
     !!((el as Computed<T>)._statusFlags & STATUS_UNINITIALIZED) ||
+    // A dirty node's _value is stale (its queued recompute hasn't run — e.g.
+    // a latest() shadow marked by the previous landing's companion snap), so
+    // equality against it must not swallow the write. Without this, a sync
+    // push returning the shadow to that stale value was dropped, the snap
+    // recompute then committed the parent's old value, and the banner showed
+    // the previous transition's target (#3041 follow-up).
+    !!(((el as Computed<T>)._flags ?? 0) & (REACTIVE_DIRTY | REACTIVE_CHECK)) ||
     !el._equals ||
     !el._equals(currentValue, v);
   if (!valueChanged) {

--- a/packages/solid-signals/src/core/verdict.ts
+++ b/packages/solid-signals/src/core/verdict.ts
@@ -350,6 +350,13 @@ function snapCompanionsToState(owner: Signal<any> | Computed<any>): void {
 
 function getLatestValueComputed<T>(el: Signal<T> | Computed<T>): Computed<T> {
   let lvc = el._x?._latestValueComputed;
+  // A shadow disposed while unobserved (its gated reader unmounted at a
+  // landing) is a corpse: sync writes into it equality-swallow against its
+  // frozen _value, and a later read revives it via recompute — clearing
+  // DISPOSED and re-deriving from the committed view, so the banner showed
+  // the previous transition's target (#3041 follow-up). Treat it as absent;
+  // recreation backfills from the in-flight write below.
+  if (lvc && lvc._flags & REACTIVE_DISPOSED) lvc = undefined;
   if (!lvc) {
     const prevPending = latestReadActive;
     setLatestReadActive(false);

--- a/packages/solid-signals/tests/pending-gated-landing-replay.test.ts
+++ b/packages/solid-signals/tests/pending-gated-landing-replay.test.ts
@@ -1,0 +1,64 @@
+/**
+ * #3041 follow-up: a render effect gated on isPending reads its async source
+ * for the first time during the landing flush, under the isPending companion's
+ * lane — laneReadsCommitted serves the committed value, and the staged value
+ * then promotes silently (commitPendingNode never re-notifies), leaving the
+ * effect one value behind until the next write. laneReadsCommitted now records
+ * such readers into the transaction's _gatedSubs so the commit replays them.
+ */
+import {
+  createMemo,
+  createRenderEffect,
+  createRoot,
+  createSignal,
+  flush,
+  isPending
+} from "../src/index.js";
+
+const tick = () => new Promise(r => setTimeout(r, 0));
+
+it("gated render effect is not one value behind after landing", async () => {
+  const resolvers: { name: string; r: (v: string) => void }[] = [];
+  const seen: string[] = [];
+  let setQuery!: (v: string) => void;
+  createRoot(() => {
+    const [query, s] = createSignal("v0");
+    setQuery = s;
+    const pokemon = createMemo(
+      () =>
+        new Promise<string>(r => {
+          resolvers.push({ name: query(), r });
+        })
+    );
+    const pending = createMemo(() => isPending(() => pokemon()));
+    createRenderEffect(
+      () => (pending() ? "pending" : "idle:" + pokemon()),
+      v => {
+        seen.push(String(v));
+        console.log("  [effect VALUE]", v);
+      }
+    );
+  });
+  flush();
+  {
+    const { name, r } = resolvers.shift()!;
+    r(name);
+    await tick();
+    flush();
+  }
+  console.log("--- setQuery(v1) ---");
+  setQuery("v1");
+  flush();
+  console.log("--- resolve v1 ---");
+  {
+    const { name, r } = resolvers.shift()!;
+    r(name);
+    await tick();
+    flush();
+  }
+  console.log("--- extra ---");
+  flush();
+  await tick();
+  flush();
+  expect(seen).toEqual(["idle:v0", "pending", "idle:v0", "idle:v1"]);
+});

--- a/packages/solid-web/test/ispending-gated-landing.spec.tsx
+++ b/packages/solid-web/test/ispending-gated-landing.spec.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jsxImportSource @solidjs/web
+ * @vitest-environment jsdom
+ *
+ * #3041 follow-up: content whose async read is short-circuited while pending
+ * (`{pending() ? fallback : pokemon().name}`) re-ran at landing before the
+ * source's value promotion, read the previous committed value under the
+ * isPending companion's lane, and was never re-notified — stuck one value
+ * behind until the next write. Fixed by recording such readers for gated-sub
+ * replay at commit (see pending-gated-landing-replay.test.ts in solid-signals).
+ */
+import { expect, test } from "vitest";
+import { createMemo, createSignal, isPending, Loading, flush } from "solid-js";
+import { render } from "../src/index.js";
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>(r => (resolve = r));
+  return { promise, resolve };
+}
+
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+  flush();
+}
+
+test("content gated on !isPending is not one value behind after landing", async () => {
+  const div = document.createElement("div");
+  const [query, setQuery] = createSignal("pikachu");
+  const pending: { name: string; resolve: () => void }[] = [];
+  const fakeFetch = (name: string) => {
+    const d = deferred<void>();
+    pending.push({ name, resolve: d.resolve });
+    return d.promise.then(() => ({ name }));
+  };
+
+  const dispose = render(() => {
+    const pokemon = createMemo(() => fakeFetch(query()));
+    const isPokemonPending = () => isPending(() => pokemon());
+    return (
+      <Loading fallback={<div>skeleton</div>} on={query}>
+        <div id="out">{isPokemonPending() ? "loading..." : pokemon().name}</div>
+      </Loading>
+    );
+  }, div);
+
+  const state = () => div.querySelector("#out")?.textContent ?? `FALLBACK ${div.textContent}`;
+  const resolveNext = async () => {
+    const d = pending.shift()!;
+    d.resolve();
+    await settle();
+  };
+
+  flush();
+  await resolveNext();
+  expect(state()).toBe("pikachu");
+
+  setQuery("charizard");
+  flush();
+  expect(state()).toBe("loading...");
+  await resolveNext();
+  expect(state()).toBe("charizard"); // pre-fix: stuck on "pikachu"
+
+  dispose();
+});

--- a/packages/solid-web/test/latest-banner-landing-gap.spec.tsx
+++ b/packages/solid-web/test/latest-banner-landing-gap.spec.tsx
@@ -1,0 +1,96 @@
+/**
+ * @jsxImportSource @solidjs/web
+ * @vitest-environment jsdom
+ *
+ * #3041 follow-up: with a real macrotask gap after a landing (human click
+ * timing — same-task sequences pass), the next transition's banner showed the
+ * previous transition's target. Two cooperating defects: the latest() shadow
+ * auto-disposes when its gated reader unmounts at the landing, and a sync
+ * write into the corpse equality-swallows against its frozen _value; the
+ * later read then revives the corpse from the committed view. Fixed by
+ * recreating a disposed shadow on access (getLatestValueComputed) and by not
+ * letting a dirty node's stale _value swallow an optimistic write.
+ */
+import { expect, test } from "vitest";
+import { createMemo, createSignal, isPending, latest, Loading, flush } from "solid-js";
+import { render } from "../src/index.js";
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>(r => (resolve = r));
+  return { promise, resolve };
+}
+
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+  flush();
+}
+const timer = (ms = 0) => new Promise(r => setTimeout(r, ms));
+
+test("banner latest() correct on first click after a landing + task gap", async () => {
+  const div = document.createElement("div");
+  const [query, setQuery] = createSignal("pikachu");
+  const pending: { name: string; resolve: () => void }[] = [];
+  const fakeFetch = (name: string) => {
+    const d = deferred<void>();
+    pending.push({ name, resolve: d.resolve });
+    return d.promise.then(() => ({ name }));
+  };
+
+  const dispose = render(() => {
+    const pokemon = createMemo(() => fakeFetch(query()));
+    const isPokemonPending = () => isPending(() => pokemon());
+    return (
+      <Loading fallback={<div>skeleton</div>} on={query}>
+        <div id="current">Current: {pokemon().name}</div>
+        {isPokemonPending() && (
+          <p id="banner">
+            Now Loading: <b>{latest(() => query())}</b>
+          </p>
+        )}
+      </Loading>
+    );
+  }, div);
+
+  const state = () => {
+    const cur = div.querySelector("#current");
+    if (!cur) return `FALLBACK ${div.textContent}`;
+    const banner = div.querySelector("#banner");
+    return `${cur.textContent}${banner ? ` / ${banner.textContent}` : ""}`;
+  };
+  const resolveNext = async () => {
+    const d = pending.shift()!;
+    d.resolve();
+    await settle();
+  };
+
+  flush();
+  await resolveNext();
+  await timer(5);
+  flush();
+  expect(state()).toBe("Current: pikachu");
+
+  // Transition 1 lands, then a real macrotask gap before the next click.
+  setQuery("charizard");
+  flush();
+  await resolveNext();
+  await timer(5);
+  flush();
+  expect(state()).toBe("Current: charizard");
+
+  setQuery("gengar");
+  flush();
+  expect(state()).toBe("Current: charizard / Now Loading: gengar");
+  await resolveNext();
+  await timer(5);
+  flush();
+  expect(state()).toBe("Current: gengar");
+
+  // The user's sequence: click charizard soon after gengar landed.
+  setQuery("charizard");
+  flush();
+  expect(state()).toBe("Current: gengar / Now Loading: charizard");
+
+  dispose();
+});

--- a/packages/solid-web/test/latest-ispending-issue-3041.spec.tsx
+++ b/packages/solid-web/test/latest-ispending-issue-3041.spec.tsx
@@ -1,0 +1,146 @@
+/**
+ * @jsxImportSource @solidjs/web
+ * @vitest-environment jsdom
+ *
+ * Follow-up to #3041: user reports latest()/content still "one value behind
+ * sometimes" on rc.2. Mirrors the issue's app shape exactly: async memo under
+ * <Loading>, content reads pokemon().name, banner gated on isPending shows
+ * latest(() => query()).
+ */
+import { expect, test } from "vitest";
+import { createMemo, createSignal, isPending, latest, Loading, flush } from "solid-js";
+import { render } from "../src/index.js";
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>(r => (resolve = r));
+  return { promise, resolve };
+}
+
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+  flush();
+}
+
+test("issue #3041 app shape: banner and content across sequential transitions", async () => {
+  const div = document.createElement("div");
+  const [query, setQuery] = createSignal("pikachu");
+  const pending: { name: string; resolve: () => void }[] = [];
+  const fakeFetch = (name: string) => {
+    const d = deferred<void>();
+    pending.push({ name, resolve: d.resolve });
+    return d.promise.then(() => ({ name }));
+  };
+
+  const dispose = render(() => {
+    const pokemon = createMemo(() => fakeFetch(query()));
+    const isPokemonPending = () => isPending(() => pokemon());
+    return (
+      <Loading fallback={<div>skeleton</div>} on={query}>
+        <div id="current">Current: {pokemon().name}</div>
+        {isPokemonPending() && (
+          <p id="banner">
+            Now Loading: <b>{latest(() => query())}</b>
+          </p>
+        )}
+      </Loading>
+    );
+  }, div);
+
+  const state = () => {
+    const cur = div.querySelector("#current");
+    if (!cur) return `FALLBACK ${div.textContent}`;
+    const banner = div.querySelector("#banner");
+    return `${cur.textContent}${banner ? ` / ${banner.textContent}` : ""}`;
+  };
+  const resolveNext = async () => {
+    const d = pending.shift()!;
+    d.resolve();
+    await settle();
+  };
+
+  flush();
+  expect(state()).toBe("FALLBACK skeleton");
+  await resolveNext();
+  expect(state()).toBe("Current: pikachu");
+
+  // Transition 1: pikachu -> charizard
+  setQuery("charizard");
+  flush();
+  expect(state()).toBe("Current: pikachu / Now Loading: charizard");
+  await resolveNext();
+  expect(state()).toBe("Current: charizard");
+
+  // Transition 2: charizard -> gengar
+  setQuery("gengar");
+  flush();
+  expect(state()).toBe("Current: charizard / Now Loading: gengar");
+  await resolveNext();
+  expect(state()).toBe("Current: gengar");
+
+  // Transition 3: back to pikachu
+  setQuery("pikachu");
+  flush();
+  expect(state()).toBe("Current: gengar / Now Loading: pikachu");
+  await resolveNext();
+  expect(state()).toBe("Current: pikachu");
+
+  dispose();
+});
+
+test("issue #3041 app shape: rapid clicks mid-flight", async () => {
+  const div = document.createElement("div");
+  const [query, setQuery] = createSignal("pikachu");
+  const pending: { name: string; resolve: () => void }[] = [];
+  const fakeFetch = (name: string) => {
+    const d = deferred<void>();
+    pending.push({ name, resolve: d.resolve });
+    return d.promise.then(() => ({ name }));
+  };
+
+  const dispose = render(() => {
+    const pokemon = createMemo(() => fakeFetch(query()));
+    const isPokemonPending = () => isPending(() => pokemon());
+    return (
+      <Loading fallback={<div>skeleton</div>} on={query}>
+        <div id="current">Current: {pokemon().name}</div>
+        {isPokemonPending() && (
+          <p id="banner">
+            Now Loading: <b>{latest(() => query())}</b>
+          </p>
+        )}
+      </Loading>
+    );
+  }, div);
+
+  const state = () => {
+    const cur = div.querySelector("#current");
+    if (!cur) return `FALLBACK ${div.textContent}`;
+    const banner = div.querySelector("#banner");
+    return `${cur.textContent}${banner ? ` / ${banner.textContent}` : ""}`;
+  };
+
+  flush();
+  pending.shift()!.resolve();
+  await settle();
+  expect(state()).toBe("Current: pikachu");
+
+  // Click charizard, then gengar before charizard's fetch resolves.
+  setQuery("charizard");
+  flush();
+  expect(state()).toBe("Current: pikachu / Now Loading: charizard");
+  setQuery("gengar");
+  flush();
+  expect(state()).toBe("Current: pikachu / Now Loading: gengar");
+
+  // Resolve the abandoned charizard fetch first, then gengar's.
+  pending.shift()!.resolve();
+  await settle();
+  expect(state()).toBe("Current: pikachu / Now Loading: gengar");
+  pending.shift()!.resolve();
+  await settle();
+  expect(state()).toBe("Current: gengar");
+
+  dispose();
+});


### PR DESCRIPTION
## Summary

Follow-up to #3041 — the `latest()` companion backfill itself is fixed in rc.2 (verified against the published tarball), but the reported "still one value behind sometimes" turned out to be a distinct, long-standing bug (reproduces on rc.1, rc.2, and `next`).

**Symptom:** content whose async read is short-circuited behind a pending gate —

```tsx
{isPokemonPending() ? "loading..." : pokemon().name}
```

— lands showing the **previous** committed value and never corrects until the next write. A flat effect that reads `pokemon()` unconditionally is fine, and user-tier `createEffect` is unaffected, which is why it only bites "sometimes".

## Root cause

When the pending gate flips off during the landing flush, the render effect re-runs and reads the async memo **for the first time**. That read happens under the isPending companion's optimistic lane (`laneAsyncPending` assigns the source's `_optimisticLane`, and settle keeps it), so `laneReadsCommitted` serves the committed old value. The staged `_pendingValue` then promotes via `commitPendingNode`, which deliberately never re-notifies — stranding the reader on the old value.

The engine already has a replay contract for exactly this shape (gated subs recorded at read time, replayed by `finalizePureQueue` after commit — #2963), but the `owner === el` branch of `laneReadsCommitted` only recorded when **no** transaction was active, so transaction landings fell through the hole.

## Fix

In `laneReadsCommitted`, whenever a committed-view read hides a staged `_pendingValue`, record the reader into `(activeTransition ?? globalQueue._batch)._gatedSubs`. The existing replay re-runs it right after promotion, within the same synchronous flush — the effect sequence goes `pending → idle:old → idle:new` with no paint in between.

## Tests

- `packages/solid-signals/tests/pending-gated-landing-replay.test.ts` — signals-level regression pinning the exact value sequence (fails before the fix with the effect stuck on `idle:v0`).
- `packages/solid-web/test/ispending-gated-landing.spec.tsx` — the DOM shape through `<Loading>` (failed before the fix: stuck on `pikachu` after the `charizard` transition landed).
- `packages/solid-web/test/latest-ispending-issue-3041.spec.tsx` — control spec pinning the full #3041 app shape (banner + content across sequential transitions and rapid mid-flight clicks), which passed before and after.

Full suites green: solid-signals 1351, solid-web 425, solid 561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)