### PR TITLE
test(web): pin the HTTP invariants nothing was watching

### DIFF
--- a/packages/web/test/server/server-functions-addressing.spec.tsx
+++ b/packages/web/test/server/server-functions-addressing.spec.tsx
@@ -18,7 +18,7 @@
  * (server-functions/dist/*, wired up in vite.config.server.mjs).
  */
 import { AsyncLocalStorage } from "node:async_hooks";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   GET as serverGET,
   createServerReference as createServerSideReference,
@@ -364,5 +364,86 @@ describe("server-function addressing (#3070, built bundles)", () => {
 
   it("refuses to render bound arguments JSON cannot carry", () => {
     expect(() => serverFunctionUrl("addr-bound-1", [new Date()])).toThrow(/JSON-safe/);
+  });
+
+  it("does not fold an encoded path or control character onto the plain id", async () => {
+    // The segment is percent-DECODED before the registry is asked, so what
+    // arrives is a different string than the id it was built from and the
+    // lookup misses. The failure mode this rules out is the opposite one:
+    // a runtime that normalized, trimmed or stripped the decoded segment
+    // would let a caller reach `addr-encoded` by an address that no edge
+    // rule, cache key or log line agrees is `addr-encoded` — per-function
+    // policy keyed on the path stops applying to a call that dispatches.
+    const fn = vi.fn(async () => "reached");
+    registerServerFunction("addr-encoded", fn);
+
+    for (const path of [
+      "/_server/%2e%2e%2faddr-encoded", // `../addr-encoded`
+      "/_server/data/%2e%2e%2faddr-encoded",
+      "/_server/addr-encoded%00", // a trailing NUL
+      "/_server/addr-encoded%20", // trailing space
+      "/_server/addr-encoded%0a", // trailing newline
+      "/_server/%20addr-encoded" // leading space
+    ]) {
+      const response = await unscripted(path, { method: "POST" });
+      expect([path, response.status]).toEqual([path, 404]);
+    }
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("reads the `data` segment and the mount literally", async () => {
+    // `data` is a path segment, not a keyword: matched case-sensitively
+    // like every other segment, so `DATA` is simply a two-segment path the
+    // addresses give no meaning to. The mount is compared at a segment
+    // boundary for the same reason — a sibling route whose path merely
+    // STARTS with the mount is somebody else's route, and answering on it
+    // would put a dispatch behind an address the app never advertised.
+    const fn = vi.fn(async () => "reached");
+    registerServerFunction("addr-literal", fn);
+
+    for (const path of [
+      "/_server/DATA/addr-literal",
+      "/_server/Data/addr-literal",
+      "/_serverfoo/data/addr-literal",
+      "/_serverfoo/addr-literal"
+    ]) {
+      const response = await unscripted(path, { method: "POST" });
+      expect([path, response.status]).toEqual([path, 404]);
+    }
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("refuses an oversized id before reading the request body", async () => {
+    // An id is a compiler-minted string; a 200 KB one is somebody probing.
+    // It has to cost nothing to say no: the id is resolved from the path
+    // before the body is buffered or decoded, so the refusal is a registry
+    // miss and the payload behind it is never paid for. Moving the bounds
+    // check ahead of the lookup — a plausible-looking tidy-up — would make
+    // every junk address cost a full body read first.
+    registerServerFunction("addr-oversized", async () => "ok");
+    // a chunked upload, so the body is only paid for if something reads it
+    let pulls = 0;
+    const body = new ReadableStream({
+      pull(controller) {
+        pulls++;
+        controller.enqueue(new TextEncoder().encode("[]"));
+        if (pulls >= 64) controller.close();
+      }
+    });
+    const response = await handleServerFunctionRequest(
+      new Request(`http://localhost/_server/${"z".repeat(200_000)}`, {
+        method: "POST",
+        body,
+        // @ts-expect-error a streaming request body needs the node duplex flag
+        duplex: "half",
+        headers: { "Sec-Fetch-Site": "same-origin" }
+      })
+    );
+
+    expect(response.status).toBe(404);
+    // one pull is the stream filling its own queue on construction; more
+    // than that is the runtime reading a payload it has already decided
+    // to refuse
+    expect(pulls).toBeLessThanOrEqual(1);
   });
 });

--- a/packages/web/test/server/server-functions-addressing.spec.tsx
+++ b/packages/web/test/server/server-functions-addressing.spec.tsx
@@ -413,7 +413,7 @@ describe("server-function addressing (#3070, built bundles)", () => {
     expect(fn).not.toHaveBeenCalled();
   });
 
-  it("refuses an oversized id before reading the request body", async () => {
+  it("answers an unknown id before buffering the request body", async () => {
     // An id is a compiler-minted string; a 200 KB one is somebody probing.
     // It has to cost nothing to say no: the id is resolved from the path
     // before the body is buffered or decoded, so the refusal is a registry

--- a/packages/web/test/server/server-functions-csrf.spec.tsx
+++ b/packages/web/test/server/server-functions-csrf.spec.tsx
@@ -228,11 +228,29 @@ describe("the origin gate's reading of the headers", () => {
     // absence of an Origin (which the deployment may opt into accepting)
     // and it is not an origin that can match one: it is a caller declining
     // to say where it came from, on a request that carries cookies.
+    // Run with the no-proof escape hatch OPEN: a request carrying nothing
+    // would be accepted here, so the refusal below can only come from the
+    // literal `null` itself. Without that, this passes on a gate that has
+    // stopped reading Origin at all.
     const fn = vi.fn(async () => "ok");
     registerServerFunction("csrf-reading", fn);
+    const lenient = { csrf: { allowRequestsWithoutOriginCheck: true }, provideEvent };
 
-    expect((await post({ Origin: "null" })).status).toBe(403);
-    expect(fn).not.toHaveBeenCalled();
+    const noProof = await handleServerFunctionRequest(
+      new Request("https://app.example/_server/csrf-reading", { method: "POST" }),
+      lenient
+    );
+    expect(noProof.status).toBe(200);
+
+    const opaque = await handleServerFunctionRequest(
+      new Request("https://app.example/_server/csrf-reading", {
+        method: "POST",
+        headers: { Origin: "null" }
+      }),
+      lenient
+    );
+    expect(opaque.status).toBe(403);
+    expect(fn).toHaveBeenCalledOnce();
   });
 
   it("compares the Origin byte for byte: scheme, host case and port all count", async () => {
@@ -288,16 +306,6 @@ describe("the origin gate's reading of the headers", () => {
       expect([referer, response.status]).toEqual([referer, 403]);
     }
     expect(fn).not.toHaveBeenCalled();
-  });
-
-  it("reads only the origin out of a Referer, path and all", async () => {
-    // The default `Referrer-Policy` sends the full url same-origin, so the
-    // common case carries a path, a query and sometimes a fragment. Only
-    // the origin is compared; the rest is the referring page's business.
-    registerServerFunction("csrf-reading", async () => "ok");
-
-    const response = await post({ Referer: "https://app.example/orders/7?tab=items#total" });
-    expect(response.status).toBe(200);
   });
 
   it("falls through to Origin when Sec-Fetch-Site carries a value it does not know", async () => {

--- a/packages/web/test/server/server-functions-csrf.spec.tsx
+++ b/packages/web/test/server/server-functions-csrf.spec.tsx
@@ -206,6 +206,156 @@ describe("the origin gate's decision matrix", () => {
 });
 
 /**
+ * How the gate READS the headers, as opposed to which one it consults.
+ * `Origin` is compared as a string against the request url's origin, and
+ * `Referer` contributes only its origin — so every case below is really
+ * one question: what does a browser actually put in these headers, and
+ * what happens to everything else that can arrive there? Every answer is
+ * fail-closed, and each is a single `.toLowerCase()` or `.normalize()`
+ * away from being fail-open, which is why they are written down.
+ */
+describe("the origin gate's reading of the headers", () => {
+  function post(headers: Record<string, string>, host = "app.example") {
+    return handleServerFunctionRequest(
+      new Request(`https://${host}/_server/csrf-reading`, { method: "POST", headers }),
+      { provideEvent }
+    );
+  }
+
+  it("refuses `Origin: null` — an opaque origin proves nothing", async () => {
+    // A sandboxed iframe, a `no-referrer` redirect chain and a few
+    // privacy extensions all send the literal string `null`. It is not the
+    // absence of an Origin (which the deployment may opt into accepting)
+    // and it is not an origin that can match one: it is a caller declining
+    // to say where it came from, on a request that carries cookies.
+    const fn = vi.fn(async () => "ok");
+    registerServerFunction("csrf-reading", fn);
+
+    expect((await post({ Origin: "null" })).status).toBe(403);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("compares the Origin byte for byte: scheme, host case and port all count", async () => {
+    // Browsers serialize an origin one way (lowercase scheme and host, the
+    // default port omitted), so anything else in this header did not come
+    // from a browser's serializer. The tempting repair is to run the header
+    // through the URL parser too, which would make every line below match:
+    // that is a security gate deciding which spellings of a host are "the
+    // same" — case folding, IDNA mapping, default-port equivalence — on
+    // behalf of a caller that already had one correct way to say it.
+    const fn = vi.fn(async () => "ok");
+    registerServerFunction("csrf-reading", fn);
+
+    for (const origin of [
+      "http://app.example", // scheme
+      "HTTPS://app.example", // scheme case
+      "https://APP.example", // host case
+      "https://app.example:443", // the default port, spelled out
+      "https://app.example:8443" // a different port is a different origin
+    ]) {
+      const response = await post({ Origin: origin });
+      expect([origin, response.status]).toEqual([origin, 403]);
+    }
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("matches a punycode Origin against a unicode host, and refuses a lookalike", async () => {
+    // A browser sends the ASCII (punycode) form of an internationalized
+    // host in `Origin`, while the request url may be written either way —
+    // the URL parser applies IDNA to it, so the two meet in punycode. The
+    // lookalike is `примep.example`, spelled with a Latin `p`: it renders
+    // identically and encodes to a different label, which is exactly the
+    // case a homograph attack turns on.
+    registerServerFunction("csrf-reading", async () => "ok");
+
+    const matching = await post({ Origin: "https://xn--e1afmkfd.example" }, "пример.example");
+    expect(matching.status).toBe(200);
+
+    const lookalike = await post({ Origin: "https://xn--ep-vlcqng.example" }, "пример.example");
+    expect(lookalike.status).toBe(403);
+  });
+
+  it("refuses a Referer that parses but names no origin", async () => {
+    // Distinct from the unparseable Referer above: these are well-formed
+    // URLs whose origin serializes to the string `null`. Reading them as
+    // "no Referer" would quietly promote them to the no-proof branch,
+    // which a deployment may have opted into accepting.
+    const fn = vi.fn(async () => "ok");
+    registerServerFunction("csrf-reading", fn);
+
+    for (const referer of ["data:text/html,<form>", "about:blank"]) {
+      const response = await post({ Referer: referer });
+      expect([referer, response.status]).toEqual([referer, 403]);
+    }
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("reads only the origin out of a Referer, path and all", async () => {
+    // The default `Referrer-Policy` sends the full url same-origin, so the
+    // common case carries a path, a query and sometimes a fragment. Only
+    // the origin is compared; the rest is the referring page's business.
+    registerServerFunction("csrf-reading", async () => "ok");
+
+    const response = await post({ Referer: "https://app.example/orders/7?tab=items#total" });
+    expect(response.status).toBe(200);
+  });
+
+  it("falls through to Origin when Sec-Fetch-Site carries a value it does not know", async () => {
+    // The header's values are a closed set, matched case-sensitively as
+    // the spec defines them. Anything else — a proxy rewriting the case, a
+    // future value, a fabricated one — is not evidence, so the gate
+    // carries on to `Origin` rather than treating an unrecognised value as
+    // either proof or refusal.
+    registerServerFunction("csrf-reading", async () => "ok");
+
+    const trusted = await post({
+      "Sec-Fetch-Site": "SAME-ORIGIN",
+      Origin: "https://app.example"
+    });
+    expect(trusted.status).toBe(200);
+
+    const untrusted = await post({
+      "Sec-Fetch-Site": "SAME-ORIGIN",
+      Origin: "https://evil.example"
+    });
+    expect(untrusted.status).toBe(403);
+
+    // and on its own it proves nothing, so the no-proof branch decides
+    expect((await post({ "Sec-Fetch-Site": "banana" })).status).toBe(403);
+  });
+
+  it("refuses a duplicated Sec-Fetch-Site or Origin", async () => {
+    // A header sent twice arrives comma-joined (`Headers.get` on the
+    // platform's own implementation), which matches neither the closed set
+    // of fetch-site values nor any origin. Both fields are single-valued,
+    // so a duplicate is a request that passed through something that
+    // appends rather than replaces — a header-smuggling shape, and the one
+    // place where "be liberal in what you accept" hands an attacker a
+    // second bite at the value the gate reads.
+    const fn = vi.fn(async () => "ok");
+    registerServerFunction("csrf-reading", fn);
+
+    const site = new Headers();
+    site.append("Sec-Fetch-Site", "same-origin");
+    site.append("Sec-Fetch-Site", "same-origin");
+    expect(site.get("Sec-Fetch-Site")).toBe("same-origin, same-origin");
+
+    const origin = new Headers();
+    origin.append("Origin", "https://app.example");
+    origin.append("Origin", "https://app.example");
+
+    for (const headers of [site, origin]) {
+      const response = await handleServerFunctionRequest(
+        new Request("https://app.example/_server/csrf-reading", { method: "POST", headers }),
+        { provideEvent }
+      );
+      expect(response.status).toBe(403);
+    }
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+/**
  * GET-declared reads and the gate (#3114). The default skip is deliberate —
  * same-origin policy already keeps a cross-site caller from READING the
  * response, and the gate's `Vary` fragments the shared-cache entries the

--- a/packages/web/test/server/server-functions-encode-hygiene.spec.tsx
+++ b/packages/web/test/server/server-functions-encode-hygiene.spec.tsx
@@ -6,6 +6,8 @@
  *   message (nine-fold inflated by percent-encoding for non-latin1) blows
  *   past receiver header limits and the whole response stops being
  *   readable: a network error in place of the application error (#3093).
+ *   The same value is flattened of CR/LF, so a message built from input
+ *   cannot split the response into headers of its own making.
  * - Null-body statuses (204, 205, 304) answer void results with a real
  *   null-body response instead of a `TypeError` from the `Response`
  *   constructor that dispatch's catch used to sanitize into a phantom
@@ -112,6 +114,37 @@ describe("error header value is bounded (#3093)", () => {
 
     const response = await handleServerFunctionRequest(scriptedPost("encode-header-short"));
     expect(response.headers.get(ERROR_HEADER)).toBe("boom");
+  });
+
+  it("strips CR/LF so the label cannot become a header of its own", async () => {
+    // The label is derived from an error MESSAGE, and a message is often
+    // built from input — a parse error quoting the offending line, a
+    // validation error echoing a field. A bare CRLF in a header value is
+    // response splitting: everything after it reads as further headers,
+    // and then as a body, to anything on the path that parses the response
+    // itself (a proxy, a cache, an older HTTP client). The value is
+    // stripped rather than encoded here because the label is only ever a
+    // classification hint; the message itself travels in the body, so
+    // nothing is lost by flattening it.
+    registerServerFunction("encode-header-crlf", async () => {
+      throw markSafeError(new Error("boom\r\nX-Injected: yes"));
+    });
+
+    const response = await handleServerFunctionRequest(scriptedPost("encode-header-crlf"));
+    const header = response.headers.get(ERROR_HEADER)!;
+    expect(header).toBe("boomX-Injected: yes");
+    expect(header).not.toMatch(/[\r\n]/);
+    expect(response.headers.has("X-Injected")).toBe(false);
+
+    // the real message, newlines included, still arrives through the body
+    const restore = connectTransport();
+    try {
+      await expect(createServerReference("encode-header-crlf")()).rejects.toMatchObject({
+        message: "boom\r\nX-Injected: yes"
+      });
+    } finally {
+      restore();
+    }
   });
 });
 

--- a/packages/web/test/server/server-functions-http-hygiene.spec.tsx
+++ b/packages/web/test/server/server-functions-http-hygiene.spec.tsx
@@ -11,6 +11,11 @@
  *   caches can store them. POST dispatch stays gated.
  * - Every response defaults to `Cache-Control: no-store` unless the function
  *   set its own cache policy — caching is opt-in on the wire.
+ * - The endpoint has no CORS surface at all: no `Access-Control-*` header is
+ *   ever emitted, so a browser preflight fails and the gate is never the
+ *   only thing standing between a cross-origin page and a dispatch.
+ * - Conditional requests and `Range` are not part of the contract: a
+ *   declared read answers in full, never with a 304 or a 206 it cannot back.
  *
  * Runs against the built bundles like the other server-function specs.
  */
@@ -109,6 +114,161 @@ describe("server-function method allowlist (#3069)", () => {
     expect(head.body).toBeNull();
     expect(head.headers.get("Content-Type")).toBe(get.headers.get("Content-Type"));
     expect(calls).toBe(2);
+  });
+
+  it("matches the method exactly: a lowercased `post` is not POST", async () => {
+    // The comparison is `===` against the uppercase token, and the platform
+    // `Request` constructor normalizes the six well-known methods, so this
+    // can only arrive from an adapter that builds the request itself — h3,
+    // express, a serverless shim reading `req.method` off a socket. Those
+    // are exactly the deployments where a case-folding "fix" would be
+    // proposed, and case-folding here would let `head`/`options` through
+    // the allowlist by a spelling the allowlist never named.
+    const fn = vi.fn(async () => "side effect happened");
+    registerServerFunction("hygiene-method-case", fn);
+
+    const request = postRequest("hygiene-method-case");
+    Object.defineProperty(request, "method", { value: "post", configurable: true });
+
+    const response = await handleServerFunctionRequest(request, { provideEvent });
+    expect(response.status).toBe(405);
+    expect(response.headers.get("Allow")).toBe("POST");
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("advertises Allow on OPTIONS and on a verb it has never heard of", async () => {
+    // OPTIONS gets no special handling — there is no CORS surface for it to
+    // describe (below) and no `Allow`-only branch — so it lands on the same
+    // 405 as any other verb, carrying the same advertisement. A method the
+    // runtime has never seen behaves identically: the allowlist is closed,
+    // and `Allow` is the complete answer to "then what may I send?".
+    registerServerFunction("hygiene-allow-post", async () => "ok");
+    declareGET("hygiene-allow-read", async () => "read");
+
+    for (const method of ["OPTIONS", "FROB"]) {
+      const postOnly = await handleServerFunctionRequest(
+        readRequest("hygiene-allow-post", method, { "Sec-Fetch-Site": "same-origin" }),
+        { provideEvent }
+      );
+      expect([method, postOnly.status, postOnly.headers.get("Allow")]).toEqual([
+        method,
+        405,
+        "POST"
+      ]);
+
+      const declared = await handleServerFunctionRequest(
+        readRequest("hygiene-allow-read", method, { "Sec-Fetch-Site": "same-origin" }),
+        { provideEvent }
+      );
+      expect([method, declared.status, declared.headers.get("Allow")]).toEqual([
+        method,
+        405,
+        "POST, GET, HEAD"
+      ]);
+    }
+  });
+
+  it("honours no method-override header or query parameter", async () => {
+    // Every one of these is a convention some framework or proxy honours,
+    // and honouring any of them would reintroduce the hole #3069 closed:
+    // a GET — issued by a link checker, a prefetcher, an <img> on someone
+    // else's page — carrying a header or a query parameter that turns it
+    // into a dispatch of an undeclared function.
+    const fn = vi.fn(async () => "side effect happened");
+    registerServerFunction("hygiene-override", fn);
+
+    for (const header of ["X-HTTP-Method-Override", "X-Method-Override", "X-HTTP-Method"]) {
+      const response = await handleServerFunctionRequest(
+        readRequest("hygiene-override", "GET", {
+          "Sec-Fetch-Site": "same-origin",
+          [header]: "POST"
+        }),
+        { provideEvent }
+      );
+      expect([header, response.status]).toEqual([header, 405]);
+    }
+
+    const query = await handleServerFunctionRequest(
+      new Request("https://app.example/_server/hygiene-override?_method=POST", {
+        headers: { "Sec-Fetch-Site": "same-origin" }
+      }),
+      { provideEvent }
+    );
+    expect(query.status).toBe(405);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The endpoint has no CORS surface (#3069). Nothing here emits an
+ * `Access-Control-*` header, on any status, so a cross-origin `fetch` from
+ * a page never gets past the browser: the preflight has no
+ * `Access-Control-Allow-Origin` to read, and a simple request's response is
+ * unreadable. That is the layer BELOW the origin gate — the gate stops the
+ * dispatch, the missing CORS headers stop the browser from ever asking —
+ * and the reason a deployment must opt in at its own edge, deliberately,
+ * rather than find that the RPC endpoint quietly answers everybody.
+ */
+describe("no CORS surface (#3069)", () => {
+  it("emits no Access-Control-* header on any path", async () => {
+    registerServerFunction("hygiene-cors", async () => "ok");
+    registerServerFunction("hygiene-cors-throw", async () => {
+      throw new Error("boom");
+    });
+    declareGET("hygiene-cors-read", async () => "read");
+
+    const responses = await Promise.all([
+      handleServerFunctionRequest(postRequest("hygiene-cors"), { provideEvent }),
+      handleServerFunctionRequest(postRequest("hygiene-cors-throw"), { provideEvent }),
+      handleServerFunctionRequest(postRequest("hygiene-cors-missing"), { provideEvent }),
+      handleServerFunctionRequest(readRequest("hygiene-cors-read", "GET"), { provideEvent }),
+      handleServerFunctionRequest(readRequest("hygiene-cors-read", "HEAD"), { provideEvent }),
+      handleServerFunctionRequest(
+        readRequest("hygiene-cors", "GET", { "Sec-Fetch-Site": "same-origin" }),
+        { provideEvent }
+      ),
+      handleServerFunctionRequest(postRequest("hygiene-cors", { "Sec-Fetch-Site": "cross-site" }), {
+        provideEvent
+      })
+    ]);
+
+    // 200, 500, 404, 200, 200, 405, 403 — the whole span of answers
+    expect(responses.map(response => response.status)).toEqual([200, 500, 404, 200, 200, 405, 403]);
+    for (const response of responses) {
+      const names = [...response.headers.keys()].filter(name =>
+        name.toLowerCase().startsWith("access-control")
+      );
+      expect(names).toEqual([]);
+    }
+  });
+
+  it("fails a browser preflight closed", async () => {
+    const fn = vi.fn(async () => "ok");
+    registerServerFunction("hygiene-preflight", fn);
+    declareGET("hygiene-preflight-read", async () => "read");
+
+    // What Chrome sends ahead of a cross-origin `fetch` with a JSON body
+    for (const id of ["hygiene-preflight", "hygiene-preflight-read"]) {
+      const response = await handleServerFunctionRequest(
+        new Request(`https://app.example/_server/${id}`, {
+          method: "OPTIONS",
+          headers: {
+            Origin: "https://evil.example",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "cross-site",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "content-type"
+          }
+        }),
+        { provideEvent }
+      );
+      // The gate answers first — a preflight is not a read, so even a
+      // declared function is gated on OPTIONS — and either way the browser
+      // finds no allow-origin to honour.
+      expect([id, response.status]).toEqual([id, 403]);
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    }
+    expect(fn).not.toHaveBeenCalled();
   });
 });
 
@@ -223,5 +383,188 @@ describe("server-function cache hygiene (#3071)", () => {
     expect(tagged.status).toBe(200);
     expect(tagged.headers.get("Cache-Control")).toBe("public, max-age=60");
     expect(tagged.headers.has("X-Server-Function-Format")).toBe(false);
+  });
+
+  it("keeps no-store on the refusals built before dispatch, not only the ones above", async () => {
+    // 404 and 405 are covered above; these are the refusals assembled on
+    // other branches, each a plain `new Response(...)` that a later edit
+    // could easily add without the default. A cached 403 or 413 is the
+    // worse failure of the two directions: a CDN that stored one serves
+    // the refusal to the user who WOULD have been allowed, and the app
+    // looks broken to exactly the people it works for.
+    registerServerFunction("hygiene-refusals", async () => {
+      throw new Error("boom");
+    });
+
+    const refusals: [number, Response][] = [
+      // arguments that are not the encoding the url claims
+      [
+        400,
+        await handleServerFunctionRequest(postRequest("hygiene-refusals?args=hello"), {
+          provideEvent
+        })
+      ],
+      // the origin gate
+      [
+        403,
+        await handleServerFunctionRequest(
+          postRequest("hygiene-refusals", { "Sec-Fetch-Site": "cross-site" }),
+          { provideEvent }
+        )
+      ],
+      // arguments past the configured bound
+      [
+        413,
+        await handleServerFunctionRequest(postRequest(`hygiene-refusals?args=${"x".repeat(200)}`), {
+          bodySizeLimit: 10,
+          provideEvent
+        })
+      ],
+      // the function itself threw
+      [500, await handleServerFunctionRequest(postRequest("hygiene-refusals"), { provideEvent })]
+    ];
+
+    for (const [expected, response] of refusals) {
+      expect([expected, response.status]).toEqual([expected, expected]);
+      expect([expected, response.headers.get("Cache-Control")]).toEqual([expected, "no-store"]);
+    }
+  });
+
+  it("merges the gate's Vary onto the author's rather than replacing it", async () => {
+    // The gate's `Vary` has to be added to a gated response, and the
+    // function may have set one of its own for reasons the runtime knows
+    // nothing about (content negotiation, a per-locale answer). Replacing
+    // it would silently collapse those variants onto one cache entry.
+    registerServerFunction(
+      "hygiene-vary-merge",
+      async () => new Response("v", { headers: { Vary: "Accept-Language" } })
+    );
+
+    const response = await handleServerFunctionRequest(postRequest("hygiene-vary-merge"), {
+      provideEvent
+    });
+    expect(response.headers.get("Vary")).toBe("Accept-Language, Sec-Fetch-Site, Origin, Referer");
+  });
+
+  it("does not list a field the author already named, whatever its case", async () => {
+    // Field names are case-insensitive, so `origin` and `Origin` are one
+    // field. Appending the second spelling would grow the header on every
+    // hop through a proxy that re-adds its own, and some caches treat a
+    // repeated name as a distinct key.
+    registerServerFunction(
+      "hygiene-vary-dedupe",
+      async () => new Response("v", { headers: { Vary: "origin, accept-language" } })
+    );
+
+    const response = await handleServerFunctionRequest(postRequest("hygiene-vary-dedupe"), {
+      provideEvent
+    });
+    // the author's spelling survives; only the fields it lacks are appended
+    expect(response.headers.get("Vary")).toBe("origin, accept-language, Sec-Fetch-Site, Referer");
+  });
+
+  it("leaves `Vary: *` alone", async () => {
+    // `*` already means "never reuse this for another request" — strictly
+    // stronger than naming three fields. Appending to it would produce
+    // `*, Sec-Fetch-Site, ...`, which is not a weaker rule but a
+    // malformed one, and caches disagree about what to do with it.
+    registerServerFunction(
+      "hygiene-vary-star",
+      async () => new Response("v", { headers: { Vary: "*" } })
+    );
+
+    const response = await handleServerFunctionRequest(postRequest("hygiene-vary-star"), {
+      provideEvent
+    });
+    expect(response.headers.get("Vary")).toBe("*");
+  });
+});
+
+/**
+ * HEAD over a result that is still being produced (#3069). HEAD runs the
+ * function — that is what makes its headers those of the equivalent GET —
+ * so a streaming result leaves a live source behind with nobody to read
+ * it. Dropping the body means CANCELLING that source, not draining it: an
+ * unbounded or slow stream drained to completion is a request that never
+ * finishes and memory that nobody accounted for, on a verb that link
+ * checkers, uptime probes and prefetchers send unprompted.
+ */
+describe("HEAD over a streamed result (#3069)", () => {
+  it("answers the GET's headers with no body, and cancels the source", async () => {
+    let pulls = 0;
+    let cancelled = false;
+    const streamed = () =>
+      new Response(
+        new ReadableStream({
+          // never closes: a drained body would hang this test rather than
+          // fail it, which is the honest shape of the bug
+          pull(controller) {
+            pulls++;
+            controller.enqueue(new TextEncoder().encode("chunk"));
+          },
+          cancel() {
+            cancelled = true;
+          }
+        }),
+        { headers: { "Content-Type": "text/plain", "X-Marker": "kept" } }
+      );
+    declareGET("hygiene-head-stream", streamed);
+
+    const get = await handleServerFunctionRequest(readRequest("hygiene-head-stream", "GET", {}), {
+      provideEvent
+    });
+    const getHeaders = [...get.headers].sort();
+    await get.body!.cancel();
+
+    pulls = 0;
+    cancelled = false;
+    const head = await handleServerFunctionRequest(readRequest("hygiene-head-stream", "HEAD", {}), {
+      provideEvent
+    });
+
+    expect([...head.headers].sort()).toEqual(getHeaders);
+    expect(head.body).toBeNull();
+    // give a drain a chance to run away with it before asserting
+    await new Promise(resolve => setTimeout(resolve, 20));
+    expect(cancelled).toBe(true);
+    // the stream fills its queue once on construction; anything beyond
+    // that is the runtime pumping a body it is about to throw away
+    expect(pulls).toBeLessThanOrEqual(1);
+  });
+});
+
+/**
+ * A declared read answers the whole result or nothing (#3071). It is a
+ * function call rendered as a GET, not a stored representation: there is
+ * no validator to compare against and no stable byte range to serve a
+ * slice of, since the answer is recomputed per call. So the conditional
+ * and range headers a cache, a proxy or a media element may attach are
+ * ignored, and the response advertises no range support to invite them.
+ * The alternative — answering 304 without an `ETag` anyone issued, or 206
+ * over bytes that will differ next call — is a wrong answer delivered with
+ * confidence, and the caller has no way to tell.
+ */
+describe("conditional requests and Range on a declared read", () => {
+  it("answers in full, never a 304 or a 206", async () => {
+    declareGET("hygiene-conditional", async () => ({ hello: "world" }));
+    const body = JSON.stringify({ hello: "world" });
+
+    const conditionals: Record<string, string>[] = [
+      { "If-None-Match": '"anything"' },
+      { "If-Modified-Since": new Date().toUTCString() },
+      { "If-Match": '"anything"' },
+      { Range: "bytes=0-3" }
+    ];
+    for (const headers of conditionals) {
+      const response = await handleServerFunctionRequest(
+        readRequest("hygiene-conditional", "GET", headers),
+        { provideEvent }
+      );
+      const label = Object.keys(headers)[0];
+      expect([label, response.status]).toEqual([label, 200]);
+      expect([label, await response.text()]).toEqual([label, body]);
+      expect([label, response.headers.get("Accept-Ranges")]).toEqual([label, null]);
+      expect([label, response.headers.get("Content-Range")]).toEqual([label, null]);
+    }
   });
 });


### PR DESCRIPTION
An audit of the server-function runtime against the HTTP surface — methods, addressing, headers, bodies, caching, CORS, cookies — turned up four defects (#3128, #3129, #3130, #3131) and something larger: a great deal of behaviour that is deliberate, correct, and guarded by nothing at all.

This PR pins that behaviour. Every test here passes on `next` today; none of it would have been noticed breaking. Tests only, no runtime change, no changeset.

### What is now pinned

**The origin gate's reading of the headers** — `Origin: null` (sandboxed iframe, `data:`), an explicit `:443`, byte-for-byte comparison rather than normalised, punycode, a `Referer` that parses but names no origin, an unrecognised `Sec-Fetch-Site` value falling through to the `Origin` check, and duplicated `Sec-Fetch-Site`/`Origin` — comma-joined in transit — still refusing. #3111 pinned the gate's POST branches; these are the header-reading cases it did not reach.

**Methods** — exact matching (`post`, `Post`, `POST ` are not `POST`), `Allow` correct on `OPTIONS` and on an unknown verb, and that no method-override header or `?_method=` is honoured, so a front proxy that translates one cannot smuggle a mutation past the gate.

**Addressing** — an encoded path segment or control character does not fold onto the plain id, the `data` segment and the mount are read literally, and an oversized id is refused before the body is read.

**CORS** — nothing is emitted on any path and a browser-shaped preflight fails closed. That is the entire cross-origin story of this runtime, and it rested on no test.

**Header hygiene** — CR/LF stripped from the error label so it cannot become a header of its own; `no-store` on the refusals built before dispatch; and the `Vary` merge preserving an author's value, deduping case-insensitively, and short-circuiting on `Vary: *`.

**HEAD over a streamed result** — the GET's headers, no body, and the source cancelled rather than pumped to completion.

**Conditional requests and `Range` on a declared read** — answered in full, never a bogus `304` or `206`. Spec-legal, deliberate, and the kind of thing a well-meaning change would "fix".

### How each test earned its place

By mutating the built runtime and confirming the test fails — 24 mutations, every new test killed by at least one. A sample:

| mutation | turns red |
| --- | --- |
| `matchesOrigin` compares both sides lowercased | compares the Origin byte for byte |
| read only the first comma-separated `Sec-Fetch-Site` | refuses a duplicated `Sec-Fetch-Site` or `Origin` |
| honour `X-HTTP-Method-Override` | honours no method-override header or query parameter |
| emit `Access-Control-Allow-Origin: *` | emits no `Access-Control-*` on any path; preflight fails closed |
| match the `data/` segment case-insensitively | reads the `data` segment and the mount literally |
| default `no-store` only on 2xx | keeps `no-store` on the refusals built before dispatch |
| drop the body without cancelling the source | HEAD answers the GET's headers with no body, and cancels |
| stop stripping CR/LF from the error label | strips CR/LF so the label cannot become a header |

### Two cases that resisted, stated rather than hidden

An explicit `:443` in the request **url**, and the matching half of the punycode pair, are both normalised by the URL parser before the runtime ever sees them — so no mutation of the gate can turn either red. The first was dropped and refolded into the `Origin`-header direction, where it is a real decision (`Origin: https://app.example:443` → 403). The second is kept as half of a pair whose other half does discriminate, because the pair is the statement; trim it if you would rather have only killable assertions.

### Notes

No new files — every invariant had a home in an existing spec. Suite: 45 files, 474 passed, 1 expected fail, 2 skipped (up from 452 passed). `tsc` gains one error, `bodySizeLimit` missing from `HandleServerFunctionOptions` in the generated `types/` — the same stale-types problem that already produces five identical errors in `server-functions-request-bounds.spec.tsx` on `next`; the option is real in the source. I followed the existing convention rather than working around it.

### Follow-up from review

A later pass found a third assertion that could not fail — `refuses Origin: null` passed on a gate that had stopped reading `Origin` entirely, since the no-proof branch refuses by default. It now runs with the no-proof escape hatch open, so only the literal value can produce the refusal, and a mutation treating `Origin: "null"` as absent fails it. A redundant `Referer` case was dropped (the pre-existing fallback test already carries a path), and the oversized-id test was renamed to what it pins: the runtime has no id size check, it answers an unknown id before buffering the body.
