### PR TITLE
redirect(): prefer the logical path carried in the Href brand slot

### DIFF
--- a/packages/web/src/response.ts
+++ b/packages/web/src/response.ts
@@ -66,7 +66,15 @@ export function isResponseEnvelope(value: unknown): value is ResponseEnvelope {
 export const HREF: unique symbol = Symbol.for("solid.Href") as any;
 
 export interface Href {
-  [HREF]: true;
+  /**
+   * The brand doubles as a channel: when the slot holds a string it is the
+   * value's *logical* path — the routable pathname before an integration's
+   * display rendering (eg. a hash router's `#` prefix). `redirect()` prefers
+   * it over coercion so Location headers carry routable paths; `toString()`
+   * remains the display href for the DOM. `true` brands a value whose
+   * string form is already logical.
+   */
+  [HREF]: true | string;
   toString(): string;
 }
 
@@ -157,7 +165,11 @@ export function redirect(url: string | Href, init: number | ResponseHelperInit =
   if (responseInit.status === undefined) {
     responseInit.status = 302;
   }
-  headers.set("Location", String(url));
+  // An Href whose brand slot carries its logical path (see `Href`) redirects
+  // there — String(url) would yield the display href (eg. `#/page1` under a
+  // hash router), which is an anchor value, not a location.
+  const target = typeof url === "string" ? url : (url as Href)[HREF];
+  headers.set("Location", typeof target === "string" ? target : String(url));
   return new Response(null, { ...responseInit, headers });
 }
 

--- a/packages/web/test/runtime/redirect-href.spec.js
+++ b/packages/web/test/runtime/redirect-href.spec.js
@@ -1,0 +1,41 @@
+/**
+ * @vitest-environment node
+ *
+ * `redirect()` with Href-branded values: the brand slot doubles as the
+ * logical-path channel. A router's typed path node stringifies to its
+ * *display* href (a hash router renders `#/page1`) for use in anchors,
+ * while the brand slot carries the routable pathname — redirect() must
+ * put the logical path in Location, not the display form. A legacy
+ * `true`-branded Href keeps coercing through String().
+ */
+import { describe, expect, it } from "vitest";
+import { redirect, isHref, HREF } from "../../src/response.js";
+
+const displayHref = (logical, display) => ({
+  [HREF]: logical,
+  toString: () => display
+});
+
+describe("redirect() Href handling", () => {
+  it("prefers the logical path carried in the brand slot", () => {
+    const node = displayHref("/page1", "#/page1");
+    expect(isHref(node)).toBe(true);
+    const res = redirect(node);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/page1");
+  });
+
+  it("falls back to string coercion for a `true`-branded Href", () => {
+    const legacy = { [HREF]: true, toString: () => "/somewhere" };
+    const res = redirect(legacy);
+    expect(res.headers.get("Location")).toBe("/somewhere");
+  });
+
+  it("leaves plain string urls untouched", () => {
+    expect(redirect("/plain").headers.get("Location")).toBe("/plain");
+  });
+
+  it("still rejects unbranded objects", () => {
+    expect(() => redirect({ toString: () => "/sneaky" })).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## Summary

- The `Href` brand slot (`Symbol.for("solid.Href")`) can now carry a string: the value's **logical path** — the routable pathname before an integration's display rendering. `isHref` already only checks truthiness, so this is backward compatible with `true`-branded values.
- `redirect()` prefers the logical path over `String(url)` when the slot carries one. Under a hash router, `String(node)` yields the *display* href (`#/page1`) — an anchor value, not a location — which produced malformed navigations (solidjs/solid-router#582).
- `true`-branded Hrefs and plain string urls behave exactly as before.

The router side (branding its typed path nodes with their logical path) landed in solid-router `next`; it works against the current release since the router also parses display-form Location headers, so this can ride whenever the next release goes out — it just makes Location headers carry routable paths.

## Test plan

- [x] New `packages/web/test/runtime/redirect-href.spec.js`: logical-path preference, `true`-brand fallback, plain strings, unbranded rejection
- [x] Full `@solidjs/web` suite: 609 passed

Made with [Cursor](https://cursor.com)