### PR TITLE
Fix 3127 universal text

### DIFF
--- a/.changeset/fix-universal-static-text.md
+++ b/.changeset/fix-universal-static-text.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/babel-plugin": patch
+---
+
+Pass decoded, unescaped static text to universal renderers instead of HTML-encoded source text.

--- a/packages/babel-plugin/src/shared/transform.ts
+++ b/packages/babel-plugin/src/shared/transform.ts
@@ -1,4 +1,5 @@
 import * as t from "@babel/types";
+import { decode } from "html-entities";
 import { transformElement as transformElementDOM } from "../dom/element";
 import { createTemplate as createTemplateDOM } from "../dom/template";
 import { transformElement as transformElementSSR } from "../ssr/element";
@@ -191,7 +192,9 @@ export function transformNode(
         ? info.doNotEscape
           ? String(staticValue)
           : (escapeHTML(String(staticValue)) as string)
-        : trimWhitespace((node.extra?.raw as string | undefined) ?? "");
+        : t.isJSXText(node) && info.decodeEntities
+          ? decode(trimWhitespace((node.extra?.raw as string | undefined) ?? ""))
+          : trimWhitespace((node.extra?.raw as string | undefined) ?? "");
     if (!(text as string).length) return null;
     const results: TransformResult = {
       template: text,

--- a/packages/babel-plugin/src/types.ts
+++ b/packages/babel-plugin/src/types.ts
@@ -143,6 +143,7 @@ export interface TransformInfo {
   fragmentChild?: boolean;
   componentChild?: boolean;
   doNotEscape?: boolean;
+  decodeEntities?: boolean;
   skipId?: boolean;
   toBeClosed?: Set<string>;
   parentResults?: TransformResult;

--- a/packages/babel-plugin/src/universal/element.ts
+++ b/packages/babel-plugin/src/universal/element.ts
@@ -274,7 +274,7 @@ function transformChildren(path: BabelPath<t.JSXElement>, results: UniversalTran
   const filteredChildren = filterChildren(path.get("children")),
     multi = checkLength(filteredChildren),
     childNodes = filteredChildren
-      .map(path => transformNode(path))
+      .map(path => transformNode(path, { doNotEscape: true, decodeEntities: true }))
       .reduce((memo: TransformResult[], child) => {
         if (!child) return memo;
         const i = memo.length;

--- a/packages/babel-plugin/test/__universal_fixtures__/textInterpolation/code.js
+++ b/packages/babel-plugin/test/__universal_fixtures__/textInterpolation/code.js
@@ -52,6 +52,10 @@ const escape3 = <>
 
 const injection = <span>Hi{"<script>alert();</script>"}</span>;
 
+const staticLessThan = <item>{"<span> restyles a run"}</item>;
+const staticAmpersand = <item>{"<b> & <i>"}</item>;
+const jsxEntity = <item>lit &lt; text</item>;
+
 let value = "World";
 const evaluated = <span>Hello {value + "!"}</span>;
 

--- a/packages/babel-plugin/test/__universal_fixtures__/textInterpolation/output.js
+++ b/packages/babel-plugin/test/__universal_fixtures__/textInterpolation/output.js
@@ -72,7 +72,7 @@ const multiLineNoTrailingSpace = _el$22;
 
 /* prettier-ignore */
 var _el$24 = _$createElement("span");
-_$insertNode(_el$24, _$createTextNode(`&nbsp;&lt;Hi&gt;&nbsp;`));
+_$insertNode(_el$24, _$createTextNode(` <Hi> `));
 const escape = _el$24;
 
 /* prettier-ignore */
@@ -83,47 +83,56 @@ const escape2 = _$createComponent(Comp, {
 /* prettier-ignore */
 const escape3 = "\xA0<Hi>\xA0";
 var _el$26 = _$createElement("span"),
-  _el$27 = _$createTextNode(`Hi&lt;script>alert();&lt;/script>`);
+  _el$27 = _$createTextNode(`Hi<script>alert();</script>`);
 _$insertNode(_el$26, _el$27);
 const injection = _el$26;
+var _el$29 = _$createElement("item");
+_$insertNode(_el$29, _$createTextNode(`<span> restyles a run`));
+const staticLessThan = _el$29;
+var _el$31 = _$createElement("item");
+_$insertNode(_el$31, _$createTextNode(`<b> & <i>`));
+const staticAmpersand = _el$31;
+var _el$33 = _$createElement("item");
+_$insertNode(_el$33, _$createTextNode(`lit < text`));
+const jsxEntity = _el$33;
 let value = "World";
-var _el$29 = _$createElement("span"),
-  _el$30 = _$createTextNode(`Hello World!`);
-_$insertNode(_el$29, _el$30);
-const evaluated = _el$29;
-let number = 4 + 5;
-var _el$32 = _$createElement("span"),
-  _el$33 = _$createTextNode(`4 + 5 = 9`);
-_$insertNode(_el$32, _el$33);
-const evaluatedNonString = _el$32;
-var _el$35 = _$createElement("div"),
-  _el$36 = _$createTextNode(`\nd`);
+var _el$35 = _$createElement("span"),
+  _el$36 = _$createTextNode(`Hello World!`);
 _$insertNode(_el$35, _el$36);
-_$insert(_el$35, s, _el$36);
-const newLineLiteral = _el$35;
-var _el$38 = _$createElement("div");
-_$insert(_el$38, expr);
-const trailingSpace = _el$38;
+const evaluated = _el$35;
+let number = 4 + 5;
+var _el$38 = _$createElement("span"),
+  _el$39 = _$createTextNode(`4 + 5 = 9`);
+_$insertNode(_el$38, _el$39);
+const evaluatedNonString = _el$38;
+var _el$41 = _$createElement("div"),
+  _el$42 = _$createTextNode(`\nd`);
+_$insertNode(_el$41, _el$42);
+_$insert(_el$41, s, _el$42);
+const newLineLiteral = _el$41;
+var _el$44 = _$createElement("div");
+_$insert(_el$44, expr);
+const trailingSpace = _el$44;
 const trailingSpaceComp = _$createComponent(Comp, {
   children: expr
 });
 const trailingSpaceFrag = expr;
-var _el$39 = _$createElement("span"),
-  _el$40 = _$createTextNode(` `);
-_$insertNode(_el$39, _el$40);
-_$insert(_el$39, expr, null);
-const leadingSpaceElement = _el$39;
+var _el$45 = _$createElement("span"),
+  _el$46 = _$createTextNode(` `);
+_$insertNode(_el$45, _el$46);
+_$insert(_el$45, expr, null);
+const leadingSpaceElement = _el$45;
 const leadingSpaceComponent = _$createComponent(Div, {
   get children() {
     return [" ", expr];
   }
 });
 const leadingSpaceFragment = [" ", expr];
-var _el$41 = _$createElement("span"),
-  _el$42 = _$createTextNode(` `);
-_$insertNode(_el$41, _el$42);
-_$insert(_el$41, expr, _el$42);
-const trailingSpaceElement = _el$41;
+var _el$47 = _$createElement("span"),
+  _el$48 = _$createTextNode(` `);
+_$insertNode(_el$47, _el$48);
+_$insert(_el$47, expr, _el$48);
+const trailingSpaceElement = _el$47;
 const trailingSpaceComponent = _$createComponent(Div, {
   get children() {
     return [expr, " "];


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

fix #3127

Universal renderers pass static text directly to the host's `createTextNode`, but compiler treated that text like DOM template HTML. Static expressions were HTML-escaped, while JSX entities remained encoded.

changeset:
  - keeps static expression text unescaped in universal element children;
  - decodes JSX entities after whitespace normalization, preserving entities like `&nbsp;`;
  - supports `universal` and `dynamic` universal transforms without changing DOM/SSR output;
  - adds fixture coverage for literal `<`, `&`, and JSX entities.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

ran targeted universal fixtures:

```bash
pnpm --filter @solidjs/babel-plugin exec vitest run test/universal.spec.js test/dynamic-universal.spec.js
```
result: Test Files  2 passed (2) Tests 16 passed (16)

```bash
pnpm --filter @solidjs/babel-plugin test
```
result: Test Files  20 passed (20) Tests 153 passed (153)

and prtettier with git diff checks
