### PR TITLE
test(web): pin three server-function invariants that nothing guards

### DIFF
--- a/packages/web/test/server/server-functions-csrf.spec.tsx
+++ b/packages/web/test/server/server-functions-csrf.spec.tsx
@@ -156,4 +156,48 @@ describe("the origin gate's decision matrix", () => {
     });
     expect(allowed.status).toBe(200);
   });
+  it("asks a function matcher, and honours its refusal", async () => {
+    registerServerFunction("csrf-origin-fn", async () => "ok");
+    const seen: string[] = [];
+    const csrf: ServerFunctionCSRFOptions = {
+      origin: async origin => {
+        seen.push(origin);
+        return origin === "https://trusted.example";
+      }
+    };
+
+    const allowed = await handleServerFunctionRequest(
+      request("csrf-origin-fn", { Origin: "https://trusted.example" }),
+      { csrf, provideEvent }
+    );
+    expect(allowed.status).toBe(200);
+
+    const refused = await handleServerFunctionRequest(
+      request("csrf-origin-fn", { Origin: "https://evil.example" }),
+      { csrf, provideEvent }
+    );
+    expect(refused.status).toBe(403);
+    expect(seen).toEqual(["https://trusted.example", "https://evil.example"]);
+  });
+
+  it("treats a list as the whole allowlist", async () => {
+    registerServerFunction("csrf-origin-list", async () => "ok");
+    const csrf: ServerFunctionCSRFOptions = {
+      origin: ["https://one.example", "https://two.example"]
+    };
+
+    for (const origin of ["https://one.example", "https://two.example"]) {
+      const allowed = await handleServerFunctionRequest(
+        request("csrf-origin-list", { Origin: origin }),
+        { csrf, provideEvent }
+      );
+      expect(allowed.status).toBe(200);
+    }
+
+    const refused = await handleServerFunctionRequest(
+      request("csrf-origin-list", { Origin: "https://three.example" }),
+      { csrf, provideEvent }
+    );
+    expect(refused.status).toBe(403);
+  });
 });

--- a/packages/web/test/server/server-functions-csrf.spec.tsx
+++ b/packages/web/test/server/server-functions-csrf.spec.tsx
@@ -48,3 +48,112 @@ describe("server-function CSRF bridge", () => {
     expect(response.status).toBe(200);
   });
 });
