### PR TITLE
test(web): mark three open server-function gaps as expected failures

### DIFF
--- a/packages/web/test/server/server-functions-open-gaps.spec.tsx
+++ b/packages/web/test/server/server-functions-open-gaps.spec.tsx
@@ -4,6 +4,7 @@
  * `test/lifecycle-matrix/MATRIX.md`: the marker is the point — the suite
  * stays green while the gap is open and turns red the day it closes, at
  * which point the marker comes off and the test becomes an ordinary guard.
+ * Each carries the issue that tracks it: #3117, #3118, #3119.
  *
  * Like the other server-function specs, these run against the built
  * bundles (server-functions/dist/*, wired up in vite.config.server.mjs).
@@ -70,7 +71,7 @@ function connectBufferedTransport() {
 }
 
 describe("a result the codec cannot encode", () => {
-  // GAP: the caller receives `undefined`. The function already ran and
+  // GAP (#3117): the caller receives `undefined`. The function already ran and
   // committed its side effects; only the ENCODING failed, and it failed
   // after the head was committed, so the status is spent and no error tag
   // can be added. The truncated body decodes to the answer a void function
@@ -105,7 +106,7 @@ describe("a result the codec cannot encode", () => {
 });
 
 describe("a streamed result nobody is reading", () => {
-  // GAP: the producer runs unboundedly ahead. The response stream is built
+  // GAP (#3118): the producer runs unboundedly ahead. The response stream is built
   // with no `pull` and no queuing strategy, and every codec node is
   // enqueued the moment it is parsed, so the producer runs as fast as it
   // can resolve whether or not anyone reads. On a large or infinite stream
@@ -138,7 +139,7 @@ describe("a streamed result nobody is reading", () => {
 });
 
 describe("the decode depth cap", () => {
-  // GAP: the cap is opt-out. `depthLimit: 64` exists "because payloads may
+  // GAP (#3119): the cap is opt-out. `depthLimit: 64` exists "because payloads may
   // come from an untrusted peer" and guards the seroval path only, while
   // the body format is chosen by the CALLER — selecting the JSON format
   // hands the payload to a bare JSON.parse and skips the cap entirely.

--- a/packages/web/test/server/server-functions-open-gaps.spec.tsx
+++ b/packages/web/test/server/server-functions-open-gaps.spec.tsx
@@ -1,0 +1,176 @@
+/**
+ * Gaps that are open on `next` today, written as `it.fails` so the suite
+ * stays green while they are open and turns RED the day each is fixed —
+ * at which point the marker comes off and the test becomes an ordinary
+ * guard. (The repo's existing idiom for "intended, not yet held" is
+ * `test.skip`; these use `.fails` instead because the point is to notice
+ * the fix, which a skipped test cannot do.)
+ *
+ * Each assertion states the behaviour that is wanted, not the behaviour
+ * that happens.
+ *
+ * Like the other server-function specs, these run against the built
+ * bundles (server-functions/dist/*, wired up in vite.config.server.mjs).
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  BODY_FORMAT_HEADER,
+  ERROR_HEADER,
+  handleServerFunctionRequest,
+  registerServerFunction
+} from "@solidjs/web/server-functions/server";
+import { createServerReference } from "@solidjs/web/server-functions/client";
+
+const RequestContext = Symbol.for("solid.RequestContext");
+
+beforeAll(() => {
+  (globalThis as any)[RequestContext] = new AsyncLocalStorage();
+});
+
+afterAll(() => {
+  delete (globalThis as any)[RequestContext];
+});
+
+function scriptedPost(id: string) {
+  return new Request(`https://app.example/_server/data/${id}`, {
+    method: "POST",
+    body: "[]",
+    headers: {
+      "Sec-Fetch-Site": "same-origin",
+      "X-Server-Function-Instance": "server-function:test"
+    }
+  });
+}
+
+/**
+ * Routes the client stub through the handler the way a socket does: the
+ * body is drained into a buffer first, so a stream that errors mid-flight
+ * reaches the client as a TRUNCATED body rather than as a live exception.
+ * That is the difference between an in-process call and a deployed one.
+ */
+function connectWire() {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const address = input instanceof Request ? input.url : input.toString();
+    const request = new Request(new URL(address, "https://app.example"), init);
+    request.headers.set("Sec-Fetch-Site", "same-origin");
+    const response = await handleServerFunctionRequest(request);
+
+    const chunks: Uint8Array[] = [];
+    try {
+      for await (const chunk of response.body ?? []) chunks.push(chunk as Uint8Array);
+    } catch {
+      /* the wire cut here; whatever arrived is what the client sees */
+    }
+    return new Response(chunks.length ? Buffer.concat(chunks) : null, {
+      status: response.status,
+      headers: response.headers
+    });
+  }) as typeof fetch;
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+describe("a result the codec cannot encode", () => {
+  // The function already ran and committed its side effects; only the
+  // ENCODING failed, and it failed after the head was committed, so the
+  // status is spent and no error tag can be added. The truncated body
+  // then decodes to `undefined` — the same answer a void function gives.
+  // A caller cannot tell "this mutation returned nothing" from "this
+  // mutation's result was lost", which is the worst possible reading of a
+  // write that succeeded.
+  it.fails("reaches the caller as a failure rather than as undefined", async () => {
+    let ran = 0;
+    registerServerFunction("gap-encode-failure", async () => {
+      ran++;
+      return {
+        ok: true,
+        get unencodable() {
+          throw new Error("cannot encode");
+        }
+      };
+    });
+
+    const disconnect = connectWire();
+    try {
+      await expect(createServerReference("gap-encode-failure")()).rejects.toThrow();
+      expect(ran).toBe(1);
+    } finally {
+      disconnect();
+    }
+  });
+});
+
+describe("a streamed result with a consumer that reads slowly", () => {
+  // The response stream is built with no `pull` and no queuing strategy,
+  // and every codec node is enqueued the moment it is parsed, so the
+  // producer runs as fast as it can resolve regardless of whether anyone
+  // is reading. One slow client on a large or infinite stream therefore
+  // buffers the whole result in server memory — invisible to application
+  // code, and unbounded.
+  it.fails("does not let the producer run unboundedly ahead", async () => {
+    let produced = 0;
+    registerServerFunction("gap-backpressure", async function* () {
+      while (produced < 100_000) {
+        produced++;
+        yield { n: produced };
+        await new Promise(resolve => setImmediate(resolve));
+      }
+    });
+
+    const response = await handleServerFunctionRequest(scriptedPost("gap-backpressure"));
+    const reader = response.body!.getReader();
+    for (let i = 0; i < 3; i++) {
+      await reader.read();
+      await new Promise(resolve => setTimeout(resolve, 20));
+    }
+    await reader.cancel();
+
+    // A generous ceiling: a bounded producer stays near the queue size,
+    // an unbounded one reaches five figures in this window.
+    expect(produced).toBeLessThan(500);
+  });
+});
+
+describe("the decode depth cap", () => {
+  // The codec's `depthLimit: 64` exists "because payloads may come from an
+  // untrusted peer", and it guards the seroval path only. The body format
+  // is chosen by the CALLER, so selecting the JSON format opts out of the
+  // cap entirely: `extractBody` hands the payload to a bare JSON.parse.
+  it.fails("holds whichever body format the caller selects", async () => {
+    registerServerFunction("gap-depth", async (value: unknown) => {
+      let depth = 0;
+      let cursor: any = value;
+      while (cursor && typeof cursor === "object" && "a" in cursor) {
+        depth++;
+        cursor = cursor.a;
+      }
+      return { depth };
+    });
+
+    const root: any = {};
+    let cursor = root;
+    for (let i = 0; i < 5_000; i++) {
+      cursor.a = {};
+      cursor = cursor.a;
+    }
+
+    const response = await handleServerFunctionRequest(
+      new Request("https://app.example/_server/data/gap-depth", {
+        method: "POST",
+        body: JSON.stringify([root]),
+        headers: {
+          "Sec-Fetch-Site": "same-origin",
+          "X-Server-Function-Instance": "server-function:test",
+          [BODY_FORMAT_HEADER]: "8"
+        }
+      })
+    );
+
+    // the seroval path answers 400 for a payload past the cap
+    expect(response.status).toBe(400);
+    expect(response.headers.has(ERROR_HEADER)).toBe(false);
+  });
+});

