### PR TITLE
fix: preserve wrapped module-level server exports

### DIFF
--- a/.changeset/preserve-module-server-wrappers.md
+++ b/.changeset/preserve-module-server-wrappers.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/compiler": patch
+---
+
+Preserve wrapper calls around module-level server function exports.

--- a/documentation/solid-2.0/10-server-functions.md
+++ b/documentation/solid-2.0/10-server-functions.md
@@ -33,7 +33,7 @@ export async function addTodo(title: string) {
 
 Two verified compiler behaviors anchor everything below:
 
-1. **Function-level directives round-trip wrapper calls.** `export const getData = GET(async (id) => { "use server"; ... })` compiles by swapping only the function expression — the surrounding `GET(...)` call survives in both server and client output. A pure-runtime wrapper needs no compiler support.
+1. **Wrapper calls round-trip.** `export const getData = GET(async (id) => { "use server"; ... })` compiles by swapping only the function expression, so the surrounding `GET(...)` call survives in both server and client output. Module-level directives preserve wrapped exports the same way and keep only the wrapper dependencies needed by the client.
 2. **Anything referenced only inside a `"use server"` body never reaches the client.** The extraction replaces the body with a reference, and the directive pass’s orphan-scoped dead-code elimination removes now-unused imports and bindings — schema libraries, database handles, helper imports all vanish from client output. **The directive boundary is itself the privacy mechanism.**
 
 One architectural fact worth stating: **a wrapper wraps the *reference*, not the registered function.** `registerServerReference(id, fn)` registers the raw inner function for HTTP dispatch before any wrapper runs, so wrapper-position code can only affect the client transport and the in-process callable — never HTTP dispatch. This is why anything that must run on the dispatch path (validation, auth, logging) belongs *inside* the body, and why the declaration surface (`GET`) is transport-only.
@@ -236,7 +236,7 @@ The boundary rule for future additions: **own the exchange, not the application 
 ### Compiler implications
 
 - **None, by design.** `GET` (like any in-body helper) is an ordinary runtime import; the wrapper round-trip and body-scoped DCE that make the design work are existing, verified behavior.
-- **One pre-existing bug to fix regardless:** with a *module-level* `"use server"` directive, a wrapped export (`export const x = wrapper(async () => ...)`) is silently dropped from the client build — only direct function exports become references. This gets more visible with `GET(fn)` as the blessed idiom. Minimum: a diagnostic; better: extract the inner function and preserve the call in client output.
+- **Module-level wrappers are compiler-generic:** a wrapped export (`export const x = wrapper(async () => ...)`) extracts the inner function and preserves the wrapper call in both outputs. The compiler does not recognize `GET` or any other wrapper by name.
 - **Shipped since first draft:** the third `registerServerReference(id, fn, name)` argument carrying the compiler-*static* dev `name` now exists on both proxies (development output only); it seeds the metadata channel as a default that explicit `withMeta`/`GET` writes shallow-merge over. Compiler-*produced* metadata flowing to the runtime — not a userland convention the compiler recognizes.
 
 ## Migration / replacement

--- a/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/code.js
+++ b/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/code.js
@@ -1,0 +1,14 @@
+"use server";
+import { GET, withMeta, wrap, serverOnly } from "./wrappers";
+import { db } from "./db";
+
+const cache = true;
+const metadata = { cache };
+
+export const getUser = withMeta(GET(async id => db.users.find(id)), metadata);
+
+const save = wrap(async function saveUser(user) {
+  return db.users.save(user);
+});
+
+export { save as saveUser };

--- a/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/expected.client.dev.js
+++ b/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/expected.client.dev.js
@@ -1,0 +1,9 @@
+import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
+import { GET, withMeta, wrap } from "./wrappers";
+const cache = true;
+const metadata = {
+  cache: cache
+};
+const fn_1 = withMeta(GET(createServerReference_1("64795c56-0-getUser", "getUser")), metadata),
+  fn_2 = wrap(createServerReference_1("64795c56-1-saveUser", "saveUser"));
+export { fn_1 as "getUser", fn_2 as "saveUser" };

--- a/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/expected.client.js
+++ b/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/expected.client.js
@@ -1,0 +1,9 @@
+import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
+import { GET, withMeta, wrap } from "./wrappers";
+const cache = true;
+const metadata = {
+  cache: cache
+};
+const fn_1 = withMeta(GET(createServerReference_1("64795c56-0")), metadata),
+  fn_2 = wrap(createServerReference_1("64795c56-1"));
+export { fn_1 as "getUser", fn_2 as "saveUser" };

--- a/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/expected.server.dev.js
+++ b/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/expected.server.dev.js
@@ -1,0 +1,15 @@
+import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
+import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
+import { GET, withMeta, wrap, serverOnly } from "./wrappers";
+import { db } from "./db";
+const cache = true;
+const metadata = {
+  cache: cache
+};
+const serverFunction_1 = registerServerReference_1("64795c56-0-getUser", async id => db.users.find(id), "getUser");
+export const getUser = withMeta(GET(createServerReference_1(serverFunction_1)), metadata);
+const serverFunction_2 = registerServerReference_1("64795c56-1-saveUser", async function saveUser(user) {
+  return db.users.save(user);
+}, "saveUser");
+const save = wrap(createServerReference_1(serverFunction_2));
+export { save as saveUser };

--- a/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/expected.server.js
+++ b/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/expected.server.js
@@ -1,0 +1,15 @@
+import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
+import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
+import { GET, withMeta, wrap, serverOnly } from "./wrappers";
+import { db } from "./db";
+const cache = true;
+const metadata = {
+  cache: cache
+};
+const serverFunction_1 = registerServerReference_1("64795c56-0", async id => db.users.find(id));
+export const getUser = withMeta(GET(createServerReference_1(serverFunction_1)), metadata);
+const serverFunction_2 = registerServerReference_1("64795c56-1", async function saveUser(user) {
+  return db.users.save(user);
+});
+const save = wrap(createServerReference_1(serverFunction_2));
+export { save as saveUser };

--- a/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/meta.json
+++ b/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/meta.json
@@ -1,0 +1,19 @@
+{
+  "valid": true,
+  "functions": [
+    {
+      "id": "64795c56-0",
+      "name": "getUser",
+      "exports": [
+        "getUser"
+      ]
+    },
+    {
+      "id": "64795c56-1",
+      "name": "saveUser",
+      "exports": [
+        "saveUser"
+      ]
+    }
+  ]
+}

--- a/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/output.client.js
+++ b/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/output.client.js
@@ -1,0 +1,6 @@
+import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
+import { GET, withMeta, wrap } from "./wrappers";
+const cache = true;
+const metadata = { cache };
+const fn_1 = withMeta(GET(createServerReference_1("64795c56-0")), metadata), fn_2 = wrap(createServerReference_1("64795c56-1"));
+export { fn_1 as "getUser", fn_2 as "saveUser" };

--- a/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/output.server.js
+++ b/packages/compiler/__tests__/directives/fixtures/module-wrapped-exports/output.server.js
@@ -1,0 +1,13 @@
+import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
+import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
+import { GET, withMeta, wrap, serverOnly } from "./wrappers";
+import { db } from "./db";
+const cache = true;
+const metadata = { cache };
+const serverFunction_1 = registerServerReference_1("64795c56-0", async (id) => db.users.find(id));
+export const getUser = withMeta(GET(createServerReference_1(serverFunction_1)), metadata);
+const serverFunction_2 = registerServerReference_1("64795c56-1", async function saveUser(user) {
+	return db.users.save(user);
+});
+const save = wrap(createServerReference_1(serverFunction_2));
+export { save as saveUser };

--- a/packages/compiler/src/directives/transform.rs
+++ b/packages/compiler/src/directives/transform.rs
@@ -15,10 +15,10 @@
 //! naming (`serverFunction_1`, `fn_1`, `registerServerReference_1`, ...)
 //! and statement ordering.
 
-use oxc_allocator::{Allocator, Vec as ArenaVec};
+use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
 use oxc_ast::ast::{
     BindingPattern, Declaration, ExportDefaultDeclarationKind, Expression, FunctionType,
-    ImportOrExportKind, Program, Statement, VariableDeclarationKind,
+    ImportDeclarationSpecifier, ImportOrExportKind, Program, Statement, VariableDeclarationKind,
 };
 use oxc_ast_visit::{VisitMut, walk_mut};
 use oxc_span::Span;
@@ -485,10 +485,43 @@ impl<'a> DirectivesTransform<'a> {
             source_ids.push((key, id, name));
         }
 
-        // The client build keeps none of the module: every export becomes a
-        // reference and everything else (server-only imports, helpers,
-        // secrets) is dropped wholesale.
+        let mut wrapper_dependencies = std::collections::HashSet::new();
+        let mut wrapped_initializers = Vec::new();
+        for (key, id, name) in &source_ids {
+            if !binding_init_is_wrapped(program, *key) {
+                continue;
+            }
+            let create_local = self.import_local(RuntimeImport::Create);
+            let mut create_args = vec![self.string(id)];
+            if let Some(name_argument) = self.dev_name_argument(name) {
+                create_args.push(name_argument);
+            }
+            let replacement = self.call(&create_local, create_args);
+            let Some(slot) = binding_init_function_slot(program, *key) else {
+                continue;
+            };
+            *slot = replacement;
+            let Some(initializer) = take_binding_initializer(self.allocator, program, *key) else {
+                continue;
+            };
+            collect_referenced_names(&initializer, &mut wrapper_dependencies);
+            wrapped_initializers.push((*key, initializer));
+        }
+
+        let excluded = source_ids.iter().map(|(key, _, _)| *key).collect();
+        let preserved_bindings = clone_referenced_bindings(
+            self.allocator,
+            program,
+            &mut wrapper_dependencies,
+            &excluded,
+        );
+        let preserved_imports =
+            take_referenced_imports(self.allocator, program, &wrapper_dependencies);
+
+        // Rebuild the client module from wrapper dependencies and references.
         program.body = ast.vec();
+        program.body.extend(preserved_imports);
+        program.body.extend(preserved_bindings);
 
         let mut declared: Vec<(BindingKey, String)> = Vec::new();
         let mut declarators = ast.vec();
@@ -504,18 +537,26 @@ impl<'a> DirectivesTransform<'a> {
                 };
                 let fn_id = fn_id.clone();
                 let name = name.clone();
-                let create_local = self.import_local(RuntimeImport::Create);
-                let mut create_args = vec![self.string(&fn_id)];
-                if let Some(name_argument) = self.dev_name_argument(&name) {
-                    create_args.push(name_argument);
-                }
+                let initializer = if let Some(index) = wrapped_initializers
+                    .iter()
+                    .position(|(wrapped_key, _)| wrapped_key == key)
+                {
+                    wrapped_initializers.remove(index).1
+                } else {
+                    let create_local = self.import_local(RuntimeImport::Create);
+                    let mut create_args = vec![self.string(&fn_id)];
+                    if let Some(name_argument) = self.dev_name_argument(&name) {
+                        create_args.push(name_argument);
+                    }
+                    self.call(&create_local, create_args)
+                };
                 let ast = self.ast();
                 declarators.push(ast.variable_declarator(
                     SPAN,
                     VariableDeclarationKind::Const,
                     ast.binding_pattern_binding_identifier(SPAN, ast.ident(&local)),
                     None,
-                    Some(self.call(&create_local, create_args)),
+                    Some(initializer),
                     false,
                 ));
                 declared.push((*key, local.clone()));
@@ -918,8 +959,61 @@ fn is_valid_function(expression: &Expression<'_>) -> bool {
     )
 }
 
