### PR TITLE
fix(web): skip server-injected head-manager tags in the hydration claim walk

### DIFF
--- a/.changeset/usehead-shell-head-claim-walk.md
+++ b/.changeset/usehead-shell-head-claim-walk.md
@@ -1,0 +1,14 @@
+---
+"@solidjs/web": patch
+---
+
+Skip server-injected head-manager tags in the hydration claim walk. A
+`useHead` charset/base registration is spliced as a prelude right after the
+`<head>` open tag — ahead of every head child a full-document shell authored
+itself — and the compiled shell's positional head traversal died on the
+shift: a null `nextSibling` read that halted hydration for the whole
+document. `getFirstChild`/`getNextSibling`/`getNextMatch` now step over
+elements in `document.head` that carry `data-dh` without `data-dhf` while
+hydrating; the `data-dhf` exemption keeps the server's in-place static
+`<title>` rewrite claimable, since the rewrite always stashes the original
+text there and injected tags never do.

--- a/packages/web/src/client.ts
+++ b/packages/web/src/client.ts
@@ -1752,7 +1752,8 @@ export function getNextElement(template) {
 export function getNextMatch(start: Node, elementName: string): Element;
 
 export function getNextMatch(el, nodeName) {
-  while (el && el.localName !== nodeName) el = el.nextSibling;
+  while (el && (el.localName !== nodeName || (sharedConfig.hydrating && isInjectedHeadTag(el))))
+    el = el.nextSibling;
   return el;
 } /** Hydration-walk primitive; not for hand-written code. @internal */
 export function getNextMarker(start: Node): [Node, Array<Node>];
@@ -1778,8 +1779,27 @@ export function getNextMarker(start) {
   return [end, current];
 }
 
+// Head-manager tags the server INJECTED around the shell's own markup — the
+// charset/base prelude spliced right after `<head>`, registry tags spliced
+// before `</head>` — never correspond to compiled shell markup, so the
+// positional head walk must step over them: one prepended prelude tag shifts
+// every subsequent read and hydration of the whole document dies (#3081).
+// Shell-authored tags the server rewrote IN PLACE (the static <title> given
+// the winner text) keep their position and must still be claimed; the
+// rewrite always leaves the `data-dhf` stash, which injected tags never
+// carry.
+function isInjectedHeadTag(node) {
+  return (
+    node.nodeType === 1 &&
+    node.parentNode === document.head &&
+    node.hasAttribute("data-dh") &&
+    !node.hasAttribute("data-dhf")
+  );
+}
+
 export function getFirstChild(node, expectedTag) {
-  const child = node.firstChild;
+  let child = node.firstChild;
+  while (child && sharedConfig.hydrating && isInjectedHeadTag(child)) child = child.nextSibling;
   if ("_SOLID_DEV_" && isHydrating() && expectedTag && child?.localName !== expectedTag) {
     const isMissing = !child || child.nodeType !== 1;
     console.warn(
@@ -1792,7 +1812,9 @@ export function getFirstChild(node, expectedTag) {
 }
 
 export function getNextSibling(node, expectedTag) {
-  const sibling = node.nextSibling;
+  let sibling = node.nextSibling;
+  while (sibling && sharedConfig.hydrating && isInjectedHeadTag(sibling))
+    sibling = sibling.nextSibling;
   if ("_SOLID_DEV_" && isHydrating() && expectedTag && sibling?.localName !== expectedTag) {
     const parent = node.parentNode;
     const isMissing = !sibling || sibling.nodeType !== 1;

--- a/packages/web/test/harness/__artifacts__/document-shell-usehead-head.json
+++ b/packages/web/test/harness/__artifacts__/document-shell-usehead-head.json
@@ -1,0 +1,5 @@
+{
+  "chunks": [
+    "<html _hk=0 lang=\"en\"><head><meta charset=\"utf-8\" data-dh=\"charset\"><meta name=\"shell-owned\" content=\"first\"><!--$--><!--/--><!--$--><meta _hk=30 name=\"shell-owned-dynamic\" content=\"marker-range\"><!--/--><title data-dh=\"title\" data-dhf=\"shell fallback title\">managed title</title></head><body class=\"\"><main><h1>hello</h1><p id=\"status\">waiting</p></main></body></html>"
+  ]
+}

--- a/packages/web/test/harness/document-shell.tsx
+++ b/packages/web/test/harness/document-shell.tsx
@@ -15,8 +15,8 @@
  * the dom generate by test/hydration/document-shell.spec.tsx (which hydrates
  * against that same markup) — so the constant can't drift from either side.
  */
-import { createSignal, createMemo, Loading, NoHydration, Hydration } from "solid-js";
-import type { JSX } from "@solidjs/web";
+import { createSignal, createMemo, Loading, NoHydration, Hydration, Show } from "solid-js";
+import { useHead, type JSX } from "@solidjs/web";
 
 export function App() {
   const [count, setCount] = createSignal(0);
@@ -79,3 +79,43 @@ export function Shell(props: { children: JSX.Element }) {
 
 /** What the server renders inside #app-root for <Shell><App /></Shell>. */
 export const APP_ROOT_MARKUP = `<button _hk=0 id="counter" type="button">count: <!--$-->0<!--/--></button>`;
+
+/**
+ * Whole-document hydration with useHead + shell-authored <head> children
+ * (issue #3081). The charset registration is emitted as a prelude tag
+ * spliced AHEAD of the shell's own head children — the claim walk must step
+ * over it or the whole document dies on an off-by-one. The title
+ * registration rewrites the shell's static <title> IN PLACE (data-dh +
+ * data-dhf) — that element keeps its position and the walk must still take
+ * it.
+ */
+export const [headShellStarted, setHeadShellStarted] = createSignal(false);
+
+function HeadRegistrar() {
+  useHead([
+    { tag: "meta", props: { charset: "utf-8" }, key: "charset" },
+    { tag: "title", props: { children: "managed title" } }
+  ]);
+  return null;
+}
+
+export function HeadShellApp() {
+  return (
+    <html lang="en">
+      <head>
+        <meta name="shell-owned" content="first" />
+        <HeadRegistrar />
+        <Show when={true}>
+          <meta name="shell-owned-dynamic" content="marker-range" />
+        </Show>
+        <title>shell fallback title</title>
+      </head>
+      <body class={headShellStarted() ? "started" : ""}>
+        <main>
+          <h1>hello</h1>
+          <p id="status">{headShellStarted() ? "started" : "waiting"}</p>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/packages/web/test/hydration/document-shell.spec.tsx
+++ b/packages/web/test/hydration/document-shell.spec.tsx
@@ -17,7 +17,14 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { flush } from "solid-js";
 import { hydrate } from "@solidjs/web";
-import { App, AsyncApp, computeRuns, APP_ROOT_MARKUP } from "../harness/document-shell.jsx";
+import {
+  App,
+  AsyncApp,
+  HeadShellApp,
+  setHeadShellStarted,
+  computeRuns,
+  APP_ROOT_MARKUP
+} from "../harness/document-shell.jsx";
 
 const artifactsDir = resolve(dirname(fileURLToPath(import.meta.url)), "../harness/__artifacts__");
 
@@ -104,5 +111,63 @@ describe("document-shell pattern — client hydrate (#3000)", () => {
     warn.mockRestore();
     dispose();
     container.remove();
+  });
+
+  // Whole-document hydration where the server both INJECTED a head-manager
+  // tag ahead of the shell's head children (the charset prelude) and
+  // rewrote the shell's static <title> IN PLACE (data-dh + data-dhf). The
+  // claim walk must skip the former and still claim the latter — before the
+  // fix the injected tag shifted every positional read by one and hydration
+  // for the whole document died on a null nextSibling (#3081).
+  test("useHead + shell-authored head children hydrate against document (#3081)", async () => {
+    const { chunks } = JSON.parse(
+      readFileSync(resolve(artifactsDir, "document-shell-usehead-head.json"), "utf-8")
+    ) as { chunks: string[] };
+    const html = chunks.join("");
+
+    // Recreate the served document in jsdom: documentElement/body attributes
+    // by hand (innerHTML can't author them), head/body contents
+    // byte-for-byte.
+    for (const m of /<html([^>]*)>/.exec(html)![1].matchAll(/([\w-]+)(?:=("[^"]*"|\S+))?/g)) {
+      document.documentElement.setAttribute(m[1], m[2] ? m[2].replace(/^"|"$/g, "") : "");
+    }
+    const bodyM = /<body([^>]*)>([\s\S]*)<\/body>/.exec(html)!;
+    document.head.innerHTML = html.slice(html.indexOf("<head>") + 6, html.indexOf("</head>"));
+    for (const m of bodyM[1].matchAll(/([\w-]+)(?:=("[^"]*"|\S+))?/g)) {
+      document.body.setAttribute(m[1], m[2] ? m[2].replace(/^"|"$/g, "") : "");
+    }
+    document.body.innerHTML = bodyM[2];
+
+    (globalThis as any)._$HY = { events: [], completed: new WeakSet(), r: {}, fe() {} };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    setHeadShellStarted(false);
+    const serverStatus = document.getElementById("status")!;
+    const serverTitle = document.querySelector("title")!;
+    expect(serverStatus.textContent).toBe("waiting");
+
+    const dispose = hydrate(() => <HeadShellApp />, document);
+    flush();
+    await sleep(20);
+    flush();
+
+    // Post-hydration write must reach its bindings (the issue's canary —
+    // with the walk broken, reactivity halts and this never lands).
+    setHeadShellStarted(true);
+    flush();
+
+    expect(document.getElementById("status")).toBe(serverStatus);
+    expect(serverStatus.textContent).toBe("started");
+    expect(document.body.className).toBe("started");
+    // The in-place-rewritten <title> was CLAIMED, not skipped as injected.
+    expect(document.querySelector("title")).toBe(serverTitle);
+    expect(serverTitle.textContent).toBe("managed title");
+
+    // The client legitimately warns that a charset registration is
+    // shell-only (it can never apply client-side); everything else is real.
+    const noise = warn.mock.calls.map(c => String(c[0])).filter(m => !m.includes("shell-only"));
+    expect(noise, noise.join("\n")).toEqual([]);
+    warn.mockRestore();
+    dispose();
   });
 });

--- a/packages/web/test/server/document-shell.spec.tsx
+++ b/packages/web/test/server/document-shell.spec.tsx
@@ -11,7 +11,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { renderToStream } from "@solidjs/web";
-import { App, AsyncApp, Shell, APP_ROOT_MARKUP } from "../harness/document-shell.jsx";
+import { App, AsyncApp, HeadShellApp, Shell, APP_ROOT_MARKUP } from "../harness/document-shell.jsx";
 import { hydrationRecordKeys } from "../harness/hydration-records.js";
 
 const artifactsDir = resolve(dirname(fileURLToPath(import.meta.url)), "../harness/__artifacts__");
@@ -68,6 +68,28 @@ describe("document-shell pattern — server render (#3000)", () => {
     mkdirSync(artifactsDir, { recursive: true });
     writeFileSync(
       resolve(artifactsDir, "document-shell-async.json"),
+      JSON.stringify({ chunks }, null, 2)
+    );
+  });
+
+  test("useHead + shell-authored head children: prelude tag injected ahead, title rewritten in place (#3081)", async () => {
+    const chunks = await collectChunks(() => <HeadShellApp />);
+    const html = chunks.join("");
+
+    // The charset prelude splices right after `<head>` — BEFORE every
+    // shell-authored head child (its placement constraint). The client half
+    // must hydrate over that shift.
+    expect(html.indexOf('data-dh="charset"')).toBeGreaterThan(-1);
+    expect(html.indexOf('data-dh="charset"')).toBeLessThan(html.indexOf('name="shell-owned"'));
+    // The shell's static <title> is rewritten in place, keeping its position:
+    // winner text in the element, original stashed on data-dhf.
+    expect(html).toContain(
+      '<title data-dh="title" data-dhf="shell fallback title">managed title</title>'
+    );
+
+    mkdirSync(artifactsDir, { recursive: true });
+    writeFileSync(
+      resolve(artifactsDir, "document-shell-usehead-head.json"),
       JSON.stringify({ chunks }, null, 2)
     );
   });


### PR DESCRIPTION
Fixes #3081.

## The bug

When a full-document shell authors its own `<head>` children and anything registers a `charset`/`base` tag through `useHead`, the server splices that registration as a **prelude** immediately after the `<head>` open tag — a deliberate placement constraint — landing it AHEAD of every shell-authored head child:

```html
<head><meta charset="utf-8" data-dh="charset"><meta name="shell-owned" content="first"><!--$-->…
```

The compiled shell's head traversal is positional (`getFirstChild`/`getNextSibling`), so the prepended tag shifts every read by one, the walk ends on a null read (`TypeError: Cannot read properties of null (reading 'nextSibling')`), and hydration for the whole document dies with it — which is how `@tanstack/solid-router`'s useHead registry killed every page.

## The fix

`getFirstChild`, `getNextSibling`, and `getNextMatch` now step over server-**injected** head-manager tags while hydrating: elements in `document.head` carrying `data-dh` but no `data-dhf`. The check is gated on `sharedConfig.hydrating`, so non-hydration template-clone walks stay on the fast path.

The `data-dhf` exemption is the load-bearing detail: when a title is registered, the server rewrites the shell's own static `<title>` **in place** (winner text in the element, original stashed on `data-dhf`). That element keeps its position in the walk and must still be claimed — and both the byte-rewrite path and the streamed `$dha` "t" op always leave the stash, while injected tags never carry it.

A client-side skip also fixes this for any injection order the server (or a future placement rule) chooses, rather than pinning the server to one splice position.

## Tests

Regression coverage joins the document-shell suite (the existing whole-document pattern tests):

- **server** (`test/server/document-shell.spec.tsx`): pins the injected-before-shell emission order and the in-place title rewrite, and records the chunks as an artifact.
- **client** (`test/hydration/document-shell.spec.tsx`): replays those bytes into the jsdom document, hydrates against `document`, and asserts the post-hydration signal write reaches its bindings, node identity is preserved, and the rewritten `<title>` is claimed (same element, winner text) rather than skipped.

The client test reproduces the issue's exact TypeError without the fix, and the full `packages/web` hydrate (147) and server (332) suites pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)