--- a/packages/web/test/server/server-functions-open-gaps.spec.tsx
+++ b/packages/web/test/server/server-functions-open-gaps.spec.tsx
@@ -1,28 +1,23 @@
 /**
- * Gaps that are open on `next` today, written as `it.fails` so the suite
- * stays green while they are open and turns RED the day each is fixed —
- * at which point the marker comes off and the test becomes an ordinary
- * guard. (The repo's existing idiom for "intended, not yet held" is
- * `test.skip`; these use `.fails` instead because the point is to notice
- * the fix, which a skipped test cannot do.)
- *
- * Each assertion states the behaviour that is wanted, not the behaviour
- * that happens.
+ * Gaps that are open on `next` today. Each test states the behaviour that
+ * is wanted and is marked `test.fails`, per the convention in
+ * `test/lifecycle-matrix/MATRIX.md`: the marker is the point — the suite
+ * stays green while the gap is open and turns red the day it closes, at
+ * which point the marker comes off and the test becomes an ordinary guard.
  *
  * Like the other server-function specs, these run against the built
  * bundles (server-functions/dist/*, wired up in vite.config.server.mjs).
  */
 import { AsyncLocalStorage } from "node:async_hooks";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
-  BODY_FORMAT_HEADER,
-  ERROR_HEADER,
   handleServerFunctionRequest,
   registerServerFunction
 } from "@solidjs/web/server-functions/server";
 import { createServerReference } from "@solidjs/web/server-functions/client";
 
 const RequestContext = Symbol.for("solid.RequestContext");