-/// Babel's `traceBinding`: follow identifier-initialized declarators to a
-/// declarator whose init is a function/arrow expression.
+fn nested_function_count(expression: &Expression<'_>) -> u8 {
+    let expression = unwrap_expression(expression);
+    if is_valid_function(expression) {
+        return 1;
+    }
+    let Expression::CallExpression(call) = expression else {
+        return 0;
+    };
+    call.arguments.iter().fold(0, |count, argument| {
+        let Some(expression) = argument.as_expression() else {
+            return count;
+        };
+        count
+            .saturating_add(nested_function_count(expression))
+            .min(2)
+    })
+}
+
+fn nested_function<'e, 'a>(expression: &'e Expression<'a>) -> Option<&'e Expression<'a>> {
+    if nested_function_count(expression) != 1 {
+        return None;
+    }
+    let expression = unwrap_expression(expression);
+    if is_valid_function(expression) {
+        return Some(expression);
+    }
+    let Expression::CallExpression(call) = expression else {
+        return None;
+    };
+    call.arguments
+        .iter()
+        .filter_map(|argument| argument.as_expression())
+        .find_map(nested_function)
+}
+
+fn nested_function_mut<'e, 'a>(
+    expression: &'e mut Expression<'a>,
+) -> Option<&'e mut Expression<'a>> {
+    if nested_function_count(expression) != 1 {
+        return None;
+    }
+    let expression = unwrap_expression_mut(expression);
+    if is_valid_function(expression) {
+        return Some(expression);
+    }
+    let Expression::CallExpression(call) = expression else {
+        return None;
+    };
+    call.arguments
+        .iter_mut()
+        .filter_map(|argument| argument.as_expression_mut())
+        .find_map(nested_function_mut)
+}
+
+/// Follows aliases to a direct or call-wrapped function initializer.
 fn trace_binding(
     program: &Program<'_>,
     bindings: &std::collections::HashMap<String, BindingKey>,
@@ -939,7 +1033,7 @@ fn trace_binding(
             current = identifier.name.to_string();
             continue;
         }
-        if is_valid_function(init) {
+        if nested_function(init).is_some() {
             return Some(key);
         }
         return None;
@@ -1015,13 +1109,11 @@ fn collect_exported_bindings(
 fn binding_descriptive_name(program: &Program<'_>, key: BindingKey) -> Option<String> {
     let declarator = binding_declarator(program, key)?;
     let init = unwrap_expression(declarator.init.as_ref()?);
-    if let Expression::FunctionExpression(function) = init
+    let function = nested_function(init)?;
+    if let Expression::FunctionExpression(function) = function
         && let Some(id) = &function.id
     {
         return Some(id.name.to_string());
-    }
-    if !is_valid_function(init) {
-        return None;
     }
     if let BindingPattern::BindingIdentifier(id) = &declarator.id {
         return Some(id.name.to_string());
@@ -1029,8 +1121,7 @@ fn binding_descriptive_name(program: &Program<'_>, key: BindingKey) -> Option<St
     Some("anonymous".to_string())
 }
 
-/// Mutable access to the function expression stored in a traced binding's
-/// init (through TS wrappers, like Babel replacing the inner function path).
+/// Mutable access to a traced binding's inner function expression.
 fn binding_init_function_slot<'p, 'a>(
     program: &'p mut Program<'a>,
     key: BindingKey,
@@ -1045,7 +1136,155 @@ fn binding_init_function_slot<'p, 'a>(
     };
     let declarator = declaration.declarations.get_mut(key.declarator)?;
     let slot = unwrap_expression_mut(declarator.init.as_mut()?);
-    is_valid_function(slot).then_some(slot)
+    nested_function_mut(slot)
+}
+
+fn binding_init_is_wrapped(program: &Program<'_>, key: BindingKey) -> bool {
+    binding_declarator(program, key)
+        .and_then(|declarator| declarator.init.as_ref())
+        .is_some_and(|init| {
+            let init = unwrap_expression(init);
+            !is_valid_function(init) && nested_function(init).is_some()
+        })
+}
+
+fn take_binding_initializer<'a>(
+    allocator: &'a Allocator,
+    program: &mut Program<'a>,
+    key: BindingKey,
+) -> Option<Expression<'a>> {
+    let declaration = match &mut program.body[key.statement] {
+        Statement::VariableDeclaration(declaration) => declaration,
+        Statement::ExportDeclaration(export) => match &mut export.declaration {
+            Declaration::VariableDeclaration(declaration) => declaration,
+            _ => return None,
+        },
+        _ => return None,
+    };
+    let declarator = declaration.declarations.get_mut(key.declarator)?;
+    let init = declarator.init.as_mut()?;
+    Some(std::mem::replace(
+        init,
+        AstBuilder::new(allocator).expression_null_literal(SPAN),
+    ))
+}
+
+fn collect_referenced_names(
+    expression: &Expression<'_>,
+    names: &mut std::collections::HashSet<String>,
+) {
+    use oxc_ast_visit::Visit;
+
+    struct ReferencedNames<'n> {
+        names: &'n mut std::collections::HashSet<String>,
+    }
+
+    impl<'a> Visit<'a> for ReferencedNames<'_> {
+        fn visit_identifier_reference(
+            &mut self,
+            identifier: &oxc_ast::ast::IdentifierReference<'a>,
+        ) {
+            self.names.insert(identifier.name.to_string());
+        }
+    }
+
+    ReferencedNames { names }.visit_expression(expression);
+}
+
+fn import_local_name<'s>(specifier: &'s ImportDeclarationSpecifier<'_>) -> &'s str {
+    match specifier {
+        ImportDeclarationSpecifier::ImportSpecifier(specifier) => &specifier.local.name,
+        ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => &specifier.local.name,
+        ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => &specifier.local.name,
+    }
+}
+
+fn take_referenced_imports<'a>(
+    allocator: &'a Allocator,
+    program: &mut Program<'a>,
+    references: &std::collections::HashSet<String>,
+) -> Vec<Statement<'a>> {
+    let old = std::mem::replace(&mut program.body, AstBuilder::new(allocator).vec());
+    let mut imports = Vec::new();
+    for statement in old {
+        let Statement::ImportDeclaration(mut import) = statement else {
+            continue;
+        };
+        if import.import_kind.is_type() {
+            continue;
+        }
+        let Some(specifiers) = &mut import.specifiers else {
+            continue;
+        };
+        specifiers.retain(|specifier| {
+            references.contains(import_local_name(specifier))
+                && !matches!(specifier, ImportDeclarationSpecifier::ImportSpecifier(specifier) if specifier.import_kind.is_type())
+        });
+        if !specifiers.is_empty() {
+            imports.push(Statement::ImportDeclaration(import));
+        }
+    }
+    imports
+}
+
+fn clone_referenced_bindings<'a>(
+    allocator: &'a Allocator,
+    program: &Program<'a>,
+    references: &mut std::collections::HashSet<String>,
+    excluded: &std::collections::HashSet<BindingKey>,
+) -> Vec<Statement<'a>> {
+    let bindings = collect_top_level_bindings(program);
+    let mut selected = std::collections::HashSet::new();
+    let mut pending: Vec<String> = references.iter().cloned().collect();
+    let mut index = 0;
+    while index < pending.len() {
+        let name = &pending[index];
+        index += 1;
+        let Some(key) = bindings.get(name).copied() else {
+            continue;
+        };
+        if excluded.contains(&key) || !selected.insert(key) {
+            continue;
+        }
+        let Some(initializer) =
+            binding_declarator(program, key).and_then(|item| item.init.as_ref())
+        else {
+            continue;
+        };
+        let mut dependencies = std::collections::HashSet::new();
+        collect_referenced_names(initializer, &mut dependencies);
+        for dependency in dependencies {
+            if references.insert(dependency.clone()) {
+                pending.push(dependency);
+            }
+        }
+    }
+
+    let mut statements = Vec::new();
+    for (statement_index, statement) in program.body.iter().enumerate() {
+        let declaration = match statement {
+            Statement::VariableDeclaration(declaration) => declaration,
+            Statement::ExportDeclaration(export) => match &export.declaration {
+                Declaration::VariableDeclaration(declaration) => declaration,
+                _ => continue,
+            },
+            _ => continue,
+        };
+        let mut cloned = declaration.clone_in(allocator);
+        let mut declarator_index = 0;
+        cloned.declarations.retain(|_| {
+            let keep = selected.contains(&BindingKey {
+                statement: statement_index,
+                declarator: declarator_index,
+            });
+            declarator_index += 1;
+            keep
+        });
+        if !cloned.declarations.is_empty() {
+            statements.push(Statement::VariableDeclaration(cloned));
+        }
+    }
+    statements
 }
 
 /// Applies `(index, statement)` insertions before the indexed statements,


### PR DESCRIPTION
Addresses the compiler bug documented in [RFC 10](https://github.com/solidjs/solid/blob/next/documentation/solid-2.0/10-server-functions.md#compiler-implications) and originally reported in [solidjs/solid-start#2271](https://github.com/solidjs/solid-start/issues/2271).

>**One pre-existing bug to fix regardless:** with a *module-level* `"use server"` directive, a wrapped export (`export const x = wrapper(async () => ...)`) is silently dropped from the client build — only direct function exports become references. This gets more visible with `GET(fn)` as the blessed idiom. Minimum: a diagnostic; better: extract the inner function and preserve the call in client output.

Module-level `"use server"` exports that wrap their function in calls such as `GET(async () => ...)` were omitted from the client build because only direct function initializers were traced.

This change:

- extracts a single function nested inside generic call wrappers
- preserves the wrapper chain in both server and client output
- retains only wrapper imports and local dependencies required by the client
- continues to exclude server-only implementation code
- does not special-case `GET` or any other wrapper

Adds compiler fixtures for nested wrappers, local dependencies, development metadata, and server-only import pruning. Updates the documented compiler behavior and includes a patch changeset.

Testing: `@solidjs/compiler` test suite, 3,924 passing.