+
+/**
+ * The gate's branches, pinned. Each one is a decision someone could
+ * plausibly "fix" in the wrong direction, and today only two of them fail
+ * a test if reversed:
+ *
+ * - `Sec-Fetch-Site` is authoritative WHEN PRESENT. A `same-site` call
+ *   (a sibling subdomain) and a `none` call (address bar, bookmark) are
+ *   refused outright — they never fall through to the trusted-origin
+ *   matcher, so widening `origin` cannot re-admit them. Loosening
+ *   `same-site` is the natural-looking repair for a broken subdomain
+ *   deployment, and it would hand every subdomain a CSRF surface.
+ * - Without `Sec-Fetch-Site`, `Origin` decides, then `Referer`; a matcher
+ *   that answered `true` for a non-matching origin would fail open, and
+ *   nothing currently notices.
+ * - With no proof of origin at all, the request is refused unless the
+ *   deployment has explicitly opted out.
+ */
+describe("the origin gate's decision matrix", () => {
+  it.each(["same-site", "none"])(
+    "refuses a %s call even when the Origin is trusted",
+    async site => {
+      const fn = vi.fn(async () => "ok");
+      registerServerFunction(`csrf-site-${site}`, fn);
+
+      const response = await handleServerFunctionRequest(
+        request(`csrf-site-${site}`, {
+          "Sec-Fetch-Site": site,
+          Origin: "https://app.example"
+        }),
+        { csrf: { origin: "https://app.example" }, provideEvent }
+      );
+
+      expect(response.status).toBe(403);
+      expect(fn).not.toHaveBeenCalled();
+    }
+  );
+
+  it("refuses an Origin the deployment does not trust", async () => {
+    const fn = vi.fn(async () => "ok");
+    registerServerFunction("csrf-origin-mismatch", fn);
+
+    const response = await handleServerFunctionRequest(
+      request("csrf-origin-mismatch", { Origin: "https://evil.example" }),
+      { csrf: { origin: "https://trusted.example" }, provideEvent }
+    );
+
+    expect(response.status).toBe(403);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("defaults to the request's own origin when none is configured", async () => {
+    registerServerFunction("csrf-origin-default", async () => "ok");
+
+    const same = await handleServerFunctionRequest(
+      request("csrf-origin-default", { Origin: "https://app.example" }),
+      { provideEvent }
+    );
+    expect(same.status).toBe(200);
+
+    const other = await handleServerFunctionRequest(
+      request("csrf-origin-default", { Origin: "https://evil.example" }),
+      { provideEvent }
+    );
+    expect(other.status).toBe(403);
+  });
+
+  it("falls back to Referer when Origin is absent", async () => {
+    registerServerFunction("csrf-referer", async () => "ok");
+
+    const allowed = await handleServerFunctionRequest(
+      request("csrf-referer", { Referer: "https://app.example/some/page" }),
+      { provideEvent }
+    );
+    expect(allowed.status).toBe(200);
+
+    const refused = await handleServerFunctionRequest(
+      request("csrf-referer", { Referer: "https://evil.example/some/page" }),
+      { provideEvent }
+    );
+    expect(refused.status).toBe(403);
+  });
+
+  it("refuses a Referer it cannot parse rather than ignoring it", async () => {
+    const fn = vi.fn(async () => "ok");
+    registerServerFunction("csrf-referer-garbage", fn);
+
+    const response = await handleServerFunctionRequest(
+      request("csrf-referer-garbage", { Referer: "not a url" }),
+      { provideEvent }
+    );
+
+    expect(response.status).toBe(403);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("refuses a request carrying no proof of origin, unless opted out", async () => {
+    registerServerFunction("csrf-no-proof", async () => "ok");
+
+    const refused = await handleServerFunctionRequest(request("csrf-no-proof"), { provideEvent });
+    expect(refused.status).toBe(403);
+
+    const allowed = await handleServerFunctionRequest(request("csrf-no-proof"), {
+      csrf: { allowRequestsWithoutOriginCheck: true },
+      provideEvent
+    });
+    expect(allowed.status).toBe(200);
+  });
+});

--- a/packages/web/test/server/server-functions-csrf.spec.tsx
+++ b/packages/web/test/server/server-functions-csrf.spec.tsx
@@ -67,9 +67,8 @@ describe("server-function CSRF bridge", () => {
  *   deployment has explicitly opted out.
  */
 describe("the origin gate's decision matrix", () => {
-  it.each(["same-site", "none"])(
-    "refuses a %s call even when the Origin is trusted",
-    async site => {
+  for (const site of ["same-site", "none"]) {
+    it(`refuses a ${site} call even when the Origin is trusted`, async () => {
       const fn = vi.fn(async () => "ok");
       registerServerFunction(`csrf-site-${site}`, fn);
 
@@ -83,8 +82,8 @@ describe("the origin gate's decision matrix", () => {
 
       expect(response.status).toBe(403);
       expect(fn).not.toHaveBeenCalled();
-    }
-  );
+    });
+  }
 
   it("refuses an Origin the deployment does not trust", async () => {
     const fn = vi.fn(async () => "ok");
@@ -156,6 +155,7 @@ describe("the origin gate's decision matrix", () => {
     });
     expect(allowed.status).toBe(200);
   });
+
   it("asks a function matcher, and honours its refusal", async () => {
     registerServerFunction("csrf-origin-fn", async () => "ok");
     const seen: string[] = [];

--- a/packages/web/test/server/server-functions-encode-hygiene.spec.tsx
+++ b/packages/web/test/server/server-functions-encode-hygiene.spec.tsx
@@ -20,6 +20,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { markSafeError, respond } from "@solidjs/web";
 import {
   ERROR_HEADER,
+  decodeErrorHeaderValue,
   handleServerFunctionRequest,
   registerServerFunction
 } from "@solidjs/web/server-functions/server";
@@ -162,4 +163,37 @@ describe("null-body statuses (#3095)", () => {
       restore();
     }
   });
+});
+
+/**
+ * The bound is enforced by re-encoding a shrinking slice of the SOURCE,
+ * never by cutting the encoded form — a percent escape severed in half
+ * (`%D0` without its second byte) leaves a header that no longer decodes.
+ * Asserting only the length cannot tell the two implementations apart:
+ * ASCII encodes to itself, and a truncated Cyrillic value is still short
+ * enough to pass. Decoding it is what pins the difference.
+ */
+describe("the bound applies to the source, not to the encoding (#3093)", () => {
+  // Padding shifts where the 1024-byte ceiling lands inside the encoded
+  // form. A naive `encode(message).slice(0, LIMIT)` survives the paddings
+  // that happen to land on an escape boundary, so one message cannot tell
+  // the implementations apart — the sweep is the test.
+  it.each([0, 1, 2, 3, 4, 5])(
+    "a bounded non-latin1 header decodes back to a prefix of the message (padding %i)",
+    async padding => {
+      const message = `${"x".repeat(padding)}${"Я".repeat(600)}`;
+      const id = `bounded-cyrillic-roundtrip-${padding}`;
+      registerServerFunction(id, async () => {
+        throw markSafeError(new Error(message));
+      });
+
+      const response = await handleServerFunctionRequest(scriptedPost(id));
+      const encoded = response.headers.get(ERROR_HEADER)!;
+
+      expect(encoded.length).toBeLessThanOrEqual(1024);
+      const decoded = decodeErrorHeaderValue(encoded);
+      expect(decoded.length).toBeGreaterThan(0);
+      expect(message.startsWith(decoded)).toBe(true);
+    }
+  );
 });

--- a/packages/web/test/server/server-functions-encode-hygiene.spec.tsx
+++ b/packages/web/test/server/server-functions-encode-hygiene.spec.tsx
@@ -174,14 +174,18 @@ describe("null-body statuses (#3095)", () => {
  * enough to pass. Decoding it is what pins the difference.
  */
 describe("the bound applies to the source, not to the encoding (#3093)", () => {
-  // Padding shifts where the 1024-byte ceiling lands inside the encoded
-  // form. A naive `encode(message).slice(0, LIMIT)` survives the paddings
-  // that happen to land on an escape boundary, so one message cannot tell
-  // the implementations apart — the sweep is the test.
-  it.each([0, 1, 2, 3, 4, 5])(
+  // A percent escape is six characters (`%D0%AF`), so where the ceiling
+  // lands inside the encoded form depends on what precedes the run. With
+  // no padding it lands on an escape boundary and a naive
+  // `encode(message).slice(0, LIMIT)` produces a value that still decodes
+  // — that case cannot tell the two implementations apart. One character
+  // of padding moves the ceiling into the middle of an escape, and the
+  // naive form stops decoding. Both are here so the property is stated
+  // rather than sampled.
+  it.each([0, 1])(
     "a bounded non-latin1 header decodes back to a prefix of the message (padding %i)",
     async padding => {
-      const message = `${"x".repeat(padding)}${"Я".repeat(600)}`;
+      const message = `${"x".repeat(padding)}${"\u042f".repeat(600)}`;
       const id = `bounded-cyrillic-roundtrip-${padding}`;
       registerServerFunction(id, async () => {
         throw markSafeError(new Error(message));

--- a/packages/web/test/server/server-functions-encode-hygiene.spec.tsx
+++ b/packages/web/test/server/server-functions-encode-hygiene.spec.tsx
@@ -182,9 +182,8 @@ describe("the bound applies to the source, not to the encoding (#3093)", () => {
   // of padding moves the ceiling into the middle of an escape, and the
   // naive form stops decoding. Both are here so the property is stated
   // rather than sampled.
-  it.each([0, 1])(
-    "a bounded non-latin1 header decodes back to a prefix of the message (padding %i)",
-    async padding => {
+  for (const padding of [0, 1]) {
+    it(`a bounded non-latin1 header decodes back to a prefix of the message (padding ${padding})`, async () => {
       const message = `${"x".repeat(padding)}${"\u042f".repeat(600)}`;
       const id = `bounded-cyrillic-roundtrip-${padding}`;
       registerServerFunction(id, async () => {
@@ -198,6 +197,6 @@ describe("the bound applies to the source, not to the encoding (#3093)", () => {
       const decoded = decodeErrorHeaderValue(encoded);
       expect(decoded.length).toBeGreaterThan(0);
       expect(message.startsWith(decoded)).toBe(true);
-    }
-  );
+    });
+  }
 });

--- a/packages/web/test/server/server-functions-redirect-status.spec.tsx
+++ b/packages/web/test/server/server-functions-redirect-status.spec.tsx
@@ -286,8 +286,9 @@ describe("the no-JS form convention honors returned redirects (#3096)", () => {
  * leaves a scripted caller a real redirect that fetch chases before the
  * transport can read it, and the redirect is silently lost.
  */
-describe("every status in the Fetch redirect set masks, and only for scripted callers", () => {
-  it.each([301, 302, 303, 307, 308])(
+describe("every status in the Fetch redirect set masks, and only for scripted callers (#3096)", () => {
+  // 302 is covered above; these are the four the file never exercised.
+  it.each([301, 303, 307, 308])(
     "%i travels as the redirect carrier for scripted callers, real for the rest",
     async status => {
       const id = `redirect-set-${status}`;

--- a/packages/web/test/server/server-functions-redirect-status.spec.tsx
+++ b/packages/web/test/server/server-functions-redirect-status.spec.tsx
@@ -278,3 +278,29 @@ describe("the no-JS form convention honors returned redirects (#3096)", () => {
     expect(response.headers.get("Location")).toBe("https://app.example/elsewhere");
   });
 });
+
+/**
+ * The mask is justified by ONE fact — that fetch follows these statuses —
+ * so it has to cover exactly the set fetch follows. Exercising 302 alone
+ * cannot show that: narrowing the set to {302, 303}, or dropping 307/308,
+ * leaves a scripted caller a real redirect that fetch chases before the
+ * transport can read it, and the redirect is silently lost.
+ */
+describe("every status in the Fetch redirect set masks, and only for scripted callers", () => {
+  it.each([301, 302, 303, 307, 308])(
+    "%i travels as the redirect carrier for scripted callers, real for the rest",
+    async status => {
+      const id = `redirect-set-${status}`;
+      registerServerFunction(id, async () => respond(undefined, { status, headers: location }));
+
+      const masked = await handleServerFunctionRequest(scripted(id));
+      expect(masked.status).toBe(200);
+      expect(masked.headers.get(REDIRECT_HEADER)).toBe(`${status} https://app.example/elsewhere`);
+      expect(masked.headers.get("Location")).toBeNull();
+
+      const real = await handleServerFunctionRequest(unscripted(id));
+      expect(real.status).toBe(status);
+      expect(real.headers.get("Location")).toBe("/elsewhere");
+    }
+  );
+});


### PR DESCRIPTION
Three invariants that recent fixes established, each of which can be undone today without a test failing. Tests only, no runtime change, no changeset.

### The origin gate's decision matrix

`allowsServerFunctionRequest` has six branches and `matchesOrigin` three. Two were exercised.

- **`Sec-Fetch-Site` is authoritative when present.** `same-site` (a sibling subdomain) and `none` (address bar, bookmark) are refused outright and never reach the trusted-origin matcher, so widening `origin` cannot re-admit them. Loosening `same-site` is the natural-looking repair for a broken subdomain deployment, and it would hand every subdomain a CSRF surface.
- **Then `Origin`, then `Referer`.** Neither had a negative case, so a matcher answering `true` for a non-matching origin would fail open unnoticed — including the function and array forms, which nothing touched at all. The unparseable `Referer` is refused rather than ignored.
- **No proof of origin at all** is refused unless the deployment opts out. The default that matters most, and the one nothing pinned.

### Every status in the Fetch redirect set

The mask exists because `fetch` follows these statuses, so it must cover exactly the set `fetch` follows — but only `302` was exercised. Narrowing the set to `{302, 303}`, or dropping `307`/`308`, leaves a scripted caller a real redirect that `fetch` chases before the transport can read it, and the redirect is silently lost.

### The error header's bound applies to the source

`boundedErrorHeaderValue` enforces its ceiling by re-encoding a shrinking slice of the **source**. Cutting the encoded form instead severs a percent escape and the value stops decoding — while still passing a length assertion, which is all the existing tests check.

A percent escape is six characters, so where the ceiling lands depends on what precedes the run: with no padding it lands on a boundary and even a naive slice still decodes; one character of padding breaks it. Both cases are here, because my first attempt used a single message and passed against the broken implementation for exactly that reason.

### Checked by mutation

Each test was confirmed to fail against a deliberately broken runtime:

| mutation | result |
| --- | --- |
| `same-site` falls through to the origin matcher | 1 failed |
| a function matcher returns `true` for any origin | 1 failed |
| an array matcher returns `true` for any origin | 1 failed |
| redirect set narrowed to `{302, 303}` | 3 failed |
| bound applied to the encoded form instead of the source | 1 failed |

Full suite green on `next`: 42 files, 418 passed, 2 skipped.