+const BODY_FORMAT_HEADER = "X-Server-Function-Format";
 
 beforeAll(() => {
   (globalThis as any)[RequestContext] = new AsyncLocalStorage();
@@ -46,10 +41,11 @@ function scriptedPost(id: string) {
 /**
  * Routes the client stub through the handler the way a socket does: the
  * body is drained into a buffer first, so a stream that errors mid-flight
- * reaches the client as a TRUNCATED body rather than as a live exception.
- * That is the difference between an in-process call and a deployed one.
+ * arrives as a TRUNCATED body rather than as a live exception. That is the
+ * difference between an in-process call and a deployed one, and it is the
+ * difference this gap hides behind.
  */
-function connectWire() {
+function connectBufferedTransport() {
   const original = globalThis.fetch;
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const address = input instanceof Request ? input.url : input.toString();
@@ -74,14 +70,13 @@ function connectWire() {
 }
 
 describe("a result the codec cannot encode", () => {
-  // The function already ran and committed its side effects; only the
-  // ENCODING failed, and it failed after the head was committed, so the
-  // status is spent and no error tag can be added. The truncated body
-  // then decodes to `undefined` — the same answer a void function gives.
-  // A caller cannot tell "this mutation returned nothing" from "this
-  // mutation's result was lost", which is the worst possible reading of a
-  // write that succeeded.
-  it.fails("reaches the caller as a failure rather than as undefined", async () => {
+  // GAP: the caller receives `undefined`. The function already ran and
+  // committed its side effects; only the ENCODING failed, and it failed
+  // after the head was committed, so the status is spent and no error tag
+  // can be added. The truncated body decodes to the answer a void function
+  // gives, so a write that succeeded is indistinguishable from one that
+  // returned nothing — and a data layer may retry it.
+  test.fails("reaches the caller as a failure rather than as undefined", async () => {
     let ran = 0;
     registerServerFunction("gap-encode-failure", async () => {
       ran++;
@@ -93,24 +88,34 @@ describe("a result the codec cannot encode", () => {
       };
     });
 
-    const disconnect = connectWire();
+    const restore = connectBufferedTransport();
+    let outcome: { resolved: true; value: unknown } | { resolved: false; error: unknown };
     try {
-      await expect(createServerReference("gap-encode-failure")()).rejects.toThrow();
-      expect(ran).toBe(1);
+      outcome = { resolved: true, value: await createServerReference("gap-encode-failure")() };
+    } catch (error) {
+      outcome = { resolved: false, error };
     } finally {
-      disconnect();
+      restore();
     }
+
+    expect(ran).toBe(1);
+    expect(outcome.resolved).toBe(false);
+    expect((outcome as { error: unknown }).error).toBeInstanceOf(Error);
   });
 });
 
-describe("a streamed result with a consumer that reads slowly", () => {
-  // The response stream is built with no `pull` and no queuing strategy,
-  // and every codec node is enqueued the moment it is parsed, so the
-  // producer runs as fast as it can resolve regardless of whether anyone
-  // is reading. One slow client on a large or infinite stream therefore
-  // buffers the whole result in server memory — invisible to application
-  // code, and unbounded.
-  it.fails("does not let the producer run unboundedly ahead", async () => {
+describe("a streamed result nobody is reading", () => {
+  // GAP: the producer runs unboundedly ahead. The response stream is built
+  // with no `pull` and no queuing strategy, and every codec node is
+  // enqueued the moment it is parsed, so the producer runs as fast as it
+  // can resolve whether or not anyone reads. On a large or infinite stream
+  // one slow client buffers the whole result in server memory, invisibly
+  // to application code.
+  //
+  // Counted in event-loop turns rather than wall-clock: a bounded producer
+  // stays near the queue size whatever the machine, an unbounded one
+  // tracks the turn count.
+  test.fails("does not let the producer run ahead of the consumer", async () => {
     let produced = 0;
     registerServerFunction("gap-backpressure", async function* () {
       while (produced < 100_000) {
@@ -122,24 +127,22 @@ describe("a streamed result with a consumer that reads slowly", () => {
 
     const response = await handleServerFunctionRequest(scriptedPost("gap-backpressure"));
     const reader = response.body!.getReader();
-    for (let i = 0; i < 3; i++) {
-      await reader.read();
-      await new Promise(resolve => setTimeout(resolve, 20));
+    await reader.read();
+    for (let turn = 0; turn < 200; turn++) {
+      await new Promise(resolve => setImmediate(resolve));
     }
     await reader.cancel();
 
-    // A generous ceiling: a bounded producer stays near the queue size,
-    // an unbounded one reaches five figures in this window.
-    expect(produced).toBeLessThan(500);
+    expect(produced).toBeLessThan(50);
   });
 });
 
 describe("the decode depth cap", () => {
-  // The codec's `depthLimit: 64` exists "because payloads may come from an
-  // untrusted peer", and it guards the seroval path only. The body format
-  // is chosen by the CALLER, so selecting the JSON format opts out of the
-  // cap entirely: `extractBody` hands the payload to a bare JSON.parse.
-  it.fails("holds whichever body format the caller selects", async () => {
+  // GAP: the cap is opt-out. `depthLimit: 64` exists "because payloads may
+  // come from an untrusted peer" and guards the seroval path only, while
+  // the body format is chosen by the CALLER — selecting the JSON format
+  // hands the payload to a bare JSON.parse and skips the cap entirely.
+  test.fails("holds whichever body format the caller selects", async () => {
     registerServerFunction("gap-depth", async (value: unknown) => {
       let depth = 0;
       let cursor: any = value;
@@ -150,9 +153,11 @@ describe("the decode depth cap", () => {
       return { depth };
     });
 
+    // comfortably past the 64-level cap, and well short of the ~5900
+    // nested objects that overflow V8's default stack in JSON.stringify
     const root: any = {};
     let cursor = root;
-    for (let i = 0; i < 5_000; i++) {
+    for (let i = 0; i < 500; i++) {
       cursor.a = {};
       cursor = cursor.a;
     }
@@ -169,8 +174,7 @@ describe("the decode depth cap", () => {
       })
     );
 
-    // the seroval path answers 400 for a payload past the cap
+    // the capped path answers 400 for a payload past the limit
     expect(response.status).toBe(400);
-    expect(response.headers.has(ERROR_HEADER)).toBe(false);
   });
 });


### PR DESCRIPTION
Three gaps that are open on `next` today. Each test states the behaviour that is **wanted** and is marked `test.fails`, per [`test/lifecycle-matrix/MATRIX.md`](https://github.com/solidjs/solid/blob/next/packages/web/test/lifecycle-matrix/MATRIX.md) — *"cells that FAIL against the current runtime are kept as `test.fails` with a `// GAP:` comment — those markers are the point of the suite"*.

The suite stays green while a gap is open and turns red the day it closes, at which point the marker comes off and the test becomes an ordinary guard. Tests only, no runtime change, no changeset.

### A result the codec cannot encode is delivered as `undefined` (#3117)

The function already ran and committed its side effects; only the *encoding* failed, and it failed after the head was committed — so the status is spent and no error tag can be added. The truncated body decodes to `undefined`, the same answer a void function gives.

A caller cannot tell "this mutation returned nothing" from "this mutation's result was lost". For a non-idempotent write that is the worst available reading, and a data layer may retry it.

The test drains the body into a buffer first, which is what a socket does — in-process the error surfaces live, and that difference is why this is invisible in a harness but not in a deployment.

### A streamed result has no backpressure (#3118)

The response stream is built with no `pull` and no queuing strategy, and every codec node is enqueued the moment it is parsed, so the producer runs as fast as it can resolve regardless of whether anyone is reading. On a large or infinite stream, one slow client buffers the whole result in server memory — invisible to application code and unbounded.

Counted in event-loop turns rather than wall-clock, so the assertion means the same thing on any machine: a bounded producer stays near the queue size, an unbounded one tracks the turn count. (Measured on an idle machine: ~3700 items ahead of a consumer reading three chunks over 60 ms; ~17 000 items and +19 MiB of heap over 300 ms.)

### The decode depth cap is opt-out (#3119)

`depthLimit: 64` is set *"because payloads may come from an untrusted peer"*, and it guards the seroval path only. The body format is chosen by the **caller**, so selecting the JSON format hands the payload to a bare `JSON.parse` and skips the cap entirely.

### Each fails for its own reason

Run with the markers removed:

```
AssertionError: expected true to be false        // resolved instead of rejecting
AssertionError: expected 200 to be less than 50  // producer tracked the turn count
AssertionError: expected 200 to be 400           // depth 500 decoded past the cap
```

Worth recording why that check matters: in the first commit the depth test imported `BODY_FORMAT_HEADER`, which the server entry does not export, so the request carried a header named `undefined`, the JSON format was never selected, and the function received no argument. The test failed — but not for its own reason, and `test.fails` reports that identically. It is the one real cost of this convention.