### PR TITLE
fix(web): pull a streamed result behind a demand gate

### DIFF
--- a/.changeset/stream-demand-gate.md
+++ b/.changeset/stream-demand-gate.md
@@ -8,7 +8,13 @@ every codec node is enqueued the moment it is parsed, so the producer ran
 as fast as it could resolve whether or not anyone was reading: one slow
 consumer buffered the whole result in server memory, unbounded and
 invisible to application code. The consumer's reads now drive `pull`,
-which releases one source pull at a time — measured over 200 idle
-event-loop turns, an async generator advanced by one step instead of
-running away. Teardown releases a parked pull, so an aborted or cancelled
-stream still ends.
+which releases one source pull at a time, so an unread stream stays near
+the queue size instead of running away.
+
+Scope: the gate sits on the source the runtime wraps, which is the
+result itself. An async iterable nested inside the result — `{ items:
+rows() }` — is pumped by the codec directly and is not yet gated. Ending
+the stream releases a parked pull, so an aborted, cancelled or failed
+stream still closes its source; a consumer that abandons a stream without
+cancelling it now leaves the producer parked rather than running it to
+completion.

--- a/.changeset/stream-demand-gate.md
+++ b/.changeset/stream-demand-gate.md
@@ -1,0 +1,14 @@
+---
+"@solidjs/web": patch
+---
+
+Pull a streamed server-function result behind a demand gate (#3118). The
+response stream was built with no `pull` and no queuing strategy, and
+every codec node is enqueued the moment it is parsed, so the producer ran
+as fast as it could resolve whether or not anyone was reading: one slow
+consumer buffered the whole result in server memory, unbounded and
+invisible to application code. The consumer's reads now drive `pull`,
+which releases one source pull at a time — measured over 200 idle
+event-loop turns, an async generator advanced by one step instead of
+running away. Teardown releases a parked pull, so an aborted or cancelled
+stream still ends.

--- a/packages/web/server-functions/src/server.ts
+++ b/packages/web/server-functions/src/server.ts
@@ -1676,6 +1676,20 @@ export function serializeResponseStream(value, codecOptions, signal) {
   value = guardFailures(value);
   let closeIterator = null;
   let closed = false;
+  // Demand gate. seroval's pump pulls the source as fast as it resolves and
+  // enqueues every node the moment it is parsed, so without this a slow
+  // consumer never slows the producer: the whole result accumulates in the
+  // stream's queue, in server memory, unbounded. The consumer's reads drive
+  // `pull`, which releases one source pull at a time.
+  let streamController = null;
+  let releaseDemand = null;
+  const wantsMore = () => !streamController || streamController.desiredSize > 0;
+  const awaitDemand = () => new Promise(resolve => (releaseDemand = resolve));
+  const supplyDemand = () => {
+    const resolve = releaseDemand;
+    releaseDemand = null;
+    if (resolve) resolve();
+  };
   let cancelSerialize = null;
   let onAbort = null;
   const teardown = () => {
@@ -1684,6 +1698,7 @@ export function serializeResponseStream(value, codecOptions, signal) {
     if (onAbort) signal.removeEventListener("abort", onAbort);
     if (cancelSerialize) cancelSerialize();
     if (closeIterator) closeIterator();
+    supplyDemand();
   };
   if (
     value !== null &&
@@ -1711,8 +1726,12 @@ export function serializeResponseStream(value, codecOptions, signal) {
         // torn down before the codec opened the value (abort raced the
         // codec load): close the source immediately, never pull
         if (closed) closeIterator();
+        const step = () => (finished ? { done: true, value: undefined } : it.next());
         return {
-          next: () => (finished ? Promise.resolve({ done: true, value: undefined }) : it.next())
+          // Waits for the consumer to want a chunk before pulling the next
+          // one; `finished` is re-read after the wait, since teardown can
+          // land while it is parked.
+          next: () => (wantsMore() ? Promise.resolve(step()) : awaitDemand().then(step))
         };
       }
     };
@@ -1722,6 +1741,7 @@ export function serializeResponseStream(value, codecOptions, signal) {
     // the top of shared.js), and a ReadableStream start may return a
     // promise — reads wait for it, so the stream's contract is unchanged
     async start(controller) {
+      streamController = controller;
       if (signal) {
         if (signal.aborted) {
           teardown();
@@ -1792,6 +1812,9 @@ export function serializeResponseStream(value, codecOptions, signal) {
           }
         }
       });
+    },
+    pull() {
+      supplyDemand();
     },
     cancel() {
       teardown();

--- a/packages/web/server-functions/src/server.ts
+++ b/packages/web/server-functions/src/server.ts
@@ -1745,9 +1745,14 @@ export function serializeResponseStream(value, codecOptions, signal) {
         const step = () => (finished ? { done: true, value: undefined } : it.next());
         return {
           // Pulls straight through while the queue has room, and parks
-          // until a read makes room when it does not. `finished` is re-read
-          // after the wait, since teardown can land while it is parked.
-          next: () => (wantsMore() ? Promise.resolve(step()) : awaitDemand().then(step))
+          // until a read makes room when it does not. `finished` is checked
+          // FIRST: teardown can land while a pull is in flight, and the
+          // release it fires then finds nothing parked — so a gate checked
+          // first would park the next pull on a resolver nobody will ever
+          // call, stranding the codec's pump. `finished` is re-read after
+          // the wait for the same reason from the other direction.
+          next: () =>
+            finished || wantsMore() ? Promise.resolve(step()) : awaitDemand().then(step)
         };
       }
     };

--- a/packages/web/server-functions/src/server.ts
+++ b/packages/web/server-functions/src/server.ts
@@ -1681,9 +1681,18 @@ export function serializeResponseStream(value, codecOptions, signal) {
   // consumer never slows the producer: the whole result accumulates in the
   // stream's queue, in server memory, unbounded. The consumer's reads drive
   // `pull`, which releases one source pull at a time.
+  //
+  // `desiredSize > 0` means "fewer than one chunk queued": the stream takes
+  // no queuing strategy, so it runs on the default high-water mark of 1.
+  // That default is what sets the depth, and raising it is how you would
+  // trade memory for fewer round trips.
+  //
+  // One resolver is enough because the pump is sequential — the same reason
+  // the wrapper below only exposes `next()`. Two concurrent pulls would
+  // overwrite it and strand the first.
   let streamController = null;
   let releaseDemand = null;
-  const wantsMore = () => !streamController || streamController.desiredSize > 0;
+  const wantsMore = () => streamController.desiredSize > 0;
   const awaitDemand = () => new Promise(resolve => (releaseDemand = resolve));
   const supplyDemand = () => {
     const resolve = releaseDemand;
@@ -1692,13 +1701,20 @@ export function serializeResponseStream(value, codecOptions, signal) {
   };
   let cancelSerialize = null;
   let onAbort = null;
+  // Ends the source and releases a pull parked on the demand gate. Every
+  // path that stops the stream has to run this: a parked pull holds the
+  // source open and nothing else will resolve it — `desiredSize` is 0 after
+  // close and null after error, so the gate never reopens on its own.
+  const finishSource = () => {
+    if (closeIterator) closeIterator();
+    supplyDemand();
+  };
   const teardown = () => {
     if (closed) return;
     closed = true;
     if (onAbort) signal.removeEventListener("abort", onAbort);
     if (cancelSerialize) cancelSerialize();
-    if (closeIterator) closeIterator();
-    supplyDemand();
+    finishSource();
   };
   if (
     value !== null &&
@@ -1728,9 +1744,9 @@ export function serializeResponseStream(value, codecOptions, signal) {
         if (closed) closeIterator();
         const step = () => (finished ? { done: true, value: undefined } : it.next());
         return {
-          // Waits for the consumer to want a chunk before pulling the next
-          // one; `finished` is re-read after the wait, since teardown can
-          // land while it is parked.
+          // Pulls straight through while the queue has room, and parks
+          // until a read makes room when it does not. `finished` is re-read
+          // after the wait, since teardown can land while it is parked.
           next: () => (wantsMore() ? Promise.resolve(step()) : awaitDemand().then(step))
         };
       }
@@ -1781,12 +1797,14 @@ export function serializeResponseStream(value, codecOptions, signal) {
           if (closed) return;
           closed = true;
           if (onAbort) signal.removeEventListener("abort", onAbort);
+          finishSource();
           controller.close();
         },
         onError(error) {
           if (closed) return;
           closed = true;
           if (onAbort) signal.removeEventListener("abort", onAbort);
+          finishSource();
           // The head is committed by the time an encode failure arrives, so
           // the status is spent and no error tag can be added — and merely
           // erroring the stream truncates the body over a socket, which the

--- a/packages/web/test/server/server-functions-open-gaps.spec.tsx
+++ b/packages/web/test/server/server-functions-open-gaps.spec.tsx
@@ -161,17 +161,18 @@ describe("a result the codec cannot encode", () => {
 });
 
 describe("a streamed result nobody is reading", () => {
-  // GAP (#3118): the producer runs unboundedly ahead. The response stream is built
-  // with no `pull` and no queuing strategy, and every codec node is
-  // enqueued the moment it is parsed, so the producer runs as fast as it
-  // can resolve whether or not anyone reads. On a large or infinite stream
-  // one slow client buffers the whole result in server memory, invisibly
-  // to application code.
+  // Closed (#3118): the source is pulled behind a demand gate. The stream
+  // was built with no `pull` and no queuing strategy, and every codec node
+  // is enqueued the moment it is parsed, so the producer ran as fast as it
+  // could resolve whether or not anyone read — one slow client buffered
+  // the whole result in server memory, invisibly to application code. The
+  // consumer's reads now drive `pull`, which releases one source pull at a
+  // time. Ordinary guard now.
   //
-  // Counted in event-loop turns rather than wall-clock: a bounded producer
-  // stays near the queue size whatever the machine, an unbounded one
-  // tracks the turn count.
-  test.fails("does not let the producer run ahead of the consumer", async () => {
+  // Counted in event-loop turns rather than wall-clock, so the assertion
+  // means the same thing on any machine: a gated producer stays near the
+  // queue size, an ungated one tracks the turn count.
+  test("does not let the producer run ahead of the consumer", async () => {
     let produced = 0;
     registerServerFunction("gap-backpressure", async function* () {
       while (produced < 100_000) {
@@ -190,6 +191,32 @@ describe("a streamed result nobody is reading", () => {
     await reader.cancel();
 
     expect(produced).toBeLessThan(50);
+  });
+
+  test("resumes as the consumer reads, and stops when it leaves", async () => {
+    let produced = 0;
+    registerServerFunction("gap-backpressure-resume", async function* () {
+      while (produced < 100_000) {
+        produced++;
+        yield { n: produced };
+        await new Promise(resolve => setImmediate(resolve));
+      }
+    });
+
+    const response = await handleServerFunctionRequest(scriptedPost("gap-backpressure-resume"));
+    const reader = response.body!.getReader();
+    for (let read = 0; read < 20; read++) await reader.read();
+    const whileReading = produced;
+    await reader.cancel();
+    const atCancel = produced;
+    for (let turn = 0; turn < 50; turn++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+
+    // it kept up with the reads rather than stalling behind them...
+    expect(whileReading).toBeGreaterThan(1);
+    // ...and a departed consumer stops it, give or take the pull in flight
+    expect(produced).toBeLessThanOrEqual(atCancel + 1);
   });
 });
 

--- a/packages/web/test/server/server-functions-open-gaps.spec.tsx
+++ b/packages/web/test/server/server-functions-open-gaps.spec.tsx
@@ -292,9 +292,11 @@ describe("a streamed result nobody is reading", () => {
       await new Promise(resolve => setImmediate(resolve));
     }
 
-    // liveness: test 1 passes just as well if the gate never reopens, so
-    // this is the case that would catch a deadlock. A healthy run tracks
-    // the reads almost exactly; the bound is loose enough for a slow CI.
+    // This pins the CANCEL half — that a departed consumer stops the
+    // producer. It does not catch a gate that never reopens: reading in a
+    // tight loop keeps a read request pending, so `desiredSize` never
+    // drops and nothing ever parks. The pausing test above is the one that
+    // catches that, and it took two attempts to learn the difference.
     expect(whileReading).toBeGreaterThanOrEqual(10);
     // ...and a departed consumer stops it, give or take the pull in flight
     expect(produced).toBeLessThanOrEqual(atCancel + 1);

--- a/packages/web/test/server/server-functions-open-gaps.spec.tsx
+++ b/packages/web/test/server/server-functions-open-gaps.spec.tsx
@@ -211,36 +211,41 @@ describe("a streamed result nobody is reading", () => {
   // after close and null after error — so the gate never reopens on its own
   // and every path that ends the stream has to release it. Without that the
   // source's cleanup silently never runs, once per failed request.
-  test("releases a parked pull when the codec ends the stream", async () => {
+  test("a codec failure landing while a pull is parked still closes the source", async () => {
     let cleanedUp = false;
-    registerServerFunction("gap-backpressure-cleanup", async () => ({
-      rows: (async function* () {
-        try {
-          for (let n = 0; n < 20; n++) {
-            yield { n };
-            await new Promise(resolve => setImmediate(resolve));
-          }
-        } finally {
-          cleanedUp = true;
+    let produced = 0;
+    // The failure has to ride INSIDE a yielded chunk of the top-level
+    // source. Putting it on a sibling branch makes the generator nested,
+    // and a nested iterable never reaches the gate at all — which is why
+    // `produced` is asserted too: it proves the source really parked, so
+    // this cannot quietly decay into testing nothing.
+    registerServerFunction("gap-backpressure-teardown", async function* () {
+      try {
+        produced++;
+        yield {
+          late: Promise.resolve().then(() => ({
+            get boom(): never {
+              throw new Error("unencodable, discovered after the gate parked");
+            }
+          }))
+        };
+        for (let n = 0; n < 20; n++) {
+          produced++;
+          yield { n };
         }
-      })(),
-      unencodable: {
-        get boom(): never {
-          throw new Error("a deferred encode failure, landing while a pull is parked");
-        }
+      } finally {
+        cleanedUp = true;
       }
-    }));
+    });
 
-    const response = await handleServerFunctionRequest(scriptedPost("gap-backpressure-cleanup"));
+    const response = await handleServerFunctionRequest(scriptedPost("gap-backpressure-teardown"));
     const reader = response.body!.getReader();
-    // ONE read, then stop: the source parks on the gate, and the encode
-    // failure on the sibling branch ends the stream while it is parked.
-    // Draining instead would never park, and would never reach the defect.
     await reader.read();
     for (let turn = 0; turn < 20; turn++) {
       await new Promise(resolve => setTimeout(resolve, 0));
     }
 
+    expect(produced).toBe(1);
     expect(cleanedUp).toBe(true);
   });
 

--- a/packages/web/test/server/server-functions-open-gaps.spec.tsx
+++ b/packages/web/test/server/server-functions-open-gaps.spec.tsx
@@ -4,7 +4,7 @@
  * `test/lifecycle-matrix/MATRIX.md`: the marker is the point — the suite
  * stays green while the gap is open and turns red the day it closes, at
  * which point the marker comes off and the test becomes an ordinary guard.
- * Each carries the issue that tracks it: #3118 (open); #3117 (closed by
+ * Each carries the issue that tracks it: #3118 (closed); #3117 (closed by
  * the error trailer frame) and #3119 (closed by #3115's request bounds)
  * remain as ordinary guards, with the trailer's full matrix alongside.
  *
@@ -193,6 +193,57 @@ describe("a streamed result nobody is reading", () => {
     expect(produced).toBeLessThan(50);
   });
 
+  test("drains to completion, so the gate cannot swallow the tail", async () => {
+    registerServerFunction("gap-backpressure-drain", async function* () {
+      for (let n = 0; n < 40; n++) {
+        yield { n };
+        await new Promise(resolve => setImmediate(resolve));
+      }
+    });
+
+    const response = await handleServerFunctionRequest(scriptedPost("gap-backpressure-drain"));
+    // a gate that never reopened, or one that missed the last chunk, hangs
+    // here instead of failing an assertion — which is the point
+    expect((await response.text()).length).toBeGreaterThan(0);
+  });
+
+  // A pull parked on the gate holds the source open, and `desiredSize` is 0
+  // after close and null after error — so the gate never reopens on its own
+  // and every path that ends the stream has to release it. Without that the
+  // source's cleanup silently never runs, once per failed request.
+  test("releases a parked pull when the codec ends the stream", async () => {
+    let cleanedUp = false;
+    registerServerFunction("gap-backpressure-cleanup", async () => ({
+      rows: (async function* () {
+        try {
+          for (let n = 0; n < 20; n++) {
+            yield { n };
+            await new Promise(resolve => setImmediate(resolve));
+          }
+        } finally {
+          cleanedUp = true;
+        }
+      })(),
+      unencodable: {
+        get boom(): never {
+          throw new Error("a deferred encode failure, landing while a pull is parked");
+        }
+      }
+    }));
+
+    const response = await handleServerFunctionRequest(scriptedPost("gap-backpressure-cleanup"));
+    const reader = response.body!.getReader();
+    // ONE read, then stop: the source parks on the gate, and the encode
+    // failure on the sibling branch ends the stream while it is parked.
+    // Draining instead would never park, and would never reach the defect.
+    await reader.read();
+    for (let turn = 0; turn < 20; turn++) {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+
+    expect(cleanedUp).toBe(true);
+  });
+
   test("resumes as the consumer reads, and stops when it leaves", async () => {
     let produced = 0;
     registerServerFunction("gap-backpressure-resume", async function* () {
@@ -213,8 +264,10 @@ describe("a streamed result nobody is reading", () => {
       await new Promise(resolve => setImmediate(resolve));
     }
 
-    // it kept up with the reads rather than stalling behind them...
-    expect(whileReading).toBeGreaterThan(1);
+    // liveness: test 1 passes just as well if the gate never reopens, so
+    // this is the case that would catch a deadlock. A healthy run tracks
+    // the reads almost exactly; the bound is loose enough for a slow CI.
+    expect(whileReading).toBeGreaterThanOrEqual(10);
     // ...and a departed consumer stops it, give or take the pull in flight
     expect(produced).toBeLessThanOrEqual(atCancel + 1);
   });

--- a/packages/web/test/server/server-functions-open-gaps.spec.tsx
+++ b/packages/web/test/server/server-functions-open-gaps.spec.tsx
@@ -193,18 +193,41 @@ describe("a streamed result nobody is reading", () => {
     expect(produced).toBeLessThan(50);
   });
 
-  test("drains to completion, so the gate cannot swallow the tail", async () => {
-    registerServerFunction("gap-backpressure-drain", async function* () {
-      for (let n = 0; n < 40; n++) {
-        yield { n };
-        await new Promise(resolve => setImmediate(resolve));
-      }
+  // The gate has to REOPEN, not merely close, and nothing above proves it:
+  // a consumer that reads in a tight loop always has a read request
+  // pending, so `desiredSize` never drops and the producer never parks.
+  // Pausing between reads is what puts it on the gate. Deleting `pull()`
+  // outright leaves every other test in this file green and deadlocks this
+  // one, which is the whole point of it.
+  test("keeps delivering after the consumer pauses long enough to park it", async () => {
+    registerServerFunction("gap-backpressure-park", async function* () {
+      for (let n = 0; n < 12; n++) yield { n };
     });
 
-    const response = await handleServerFunctionRequest(scriptedPost("gap-backpressure-drain"));
-    // a gate that never reopened, or one that missed the last chunk, hangs
-    // here instead of failing an assertion — which is the point
-    expect((await response.text()).length).toBeGreaterThan(0);
+    const response = await handleServerFunctionRequest(scriptedPost("gap-backpressure-park"));
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let body = "";
+
+    for (;;) {
+      // long enough for the queue to drain and the next pull to park
+      for (let turn = 0; turn < 5; turn++) {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      }
+      const next = await Promise.race([
+        reader.read(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("the gate parked and never reopened")), 2000)
+        )
+      ]);
+      if (next.done) break;
+      body += decoder.decode(next.value as Uint8Array);
+    }
+
+    // every item arrived, so the gate released each park in turn. Counted
+    // by this test's own key rather than by the codec's node shapes, which
+    // are not what it is about.
+    expect(body.split('["n"]').length - 1).toBe(12);
   });
 
   // A pull parked on the gate holds the source open, and `desiredSize` is 0


### PR DESCRIPTION
Closes #3118.

The response stream is built with no `pull` and no queuing strategy, and every codec node is enqueued the moment it is parsed, so the producer runs as fast as it can resolve regardless of whether anyone is reading. One slow consumer buffers the whole result in server memory — unbounded, and invisible to application code.

### The seam was already there

The iterator wrapper the runtime installs describes itself as *"the only seam where a dropped consumer can stop the producer"*. The same seam lets a **slow** consumer slow it: a read drives `pull`, and `pull` releases exactly one source pull. Ending the stream releases a parked pull too, or the source would be stranded.

`desiredSize > 0` means "fewer than one chunk queued" — the stream takes no queuing strategy, so it runs on the default high-water mark of 1. That default is what sets the depth, and it is load-bearing, so the comment says so.

### Measured

Consumer reads one chunk, then idles for 200 event-loop turns:

```
before:  producer at 200      (~17,000 items and +19 MiB in the issue's wall-clock shape)
after:   producer at 1
         reading 21 chunks advances it to 20
         cancelling stops it within the pull in flight
```

Counted in turns rather than wall-clock, so the assertion means the same thing on any machine. Throughput for a fast consumer draining a 20k-item stream is unchanged (~91 ms on both branches, within noise), and a non-streamed result never enters the wrapper.

### Scope, stated plainly

The gate sits on the source the runtime wraps — the result itself. An async iterable **nested** inside the result (`{ items: rows() }`) is pumped by the codec directly and is not gated: measured at 200 items over 200 idle turns, against 1 for the top-level shape. That is the ordinary shape, so it is worth knowing this fixes half the problem. Filed as #3125 rather than widened here, because this PR had already grown two review-found defects and adding surface without another pass seemed the wrong trade.

A consumer that abandons a stream without cancelling now leaves the producer parked rather than running it to completion. That is inherent to backpressure and the consumer's side of the WHATWG contract, but it is a behaviour change.

And the limit worth knowing before treating this as a memory guarantee: **the gate only bites if whatever writes the response to the socket propagates backpressure into `desiredSize`.** An adapter that pipes `Response.body` does; one that drains it eagerly — `for await (… ) res.write(chunk)` ignoring `write`'s return, or buffering before writing — does not, and against that adapter this is a no-op observable only in-process. I have not measured a real adapter, so I am not claiming either way; the tests here prove the runtime-side property, which is the part this repository owns.

### What review found

Three rounds, and the third found the sharpest one.

**The gate was checked before `finished`.** Teardown landing while a pull was in flight stranded the codec's pump: the release it fires finds nothing parked, the in-flight pull resolves, the pump asks for the next item, `wantsMore()` is false — 0 after close, null after error — and it parks on a resolver nobody will ever call. `push()` never returns. One token to fix, and it mirrors the previous round exactly: that defect stranded the source, this one stranded the pump.

That half is **not guarded by a test**, and I would rather say so than imply otherwise. The failure is a leaked pending promise inside seroval's pump with no outward symptom — the source still runs its `finally`, the response still ends, nothing observable differs. It was found with instrumented park/release counters, and that measurement is the evidence it rests on.

**The tests did not park at all.** Both read in a tight loop, so a read request was always pending, `desiredSize` never dropped, and the producer never reached the gate. Deleting `pull()` outright — removing the entire reopening mechanism — left all eight green, including the one whose comment claimed it would catch a deadlock. The new test pauses between reads, which is what puts the producer on the gate, and reads to completion behind a deadline so a gate that never reopens fails fast instead of hanging.

Earlier rounds. The first shape had a regression I introduced: `onDone` and `onError` set `closed` directly rather than through `teardown()`, so a pull parked on the gate was stranded — `desiredSize` is 0 after close and null after error, both failing the `> 0` check, so the gate never reopened and the source's `finally` never ran, leaking generator and cursor cleanup once per failed request. Every path that ends the stream now runs `finishSource()`.

Also corrected: an unreachable `!streamController` guard, a stale `#3118 (open)` line in the spec header, a changeset that claimed more than the test asserts, and a liveness assertion of `> 1` sitting under a comment claiming it tracked the reads.

### Tests

The `test.fails` marker #3112 put on this gap comes off, following the convention the other two gaps used when they closed. Alongside it: the producer resumes as the consumer reads and stops when it leaves (which pins the cancel half; the pausing test is the liveness one).

And the regression above: a codec failure landing while a pull is parked must still close the source.

Checked by mutation:

| mutation | result |
| --- | --- |
| gate forced permanently open | `expected 200 to be less than 50` |
| `finishSource()` removed from the codec-end paths | `expected false to be true` |
| `pull()` gutted, so the gate never reopens | `the gate parked and never reopened` |

The second guard took two attempts. The first version passed with the fix removed — the source was nested, so nothing ever parked, and a nested iterable never reaches the gate. A top-level source needs no sibling branch: the deferred failure rides *inside* a yielded chunk, so the pump enqueues it, asks for the next item, parks, and only then does the failure land. `produced` is asserted alongside the cleanup so that mistake cannot quietly recur.

Full suite green: 45 files, 456 passed, 2 skipped; the spec is stable over repeated runs.

### A later correction

Review caught two things in this description. The line about a test that "drains to completion" described a test commit `f2824f6` had already replaced, and the claim that the resume test was the liveness assertion was wrong — it reads in a tight loop, so nothing ever parks, which is the same blindness the third round found in the original pair. The pausing test is what catches a gate that never reopens; the resume test pins the cancel half. Both the body and the test's own comment now say so.
