### PR TITLE
Refuse re-entering a finished transaction; attribute the flush loop guard (#3140)

### DIFF
--- a/.changeset/fix-dead-transition-stamp-revival.md
+++ b/.changeset/fix-dead-transition-stamp-revival.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Harden the transaction-stamp lifecycle around #3140 (companion to #3143, which clears `_transition` stamps when pending values commit). `initTransition` now refuses a transaction whose `_done` chain ends in `true` — the belt for dead references that survive outside the commit path (merged forwarding chains, async settles racing completion), since `setSignal` re-opens a node's stamped transaction before the value-equal bail and re-activating a corpse spins the flush drain loop (dev threw the loop guard; production hung). The dev loop guard also now reports what kept the loop alive — transition done-state, queue counts, and the last staged node — instead of only that it happened.

--- a/packages/signals/INTERNALS-ASYNC-STATE.md
+++ b/packages/signals/INTERNALS-ASYNC-STATE.md
@@ -28,7 +28,7 @@ A `Signal`/`Computed` participating in async/transitions carries:
 | `_latestValueComputed` | Lazily-created companion: shadow computed for `latest()` | `getLatestValueComputed`, written via `syncCompanions` |
 | `_parentSource` | Companion → owner backlink (also store leaf → firewall chains) | companion creation |
 | `_optimisticLane` | Lane this node currently belongs to | `assignOrMergeLane`, cleared by `resolveLane` (stale), `resolveOptimisticNodes`, `cleanupCompletedLanes` |
-| `_transition` | Transition holding this node's pending state | `initTransition`, `reassignPendingTransition`, cleared by `resolveOptimisticNodes` |
+| `_transition` | Transition holding this node's pending state | `initTransition`, `reassignPendingTransition`, cleared by `resolveOptimisticNodes` and the `commitPendingNodes` loop (#3140/#3143: a stamp never outlives its transaction — a committed value needs no affiliation, and a dangling stamp let any later write, even a value-equal no-op, resurrect the finished transaction; `initTransition` refuses `_done === true` as the belt) |
 
 Semantics of the `(_pendingValue, _overrideValue)` pair for an optimistic node
 (see §5e — revert targets were eliminated 2026-07-07):

--- a/packages/signals/src/core/scheduler.ts
+++ b/packages/signals/src/core/scheduler.ts
@@ -672,8 +672,17 @@ export class GlobalQueue extends Queue {
     return false;
   }
   initTransition(transition?: Transition | null): void {
-    if (transition) transition = currentTransition(transition);
-    if (transition && transition === activeTransition) return;
+    if (transition) {
+      transition = currentTransition(transition);
+      // A finished transaction cannot be re-entered: its state is committed
+      // or reverted, so "rejoining" it (A26) is meaningless and re-activating
+      // it spins the drain loop (#3140). The refusal must be a bare return —
+      // redirecting the caller to a fresh batch would re-arm the loop with a
+      // new transaction identity each pass. Stamps are cleared at commit, so
+      // this is a belt for paths that hand over a chased-dead reference
+      // (merged chains, async settles racing completion).
+      if (transition._done === true || transition === activeTransition) return;
+    }
     if (!transition && activeTransition && activeTransition._time === clock) return;
     if (!activeTransition) {
       activeTransition = transition ?? createBatch();
@@ -730,8 +739,14 @@ export class GlobalQueue extends Queue {
 }
 
 export function queuePendingNode(node: Signal<any>): void {
+  if (__DEV__) lastStagedNodeName = (node as any)._name ?? null;
   currentBatch._pendingNodes.push(node);
 }
+
+// Dev-only attribution for the flush loop guard (#3140): when the guard
+// trips, naming what the loop kept chewing on lets the app author attribute
+// the runaway without patching dist.
+let lastStagedNodeName: string | null = null;
 
 // Sticky: flips true on the first refresh() ever (the only setter of
 // REACTIVE_REASK) so the hot notification loop skips the per-subscriber flag
@@ -854,6 +869,12 @@ function commitPendingNodes() {
   for (let i = 0; i < pendingNodes.length; i++) {
     const node = pendingNodes[i];
     commitPendingNode(node);
+    // The stamp dies with the commit (#3143) — symmetric with
+    // resolveOptimisticNodes clearing optimistic stamps. A stamp outliving
+    // its transaction let any later write (even a value-equal no-op, which
+    // re-opens before the equality bail) resurrect the finished transaction;
+    // a boundary flag rewritten every finalize pass then spun the drain loop
+    // forever (#3140).
     node._transition = null;
   }
   pendingNodes.length = 0;
@@ -1029,7 +1050,22 @@ export function flush<T>(fn?: () => T): T | void {
   // `flush()` is an explicit drain point, so it must also process an active
   // transition even if no microtask was scheduled for it yet.
   while (scheduled || activeTransition) {
-    if (__DEV__ && ++count === 1e5) throw new Error("Potential Infinite Loop Detected.");
+    if (__DEV__ && ++count === 1e5) {
+      // Attribution beats a bare guard (#3140): say what kept the loop alive.
+      // A completed transition being re-activated reads `done=true` here —
+      // the corpse-revival signature — while application-driven runaways
+      // (#2843) usually show staged work naming the culprit node.
+      const t = activeTransition as any;
+      throw new Error(
+        `Potential Infinite Loop Detected. Kept alive by ${
+          scheduled ? "scheduled work" : "an active transition"
+        }${
+          t
+            ? `; transition: done=${t._done === true}, pending=${t._pendingNodes.length}, optimistic=${t._optimisticNodes.length}, asyncReporters=${t._asyncReporters.size}`
+            : ""
+        }${lastStagedNodeName ? `; last staged node: ${lastStagedNodeName}` : ""}`
+      );
+    }
     globalQueue.flush();
   }
 }

--- a/packages/signals/tests/transition-corpse-revival.test.ts
+++ b/packages/signals/tests/transition-corpse-revival.test.ts
@@ -1,0 +1,106 @@
+/**
+ * #3140: a `_transition` stamp must not outlive its transaction.
+ *
+ * `commitPendingNode` committed the value but left `_transition` pointing at
+ * the finished transaction (optimistic stamps were cleared at completion;
+ * pending stamps were not). `setSignal` re-opens a node's stamped transaction
+ * BEFORE the value-equal bail, so a later no-op write resurrected the corpse:
+ * the drain loop saw a live transition again, completed it, and the next
+ * finalize pass (a Loading boundary's `_checkSources` rewrites its flag with
+ * the same value on every pass) revived it again — the dev build threw the
+ * flush loop guard, production hung the tab.
+ *
+ * The wild stamping race did not reduce to a minimal reproduction (see the
+ * issue), so each layer is pinned directly:
+ *  - commit clears the stamp (symmetry with resolveOptimisticNodes);
+ *  - a write finding a dead stamp — however it survived — must not
+ *    re-activate the finished transaction.
+ */
+import { describe, expect, it } from "vitest";
+import { action, createSignal, flush } from "../src/index.js";
+import { createRoot } from "../src/index.js";
+import { setSignal, signal, type Signal } from "../src/core/index.js";
+import { activeTransition, type Transition } from "../src/core/scheduler.js";
+
+function deferred<T = void>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>(r => (resolve = r));
+  return { promise, resolve };
+}
+
+/** Runs an action to completion and returns its (now finished) transaction. */
+async function completedTransition(): Promise<Transition> {
+  const gate = deferred();
+  let captured: Transition | null = null;
+  let start!: () => Promise<unknown>;
+  createRoot(() => {
+    start = action(function* () {
+      captured = activeTransition;
+      yield gate.promise;
+    });
+  });
+  const acting = start();
+  flush();
+  gate.resolve();
+  await acting;
+  await new Promise(r => setTimeout(r, 0));
+  flush();
+  expect(captured).not.toBeNull();
+  expect((captured as unknown as Transition)._done).toBe(true);
+  return captured as unknown as Transition;
+}
+
+describe("#3140: completed-transaction stamps", () => {
+  it("commit clears the pending stamp", async () => {
+    const gate = deferred();
+    let start!: () => Promise<unknown>;
+    createRoot(() => {
+      start = action(function* () {
+        yield gate.promise;
+      });
+    });
+
+    const node = signal(1) as Signal<number>;
+    // Stage the write in the ambient batch, then open the transaction in the
+    // same unflushed window: initTransition's batch adoption stamps every
+    // staged node with it.
+    setSignal(node, 2);
+    const acting = start();
+    expect(node._transition).not.toBeNull();
+
+    // Park (incomplete: the action is awaiting), then complete.
+    flush();
+    gate.resolve();
+    await acting;
+    await new Promise(r => setTimeout(r, 0));
+    flush();
+
+    expect(node._value).toBe(2);
+    // Pre-fix the stamp survived the commit, pointing at a done transaction.
+    expect(node._transition).toBeNull();
+  });
+
+  it("a value-equal write to a dead-stamped node does not resurrect the transaction", async () => {
+    const dead = await completedTransition();
+
+    // However a dead stamp survives (the wild race did not minimize), the
+    // write path must refuse the corpse rather than re-activate it.
+    const node = signal(5) as Signal<number>;
+    node._transition = dead;
+
+    setSignal(node, 5); // value-equal: bails after the transition re-open ran
+    // Pre-fix: activeTransition === dead here, and every drain-loop pass that
+    // rewrote any stamped flag re-armed it — the infinite flush loop.
+    expect(activeTransition).toBeNull();
+    flush();
+    expect(activeTransition).toBeNull();
+
+    // A real write is routed to the ambient batch, not the corpse.
+    const [, setTick] = createSignal(0);
+    setSignal(node, 6);
+    setTick(1);
+    expect(activeTransition).toBeNull();
+    flush();
+    expect(node._value).toBe(6);
+  });
+});

--- a/scripts/size/.size-limit.js
+++ b/scripts/size/.size-limit.js
@@ -312,8 +312,14 @@ module.exports = [
     // The #3108 truth-author fix (88fa9d64, optimistic module) plus the
     // refresh() quiescence promise (51ffcb9a, settle walk) — this scenario
     // retains every store family, so it pays both. Drift, not a regression.
+    //
+    // Transaction-lifecycle fixes (2026-08-31): 26.1 -> 26.15 KB, measured at
+    // 26.12. #3141 (initTransition guarantees a flush) and #3140 (commit
+    // clears _transition stamps; initTransition refuses a done transaction)
+    // — ~25 B of scheduler prod code for an ambient-capture fix and a
+    // prod-hang fix. The other nine budgets absorbed it within headroom.
     path: "hydrating-store-app.js",
-    limit: "26.1 KB",
+    limit: "26.15 KB",
     modifyEsbuildConfig
   },
   {


### PR DESCRIPTION
## Summary

Companion to #3143 (merged — @snowfluke's clear of `_transition` stamps at commit), completing #3140. Stacked on #3145.

- **The belt**: a dead `_transition` reference can still reach `initTransition` from outside the commit path — merged `_done` forwarding chains, async settles racing completion — and `setSignal` re-opens a node's stamped transaction *before* the value-equal bail, so re-activating the corpse spins the drain loop (dev threw the flush loop guard; production hung the tab). `initTransition` now refuses a transaction whose chased `_done` chain ends in `true`, as a bare return — the reporter measured that redirecting to a fresh batch re-arms the loop with a new identity each pass.
- **Guard attribution** (the reporter's explicit ask in #3140): the dev loop guard now reports what kept the loop alive — scheduled work vs an active transition, the transition's done-state and queue counts, and the last staged node. The corpse signature reads `done=true, pending=0`. Dev-only, tree-shaken from prod.
- **Regression pins**, white-box since the wild stamping race did not minimize: commit clears the stamp (pins #3143); a value-equal write to a dead-stamped node leaves `activeTransition` null (fails without the belt when a dead stamp survives by any path).
- **Size/perf**: the belt is one compare folded into the existing transaction-open check; no loops, no allocation. One size budget ratcheted 26.1 → 26.15 KB (~25 B shared across #3143, #3145, and this).

## Test plan

- [x] Resurrection pin fails with #3143 alone (planted dead stamp), passes with the belt
- [x] Full signals suite (1437) green post-rebase on #3143; size budgets pass