### PR TITLE
feat(web): add typed preload links to the SSR asset pipeline

### DIFF
--- a/.changeset/typed-preload-links.md
+++ b/.changeset/typed-preload-links.md
@@ -1,0 +1,19 @@
+---
+"@solidjs/web": patch
+"@solidjs/h": patch
+"solid-js": patch
+---
+
+Add typed preload links to the server asset pipeline.
+
+Static manifests can attach `preloads: PreloadLink[]`, resolver results can carry the same shape for framework integrations, and any integration can register a link with `registerAsset("preload", link)`. The runtime preserves `as`, MIME type, CORS mode, integrity, referrer policy, fetch priority, and media attributes across string, streaming, embedded-head, custom-sink, and frame renders.
+
+`lazy()` and `clientOnly()` forward resolver-provided preload links alongside their JS and CSS.
+
+`JSX.HTMLPreloadAs` and `JSX.HTMLFetchPriority` are now exported for reuse.
+
+Preload links are explicit: manifest `assets` are not preloaded automatically. Existing stylesheet and modulepreload APIs are unchanged.
+
+Development builds warn when font or fetch preloads omit `crossorigin`, because a different eventual request mode cannot reuse that preload.
+
+Frame clients also retain and consume every late root asset record instead of dropping earlier records that reuse the same transport key.

--- a/packages/h/jsx-runtime/src/jsx.d.ts
+++ b/packages/h/jsx-runtime/src/jsx.d.ts
@@ -1066,6 +1066,7 @@ export namespace JSX {
   type HTMLFormEncType = "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain";
   type HTMLFormMethod = "post" | "get" | "dialog";
   type HTMLCrossorigin = "anonymous" | "use-credentials" | EnumeratedAcceptsEmpty;
+  type HTMLFetchPriority = "high" | "low" | "auto";
   type HTMLReferrerPolicy =
     | "no-referrer"
     | "no-referrer-when-downgrade"
@@ -1091,19 +1092,8 @@ export namespace JSX {
     | "allow-top-navigation"
     | "allow-top-navigation-by-user-activation"
     | "allow-top-navigation-to-custom-protocols";
-  type HTMLLinkAs =
-    | "audio"
-    | "document"
-    | "embed"
-    | "fetch"
-    | "font"
-    | "image"
-    | "object"
-    | "script"
-    | "style"
-    | "track"
-    | "video"
-    | "worker";
+  type HTMLPreloadAs = "fetch" | "font" | "image" | "script" | "style" | "track";
+  type HTMLLinkAs = HTMLPreloadAs | "audio" | "document" | "embed" | "object" | "video" | "worker";
 
   interface AnchorHTMLAttributes<T> extends HTMLAttributes<T> {
     download?: FunctionMaybe<string | EnumeratedAcceptsEmpty | RemoveAttribute>;
@@ -1364,7 +1354,7 @@ export namespace JSX {
     browsingtopics?: FunctionMaybe<string | RemoveAttribute>;
     crossorigin?: FunctionMaybe<HTMLCrossorigin | RemoveAttribute>;
     decoding?: FunctionMaybe<"sync" | "async" | "auto" | RemoveAttribute>;
-    fetchpriority?: FunctionMaybe<"high" | "low" | "auto" | RemoveAttribute>;
+    fetchpriority?: FunctionMaybe<HTMLFetchPriority | RemoveAttribute>;
     height?: FunctionMaybe<number | string | RemoveAttribute>;
     ismap?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
     loading?: FunctionMaybe<"eager" | "lazy" | RemoveAttribute>;
@@ -1520,7 +1510,7 @@ export namespace JSX {
     color?: FunctionMaybe<string | RemoveAttribute>;
     crossorigin?: FunctionMaybe<HTMLCrossorigin | RemoveAttribute>;
     disabled?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
-    fetchpriority?: FunctionMaybe<"high" | "low" | "auto" | RemoveAttribute>;
+    fetchpriority?: FunctionMaybe<HTMLFetchPriority | RemoveAttribute>;
     href?: FunctionMaybe<string | RemoveAttribute>;
     hreflang?: FunctionMaybe<string | RemoveAttribute>;
     imagesizes?: FunctionMaybe<string | RemoveAttribute>;
@@ -1715,7 +1705,7 @@ export namespace JSX {
     blocking?: FunctionMaybe<"render" | RemoveAttribute>;
     crossorigin?: FunctionMaybe<HTMLCrossorigin | RemoveAttribute>;
     defer?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
-    fetchpriority?: FunctionMaybe<"high" | "low" | "auto" | RemoveAttribute>;
+    fetchpriority?: FunctionMaybe<HTMLFetchPriority | RemoveAttribute>;
     for?: FunctionMaybe<string | RemoveAttribute>;
     integrity?: FunctionMaybe<string | RemoveAttribute>;
     nomodule?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;

--- a/packages/solid/src/server/component.ts
+++ b/packages/solid/src/server/component.ts
@@ -245,6 +245,15 @@ export function lazy<T extends Component<any>>(
           if (typeof css === "string") ctx.registerAsset!("style", css);
           else ctx.registerAsset!("inline-style", css);
         }
+        if (assets.preloads) {
+          for (let i = 0; i < assets.preloads.length; i++) {
+            const preload = assets.preloads[i];
+            const as = (preload as any)?.as;
+            if (!noHydrate || typeof as !== "string" || as.toLowerCase() !== "script") {
+              ctx.registerAsset!("preload", preload);
+            }
+          }
+        }
         if (!noHydrate) {
           for (let i = 0; i < assets.js.length; i++) ctx.registerAsset!("module", assets.js[i]);
           if (hydrationKey != null) ctx.registerModule?.(hydrationKey, assets.js[0]);
@@ -350,6 +359,15 @@ export function lazy<T extends Component<any>>(
         if (typeof css === "string") ctx.registerAsset!("style", css);
         else ctx.registerAsset!("inline-style", css);
       }
+      if (assets.preloads) {
+        for (let i = 0; i < assets.preloads.length; i++) {
+          const preload = assets.preloads[i];
+          const as = (preload as any)?.as;
+          if (!noHydrate || typeof as !== "string" || as.toLowerCase() !== "script") {
+            ctx.registerAsset!("preload", preload);
+          }
+        }
+      }
       // Hint-only: registerModule files the module into the serialized
       // hydration map, whose key only the render that creates it knows.
       if (!noHydrate)
@@ -407,6 +425,11 @@ export function lazy<T extends Component<any>>(
           // registration during render, so this access is the only signal
           // that the client will fetch these chunks.
           if (ctx.registerAsset) {
+            if (resolved.preloads) {
+              for (let i = 0; i < resolved.preloads.length; i++) {
+                ctx.registerAsset("preload", resolved.preloads[i]);
+              }
+            }
             for (let i = 0; i < resolved.js.length; i++)
               ctx.registerAsset("module", resolved.js[i]);
           }

--- a/packages/solid/src/server/shared.ts
+++ b/packages/solid/src/server/shared.ts
@@ -15,6 +15,8 @@ export type InlineStyleAsset = {
 export type ResolvedAssets = {
   js: string[];
   css: (string | InlineStyleAsset)[];
+  /** Renderer-defined preload descriptors; lazy() only reads `as` for NoHydration filtering. */
+  preloads?: unknown[];
 };
 
 export type HydrationContext = {
@@ -42,11 +44,12 @@ export type HydrationContext = {
   registerAsset?: {
     (type: "module" | "style", url: string): void;
     (type: "inline-style", style: InlineStyleAsset): void;
+    (type: "preload", preload: unknown): void;
   };
   /** Register a moduleUrl-to-entryUrl mapping for the current boundary. */
   registerModule?: (moduleUrl: string, entryUrl: string) => void;
   /**
-   * Resolve a module's JS and CSS assets from the asset manifest. Set by
+   * Resolve a module's client assets from the asset manifest. Set by
    * the @solidjs/web server renderer. Resolver manifests (dev servers answering from a live
    * module graph) may return a promise and may resolve css entries to
    * inline-style descriptors instead of URLs.

--- a/packages/solid/test/server/nohydration.spec.ts
+++ b/packages/solid/test/server/nohydration.spec.ts
@@ -7,7 +7,7 @@ import { NoHydrateContext, getContext, createErrorBoundary } from "../../src/ser
 
 function createMockSSRContext(options: { async?: boolean } = {}) {
   const serialized = new Map<string, any>();
-  const modules: Array<{ type: string; href: string }> = [];
+  const modules: Array<{ type: string; href: any }> = [];
   const registeredModules: Array<{ url: string; js: string }> = [];
 
   const context: any = {
@@ -25,7 +25,7 @@ function createMockSSRContext(options: { async?: boolean } = {}) {
     },
     replace() {},
     block() {},
-    registerAsset(type: string, href: string) {
+    registerAsset(type: string, href: any) {
       modules.push({ type, href });
     },
     resolveAssets(moduleUrl: string) {
@@ -439,6 +439,14 @@ describe("NoHydration / Hydration (server)", () => {
 
   test("lazy() inside NoHydration registers CSS but not JS modules", () => {
     const { context, modules, registeredModules } = createMockSSRContext({ async: true });
+    context.resolveAssets = () => ({
+      css: ["style.css"],
+      js: ["module.js"],
+      preloads: [
+        { href: "hero.avif", as: "image" },
+        { href: "dependency.js", as: "SCRIPT" }
+      ]
+    });
     sharedConfig.context = context;
 
     createRoot(
@@ -460,9 +468,11 @@ describe("NoHydration / Hydration (server)", () => {
 
     const cssAssets = modules.filter(m => m.type === "style");
     const jsAssets = modules.filter(m => m.type === "module");
+    const preloadAssets = modules.filter(m => m.type === "preload");
     expect(cssAssets.length).toBe(1);
     expect(cssAssets[0].href).toBe("style.css");
     expect(jsAssets.length).toBe(0);
+    expect(preloadAssets.map(asset => asset.href)).toEqual([{ href: "hero.avif", as: "image" }]);
     expect(registeredModules.length).toBe(0);
   });
 
@@ -670,6 +680,12 @@ describe("NoHydration / Hydration (server)", () => {
 
   test("lazy() moduleUrl access registers modulepreload hints (island signal)", () => {
     const { context, modules } = createMockSSRContext({ async: true });
+    context.resolveAssets = () => ({
+      css: ["style.css"],
+      js: ["module.js"],
+      preloads: [{ href: "dependency.js", as: "script" }]
+    });
+    context.resolveAssetsSync = context.resolveAssets;
     sharedConfig.context = context;
 
     const LazyComp = lazy(
@@ -682,7 +698,9 @@ describe("NoHydration / Hydration (server)", () => {
     void LazyComp.moduleUrl;
 
     const jsAssets = modules.filter(m => m.type === "module");
+    const preloadAssets = modules.filter(m => m.type === "preload");
     expect(jsAssets.map(a => a.href)).toEqual(["module.js"]);
+    expect(preloadAssets.map(a => a.href)).toEqual([{ href: "dependency.js", as: "script" }]);
   });
 
   test("lazy() moduleUrl falls back to the raw specifier when the manifest misses", () => {

--- a/packages/solid/test/server/ssr-async.spec.ts
+++ b/packages/solid/test/server/ssr-async.spec.ts
@@ -3857,16 +3857,20 @@ describe("Asset Manifest + lazy()", () => {
   test("lazy() with moduleUrl registers assets and module mapping", async () => {
     const { lazy } = await import("../../src/server/component.js");
 
-    const registered: Array<{ type: string; url: string }> = [];
+    const registered: Array<{ type: string; value: any }> = [];
     const modules: Record<string, string> = {};
     const { context } = createMockSSRContext();
-    context.registerAsset = (type: string, url: string) => registered.push({ type, url });
+    context.registerAsset = (type: string, value: any) => registered.push({ type, value });
     context.registerModule = (moduleUrl: string, entryUrl: string) => {
       modules[moduleUrl] = entryUrl;
     };
     context.resolveAssets = (id: string) => {
       if (id === "./MyComp.tsx")
-        return { js: ["/assets/MyComp-abc123.js", "/assets/shared-def456.js"], css: [] };
+        return {
+          js: ["/assets/MyComp-abc123.js", "/assets/shared-def456.js"],
+          css: [],
+          preloads: [{ href: "/assets/hero.avif", as: "image", fetchpriority: "high" }]
+        };
       return null;
     };
     sharedConfig.context = context;
@@ -3885,8 +3889,12 @@ describe("Asset Manifest + lazy()", () => {
     );
 
     expect(registered).toEqual([
-      { type: "module", url: "/assets/MyComp-abc123.js" },
-      { type: "module", url: "/assets/shared-def456.js" }
+      {
+        type: "preload",
+        value: { href: "/assets/hero.avif", as: "image", fetchpriority: "high" }
+      },
+      { type: "module", value: "/assets/MyComp-abc123.js" },
+      { type: "module", value: "/assets/shared-def456.js" }
     ]);
     // The mapping is keyed by the hydration id of lazy's render memo (the
     // next child id of the root owner "t"), not by moduleUrl — the client
@@ -3897,16 +3905,20 @@ describe("Asset Manifest + lazy()", () => {
   test("preload() hints the module's assets without rendering it", async () => {
     const { lazy } = await import("../../src/server/component.js");
 
-    const registered: Array<{ type: string; url: string }> = [];
+    const registered: Array<{ type: string; value: any }> = [];
     const modules: Record<string, string> = {};
     const { context } = createMockSSRContext();
-    context.registerAsset = (type: string, url: string) => registered.push({ type, url });
+    context.registerAsset = (type: string, value: any) => registered.push({ type, value });
     context.registerModule = (moduleUrl: string, entryUrl: string) => {
       modules[moduleUrl] = entryUrl;
     };
     context.resolveAssets = (id: string) =>
       id === "./Route.tsx"
-        ? { js: ["/assets/Route.js", "/assets/shared.js"], css: ["/assets/Route.css"] }
+        ? {
+            js: ["/assets/Route.js", "/assets/shared.js"],
+            css: ["/assets/Route.css"],
+            preloads: [{ href: "/assets/route-font.woff2", as: "font", crossorigin: "" }]
+          }
         : null;
     sharedConfig.context = context;
 
@@ -3918,9 +3930,13 @@ describe("Asset Manifest + lazy()", () => {
     await LazyRoute.preload!();
 
     expect(registered).toEqual([
-      { type: "style", url: "/assets/Route.css" },
-      { type: "module", url: "/assets/Route.js" },
-      { type: "module", url: "/assets/shared.js" }
+      { type: "style", value: "/assets/Route.css" },
+      {
+        type: "preload",
+        value: { href: "/assets/route-font.woff2", as: "font", crossorigin: "" }
+      },
+      { type: "module", value: "/assets/Route.js" },
+      { type: "module", value: "/assets/shared.js" }
     ]);
     // Hint-only: the hydration mapping belongs to the render that creates the
     // component, which knows the hydration key.

--- a/packages/web/frames/src/frame-client.ts
+++ b/packages/web/frames/src/frame-client.ts
@@ -616,7 +616,20 @@ export function createFrameHost(options = {}) {
       store.version = version;
       clearStreamRecords(store.records);
     }
-    Object.assign(store.records, records);
+    // Root assets reuse one key for the shell and late chunks. Accumulate
+    // their arrays so frames registered later receive the full snapshot.
+    const assets = records["seg::assets"];
+    const previous = assets && store.records["seg::assets"];
+    if (!previous || previous === assets) {
+      Object.assign(store.records, records);
+    } else {
+      for (const name in assets) {
+        const values = assets[name];
+        if (Array.isArray(values)) {
+          previous[name] ? previous[name].push(...values) : (previous[name] = values);
+        }
+      }
+    }
     return true;
   };
   return {

--- a/packages/web/frames/src/frame-client.ts
+++ b/packages/web/frames/src/frame-client.ts
@@ -48,6 +48,7 @@ export type FrameChunk =
       modules?: string[];
       styles?: string[];
       inlineStyles?: { id: string; content?: string; attrs?: Record<string, string> }[];
+      preloads?: { href: string; attrs: Record<string, string> }[];
     }
   | { type: "slot"; id: string; version: number; key: string; args: Record<string, unknown> }
   | { type: "complete"; id: string; version: number }
@@ -745,7 +746,7 @@ class FrameImpl {
   #slotRegions = new Map();
   #slotResolvedRefs = new Map();
   #slotNodes = new Map();
-  #processedAssets = new Set();
+  #processedAssets = new WeakSet();
   // The pending re-check for adopt-time occurrences deferred on a
   // still-arriving args record (#2968 — see #syncSlots).
   #recordRefresh = null;
@@ -923,6 +924,7 @@ class FrameImpl {
     this.#revealed.clear();
     this.#fallbackShown.clear();
     this.#appliedHoles.clear();
+    this.#processedAssets = new WeakSet();
     this.#errorNotified = false;
     clearStreamRecords(this.#store, root);
   }
@@ -1014,16 +1016,19 @@ class FrameImpl {
       }
     }
 
-    // Module assets preload as soon as their record lands (the document
-    // behavior's analogue: <link rel="modulepreload"> so lazy components
-    // inside the frame don't waterfall). Styles are handled by the reveal
-    // gate; this pass is modules only, once per record.
+    // Root asset records reuse a store key, so consume them by identity.
+    // Styles remain owned by the reveal gate.
     for (const key in this.#store) {
-      if (this.#processedAssets.has(key) || !key.endsWith(":assets")) continue;
-      this.#processedAssets.add(key);
       const record = this.#store[key];
-      if (record && record.modules) {
+      if (!key.endsWith(":assets") || !record || this.#processedAssets.has(record)) {
+        continue;
+      }
+      this.#processedAssets.add(record);
+      if (record.modules) {
         for (const href of record.modules) ensureModulePreload(href);
+      }
+      if (record.preloads) {
+        for (const entry of record.preloads) ensurePreload(entry);
       }
     }
 
@@ -2040,12 +2045,32 @@ function parseFragment(html) {
 // registry later; the gate only needs "are this segment's stylesheets loaded,
 // and call me back when they settle".
 
+// Mirrors head.ts without importing it into the standalone frame client.
+const PRELOAD_QUALIFIERS = ["as", "crossorigin", "type", "media", "imagesrcset", "imagesizes"];
+
 /** Attribute-compared head lookup so href/id values never need escaping. */
-function findHeadElement(selector, attr, value) {
-  for (const node of document.head.querySelectorAll(selector)) {
-    if (node.getAttribute(attr) === value) return node;
+function findHeadElement(selector, attr, value, qualifiers) {
+  candidate: for (const node of document.head.querySelectorAll(selector)) {
+    if (node.getAttribute(attr) !== value) continue;
+    if (!qualifiers) return node;
+    for (let i = 0; i < PRELOAD_QUALIFIERS.length; i++) {
+      const name = PRELOAD_QUALIFIERS[i];
+      if (node.getAttribute(name) !== (qualifiers[name] ?? null)) continue candidate;
+    }
+    return node;
   }
   return null;
+}
+
+/** Ensure one typed preload exists, preserving request-qualifying attributes. */
+function ensurePreload(entry) {
+  const attrs = entry.attrs;
+  if (findHeadElement('link[rel="preload"]', "href", entry.href, attrs)) return;
+  const link = document.createElement("link");
+  link.rel = "preload";
+  for (const name in attrs) link.setAttribute(name, attrs[name]);
+  link.setAttribute("href", entry.href);
+  document.head.appendChild(link);
 }
 
 /**
@@ -2062,8 +2087,6 @@ function ensureStylesheet(entry, onSettle) {
   if (!link) {
     link = document.createElement("link");
     link.rel = "stylesheet";
-    // Fetch-metadata attributes (crossorigin, integrity, …) must be in place
-    // before the href assignment starts the request.
     if (typeof entry !== "string" && entry.attrs) {
       for (const name in entry.attrs) link.setAttribute(name, entry.attrs[name]);
     }

--- a/packages/web/frames/src/frame-sink.ts
+++ b/packages/web/frames/src/frame-sink.ts
@@ -24,7 +24,7 @@
  *   registerFragment resolve (post-flush)
  *                                     -> fragment(key, html, meta) -> [assets,] fragment [, reveal when eager]
  *   revealFragments / revealFallbacks -> reveal(keys, meta)        -> reveal
- *   registerAsset (post-flush)        -> asset(type, url)          -> assets
+ *   registerAsset (post-flush)        -> asset(type, value)        -> assets
  *   envelope completion               -> end()                     -> complete
  *   error paths (not yet routed)      -> error(id, err)            -> error
  *
@@ -170,6 +170,10 @@ export {
   ServerComponentPlugin
 } from "./frame-transport.js";
 
+function wirePreload(entry) {
+  return { href: entry.href, attrs: entry.attrs };
+}
+
 /**
  * The client-side `_$SC` registry as an idempotent expression: evaluates to
  * the registry, creating it only if absent. Idempotence matters — the
@@ -302,15 +306,23 @@ export function createFrameSink(emit, frame) {
       // Pre-flush assets (entry modules, hoisted boundary styles) are head
       // splices in the document sink; a frame carries them as an assets chunk
       // ahead of the shell html.
-      if (meta.preloads && meta.preloads.size) {
-        const styles = [];
-        const modules = [];
-        for (const url of meta.preloads) {
-          (url.endsWith(".css") ? styles : modules).push(url);
-        }
+      if ((meta.preloads && meta.preloads.size) || meta.preloadLinks) {
         const chunk = { type: "assets", id, version, key: "" };
-        if (styles.length) chunk.styles = styles;
-        if (modules.length) chunk.modules = modules;
+        if (meta.preloads && meta.preloads.size) {
+          const styles = [];
+          const modules = [];
+          for (const url of meta.preloads) {
+            (url.endsWith(".css") ? styles : modules).push(url);
+          }
+          if (styles.length) chunk.styles = styles;
+          if (modules.length) chunk.modules = modules;
+        }
+        if (meta.preloadLinks) {
+          chunk.preloads = [];
+          for (const entry of meta.preloadLinks) {
+            chunk.preloads.push(wirePreload(entry));
+          }
+        }
         emit(chunk);
       }
       emit({ type: "html", id, version, html });
@@ -415,13 +427,16 @@ export function createFrameSink(emit, frame) {
         emit(chunk);
       }
     },
-    asset(type, url) {
+    asset(type, value) {
       // Post-flush styles ride their fragment's assets chunk (fragment() gets
       // them via meta.styles) — same as the document sink, which only writes
       // style links on the fragment path. Emitting them here too would
       // duplicate, mis-keyed to the root.
-      if (type !== "module") return;
-      emit({ type: "assets", id, version, key: "", modules: [url] });
+      if (type === "module") {
+        emit({ type: "assets", id, version, key: "", modules: [value] });
+      } else if (type === "preload") {
+        emit({ type: "assets", id, version, key: "", preloads: [wirePreload(value)] });
+      }
     },
     end() {
       // The end-of-response latch: one final synchronous sweep so a commit

--- a/packages/web/jsx/jsx-h.d.ts
+++ b/packages/web/jsx/jsx-h.d.ts
@@ -1067,6 +1067,7 @@ export namespace JSX {
   type HTMLFormEncType = "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain";
   type HTMLFormMethod = "post" | "get" | "dialog";
   type HTMLCrossorigin = "anonymous" | "use-credentials" | EnumeratedAcceptsEmpty;
+  type HTMLFetchPriority = "high" | "low" | "auto";
   type HTMLReferrerPolicy =
     | "no-referrer"
     | "no-referrer-when-downgrade"
@@ -1092,19 +1093,8 @@ export namespace JSX {
     | "allow-top-navigation"
     | "allow-top-navigation-by-user-activation"
     | "allow-top-navigation-to-custom-protocols";
-  type HTMLLinkAs =
-    | "audio"
-    | "document"
-    | "embed"
-    | "fetch"
-    | "font"
-    | "image"
-    | "object"
-    | "script"
-    | "style"
-    | "track"
-    | "video"
-    | "worker";
+  type HTMLPreloadAs = "fetch" | "font" | "image" | "script" | "style" | "track";
+  type HTMLLinkAs = HTMLPreloadAs | "audio" | "document" | "embed" | "object" | "video" | "worker";
 
   interface AnchorHTMLAttributes<T> extends HTMLAttributes<T> {
     download?: FunctionMaybe<string | EnumeratedAcceptsEmpty | RemoveAttribute>;
@@ -1365,7 +1355,7 @@ export namespace JSX {
     browsingtopics?: FunctionMaybe<string | RemoveAttribute>;
     crossorigin?: FunctionMaybe<HTMLCrossorigin | RemoveAttribute>;
     decoding?: FunctionMaybe<"sync" | "async" | "auto" | RemoveAttribute>;
-    fetchpriority?: FunctionMaybe<"high" | "low" | "auto" | RemoveAttribute>;
+    fetchpriority?: FunctionMaybe<HTMLFetchPriority | RemoveAttribute>;
     height?: FunctionMaybe<number | string | RemoveAttribute>;
     ismap?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
     loading?: FunctionMaybe<"eager" | "lazy" | RemoveAttribute>;
@@ -1521,7 +1511,7 @@ export namespace JSX {
     color?: FunctionMaybe<string | RemoveAttribute>;
     crossorigin?: FunctionMaybe<HTMLCrossorigin | RemoveAttribute>;
     disabled?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
-    fetchpriority?: FunctionMaybe<"high" | "low" | "auto" | RemoveAttribute>;
+    fetchpriority?: FunctionMaybe<HTMLFetchPriority | RemoveAttribute>;
     href?: FunctionMaybe<string | RemoveAttribute>;
     hreflang?: FunctionMaybe<string | RemoveAttribute>;
     imagesizes?: FunctionMaybe<string | RemoveAttribute>;
@@ -1716,7 +1706,7 @@ export namespace JSX {
     blocking?: FunctionMaybe<"render" | RemoveAttribute>;
     crossorigin?: FunctionMaybe<HTMLCrossorigin | RemoveAttribute>;
     defer?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
-    fetchpriority?: FunctionMaybe<"high" | "low" | "auto" | RemoveAttribute>;
+    fetchpriority?: FunctionMaybe<HTMLFetchPriority | RemoveAttribute>;
     for?: FunctionMaybe<string | RemoveAttribute>;
     integrity?: FunctionMaybe<string | RemoveAttribute>;
     nomodule?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;

--- a/packages/web/jsx/jsx.d.ts
+++ b/packages/web/jsx/jsx.d.ts
@@ -1080,6 +1080,7 @@ export namespace JSX {
   type HTMLFormEncType = "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain";
   type HTMLFormMethod = "post" | "get" | "dialog";
   type HTMLCrossorigin = "anonymous" | "use-credentials" | EnumeratedAcceptsEmpty;
+  type HTMLFetchPriority = "high" | "low" | "auto";
   type HTMLReferrerPolicy =
     | "no-referrer"
     | "no-referrer-when-downgrade"
@@ -1105,19 +1106,8 @@ export namespace JSX {
     | "allow-top-navigation"
     | "allow-top-navigation-by-user-activation"
     | "allow-top-navigation-to-custom-protocols";
-  type HTMLLinkAs =
-    | "audio"
-    | "document"
-    | "embed"
-    | "fetch"
-    | "font"
-    | "image"
-    | "object"
-    | "script"
-    | "style"
-    | "track"
-    | "video"
-    | "worker";
+  type HTMLPreloadAs = "fetch" | "font" | "image" | "script" | "style" | "track";
+  type HTMLLinkAs = HTMLPreloadAs | "audio" | "document" | "embed" | "object" | "video" | "worker";
 
   interface AnchorHTMLAttributes<T> extends HTMLAttributes<T> {
     download?: string | EnumeratedAcceptsEmpty | RemoveAttribute;
@@ -1367,7 +1357,7 @@ export namespace JSX {
     browsingtopics?: string | RemoveAttribute;
     crossorigin?: HTMLCrossorigin | RemoveAttribute;
     decoding?: "sync" | "async" | "auto" | RemoveAttribute;
-    fetchpriority?: "high" | "low" | "auto" | RemoveAttribute;
+    fetchpriority?: HTMLFetchPriority | RemoveAttribute;
     height?: number | string | RemoveAttribute;
     ismap?: BooleanAttribute | RemoveAttribute;
     loading?: "eager" | "lazy" | RemoveAttribute;
@@ -1522,7 +1512,7 @@ export namespace JSX {
     color?: string | RemoveAttribute;
     crossorigin?: HTMLCrossorigin | RemoveAttribute;
     disabled?: BooleanAttribute | RemoveAttribute;
-    fetchpriority?: "high" | "low" | "auto" | RemoveAttribute;
+    fetchpriority?: HTMLFetchPriority | RemoveAttribute;
     href?: string | RemoveAttribute;
     hreflang?: string | RemoveAttribute;
     imagesizes?: string | RemoveAttribute;
@@ -1713,7 +1703,7 @@ export namespace JSX {
     blocking?: "render" | RemoveAttribute;
     crossorigin?: HTMLCrossorigin | RemoveAttribute;
     defer?: BooleanAttribute | RemoveAttribute;
-    fetchpriority?: "high" | "low" | "auto" | RemoveAttribute;
+    fetchpriority?: HTMLFetchPriority | RemoveAttribute;
     for?: string | RemoveAttribute;
     integrity?: string | RemoveAttribute;
     nomodule?: BooleanAttribute | RemoveAttribute;

--- a/packages/web/src/head.ts
+++ b/packages/web/src/head.ts
@@ -30,7 +30,9 @@ export const RESOURCE_LINK_RELS = new Set([
 
 // Attributes that qualify a resource identity: the same href preloaded
 // `as="image"` and `as="fetch"` are different requests, and crossorigin
-// changes cacheability. URL alone is not the identity.
+// changes cacheability. URL alone is not the identity. Integrity, referrer
+// policy, and fetch priority are deliberately first-registration metadata:
+// conflicting declarations do not create another resource identity.
 const RESOURCE_QUALIFIERS = ["as", "crossorigin", "type", "media", "imagesrcset", "imagesizes"];
 
 // Stylesheet attributes that are pure fetch metadata: they change how the
@@ -83,7 +85,8 @@ export function resourceIdentity(tag, props) {
   let id = "res:" + tag + ":" + (props.rel || "") + ":" + (props.href || props.src || "");
   for (let i = 0; i < RESOURCE_QUALIFIERS.length; i++) {
     const q = RESOURCE_QUALIFIERS[i];
-    if (props[q] != null) id += ":" + q + "=" + props[q];
+    const value = props[q];
+    if (value != null) id += ":" + q + "=" + (value === true ? "" : value);
   }
   return id;
 }

--- a/packages/web/src/index.server.ts
+++ b/packages/web/src/index.server.ts
@@ -133,8 +133,9 @@ export function Portal(props: { mount?: Element; children: JSX.Element }) {
  * Emits early preload hints for a `clientOnly` module: resolves the module's
  * client assets through the manifest seam lazy() uses and registers them as
  * plain link hints (`modulepreload` for js, stylesheet links / inline styles
- * for css) so the browser can start fetching when the HTML arrives instead
- * of when the client bundle evaluates the `clientOnly()` call.
+ * for css, plus explicit preload descriptors) so the browser can start
+ * fetching when the HTML arrives instead of when the client bundle evaluates
+ * the `clientOnly()` call.
  *
  * Deliberately NOT `registerModule`: that files the module into the
  * serialized hydration asset map, whose contract is "required before
@@ -160,6 +161,11 @@ function registerClientOnlyPreload(moduleUrl: string): void {
       const css = assets.css[i];
       if (typeof css === "string") registerAsset("style", css);
       else registerAsset("inline-style", css);
+    }
+    if (assets.preloads) {
+      for (let i = 0; i < assets.preloads.length; i++) {
+        registerAsset("preload", assets.preloads[i]);
+      }
     }
     for (let i = 0; i < assets.js.length; i++) registerAsset("module", assets.js[i]);
   };

--- a/packages/web/src/server-mock.ts
+++ b/packages/web/src/server-mock.ts
@@ -1,5 +1,6 @@
 //@ts-nocheck
 import type { RequestEvent, RequestEventLocals, ResponseStub } from "./client.js";
+import type { JSX } from "../jsx/jsx.js";
 
 function throwInBrowser(func: Function) {
   const err = new Error(`${func.name} is not supported in the browser, returning undefined`);
@@ -7,10 +8,28 @@ function throwInBrowser(func: Function) {
   console.error(err);
 }
 
+/** An explicit `<link rel="preload">` emitted by the SSR asset pipeline. */
+export type PreloadLink = {
+  href: string;
+  as: JSX.HTMLPreloadAs;
+  type?: string;
+  crossorigin?: JSX.HTMLCrossorigin;
+  integrity?: string;
+  referrerpolicy?: JSX.HTMLReferrerPolicy;
+  fetchpriority?: JSX.HTMLFetchPriority;
+  media?: string;
+};
+
 /** Static asset manifest produced by a build (e.g. parsed Vite manifest.json). */
 export type AssetManifest = Record<
   string,
-  { file: string; css?: string[]; isEntry?: boolean; imports?: string[] }
+  {
+    file: string;
+    css?: string[];
+    isEntry?: boolean;
+    imports?: string[];
+    preloads?: PreloadLink[];
+  }
 > & { _base?: string };
 
 /** Inline style content, e.g. dev CSS collected from a bundler's module graph. */
@@ -23,6 +42,7 @@ export type InlineStyleAsset = {
 export type ResolvedAssets = {
   js: string[];
   css: (string | InlineStyleAsset)[];
+  preloads?: PreloadLink[];
 };
 
 /**
@@ -31,8 +51,9 @@ export type ResolvedAssets = {
  * normalized into a sync resolver internally). `resolve` may return a
  * promise (async resolvers require streaming rendering); CSS entries may be
  * URL strings (emitted as load-gated `<link>` tags) or inline-style
- * descriptors (emitted as `<style>` tags). A bare `resolve`-shaped function
- * is accepted as shorthand for `{ resolve }`.
+ * descriptors (emitted as `<style>` tags), and `preloads` carries explicit
+ * preload links selected by the integration. A bare `resolve`-shaped
+ * function is accepted as shorthand for `{ resolve }`.
  */
 export type AssetResolver = {
   resolve(

--- a/packages/web/src/server.ts
+++ b/packages/web/src/server.ts
@@ -60,10 +60,28 @@ import { SerializerPlugin } from "../serialization/src/serializer-decode.js";
 
 type MountableElement = Element | Document | ShadowRoot | DocumentFragment | Node;
 
+/** An explicit `<link rel="preload">` emitted by the SSR asset pipeline. */
+export type PreloadLink = {
+  href: string;
+  as: JSX.HTMLPreloadAs;
+  type?: string;
+  crossorigin?: JSX.HTMLCrossorigin;
+  integrity?: string;
+  referrerpolicy?: JSX.HTMLReferrerPolicy;
+  fetchpriority?: JSX.HTMLFetchPriority;
+  media?: string;
+};
+
 /** Static asset manifest produced by a build (e.g. parsed Vite manifest.json). */
 export type AssetManifest = Record<
   string,
-  { file: string; css?: string[]; isEntry?: boolean; imports?: string[] }
+  {
+    file: string;
+    css?: string[];
+    isEntry?: boolean;
+    imports?: string[];
+    preloads?: PreloadLink[];
+  }
 > & { _base?: string };
 
 /** Inline style content, e.g. dev CSS collected from a bundler's module graph. */
@@ -76,6 +94,7 @@ export type InlineStyleAsset = {
 export type ResolvedAssets = {
   js: string[];
   css: (string | InlineStyleAsset)[];
+  preloads?: PreloadLink[];
 };
 
 /**
@@ -84,8 +103,9 @@ export type ResolvedAssets = {
  * normalized into a sync resolver internally). `resolve` may return a
  * promise (async resolvers require streaming rendering); CSS entries may be
  * URL strings (emitted as load-gated `<link>` tags) or inline-style
- * descriptors (emitted as `<style>` tags). A bare `resolve`-shaped function
- * is accepted as shorthand for `{ resolve }`.
+ * descriptors (emitted as `<style>` tags), and `preloads` carries explicit
+ * preload links selected by the integration. A bare `resolve`-shaped
+ * function is accepted as shorthand for `{ resolve }`.
  */
 export type AssetResolver = {
   resolve(
@@ -280,6 +300,7 @@ function resolveAssets(moduleUrl, manifest) {
   if (!entry) return null;
   const css = [];
   const js = [];
+  let preloads;
   const visited = new Set();
   const walk = key => {
     if (visited.has(key)) return;
@@ -288,10 +309,20 @@ function resolveAssets(moduleUrl, manifest) {
     if (!e) return;
     js.push(joinAssetPath(base, e.file));
     if (e.css) for (let i = 0; i < e.css.length; i++) css.push(joinAssetPath(base, e.css[i]));
+    if (e.preloads) {
+      for (let i = 0; i < e.preloads.length; i++) {
+        const link = e.preloads[i];
+        if (!link || typeof link.href !== "string" || !link.href) continue;
+        if (!preloads) preloads = [];
+        preloads.push({ ...link, href: joinAssetPath(base, link.href) });
+      }
+    }
     if (e.imports) for (let i = 0; i < e.imports.length; i++) walk(e.imports[i]);
   };
   walk(moduleUrl);
-  return { js, css };
+  const assets = { js, css };
+  if (preloads) assets.preloads = preloads;
+  return assets;
 }
 
 function registerEntryAssets(manifest) {
@@ -304,6 +335,9 @@ function registerEntryAssets(manifest) {
     if (manifest[key].isEntry) {
       const assets = resolveAssets(key, manifest);
       if (assets) {
+        if (assets.preloads)
+          for (let i = 0; i < assets.preloads.length; i++)
+            ctx.registerAsset("preload", assets.preloads[i]);
         for (let i = 0; i < assets.css.length; i++) ctx.registerAsset("style", assets.css[i]);
         // js[0] is the entry itself, which the document loads with its own <script>;
         // preload only its static import closure.
@@ -327,6 +361,7 @@ function createAssetTracking() {
     boundaryStyles,
     emittedAssets,
     inlineStyles,
+    preloadLinks: null,
     // Inline styles (dev CSS collected from the module graph, critical CSS)
     // dedupe by `id` — repeated registrations reuse the same entry object so
     // boundary Sets and the head injection never emit the same style twice.
@@ -478,6 +513,74 @@ function applyAssetTracking(context, tracking, manifest, noScripts) {
 function isCssUrl(url) {
   const q = url.search(/[?#]/);
   return (q === -1 ? url : url.slice(0, q)).endsWith(".css");
+}
+
+const PRELOAD_LINK_ATTRIBUTES = [
+  "type",
+  "crossorigin",
+  "integrity",
+  "referrerpolicy",
+  "fetchpriority",
+  "media"
+];
+
+// Normalize once for document/frame output and dedupe with useHead resources.
+function registerPreloadLink(tracking, headRegistry, link, nonce) {
+  if (!link || typeof link !== "object" || typeof link.href !== "string" || !link.href) {
+    if ("_SOLID_DEV_") console.warn('registerAsset("preload") requires a non-empty string href.');
+    return null;
+  }
+  if (typeof link.as !== "string") {
+    if ("_SOLID_DEV_") console.warn('registerAsset("preload") requires an as destination.');
+    return null;
+  }
+  const as = asciiLowerCase(link.as);
+  let destination = null;
+  switch (as) {
+    case "script":
+    case "style":
+      destination = as;
+      break;
+    case "fetch":
+    case "font":
+    case "image":
+    case "track":
+      break;
+    default:
+      if ("_SOLID_DEV_")
+        console.warn(
+          `registerAsset("preload") received an unsupported as destination "${link.as}".`
+        );
+      return null;
+  }
+  const props = { rel: "preload", href: link.href, as };
+  for (let i = 0; i < PRELOAD_LINK_ATTRIBUTES.length; i++) {
+    const name = PRELOAD_LINK_ATTRIBUTES[i];
+    const value = link[name];
+    if (value == null || value === false) continue;
+    props[name] = value === true ? "" : String(value);
+  }
+  const identity = resourceIdentity("link", props);
+  if (headRegistry.resources.has(identity)) return null;
+  // A different CORS or credentials mode has a different preload key.
+  if ("_SOLID_DEV_" && props.crossorigin == null && (as === "font" || as === "fetch"))
+    console.warn(
+      `registerAsset("preload") with as="${as}" has no crossorigin and may not match the eventual request.`
+    );
+
+  const attrs = headAttrRecord(props, true);
+  const nonceValue = destination && nonce && nonce[destination];
+  if (typeof nonceValue === "string" && nonceValue) attrs.nonce = nonceValue;
+  const entry = {
+    href: props.href,
+    attrs,
+    attrHtml: renderHeadAttrHtml(props) + nonceAttr(nonce, destination)
+  };
+  headRegistry.resources.add(identity);
+  let links = tracking.preloadLinks;
+  if (!links) tracking.preloadLinks = links = [];
+  links.push(entry);
+  return entry;
 }
 
 function createHeadRegistry() {
@@ -1226,6 +1329,10 @@ export function renderToString(code, options = {}) {
       serializer.write(id, p);
     },
     registerAsset(type, value) {
+      if (type === "preload") {
+        registerPreloadLink(tracking, headRegistry, value, nonce);
+        return;
+      }
       if (type === "inline-style") {
         tracking.registerInlineStyle(value);
         return;
@@ -1257,6 +1364,7 @@ export function renderToString(code, options = {}) {
   return assembleDocument(
     resolveSSRSelectValues(html),
     tracking.emittedAssets,
+    tracking.preloadLinks,
     tracking.inlineStyles,
     scripts.length ? scripts : "",
     nonce,
@@ -1531,6 +1639,8 @@ export function renderToStream(code, options = {}) {
     asset(type, value) {
       if (type === "module") {
         buffer.write(`<link rel="modulepreload" href="${value}"${nonceAttr(nonce, "script")}>`);
+      } else if (type === "preload") {
+        buffer.write(`<link${value.attrHtml}>`);
       } else if (type === "inline-style") {
         buffer.write(renderInlineStyle(value, nonce));
       } else if (type === "head-tag") {
@@ -1548,6 +1658,7 @@ export function renderToStream(code, options = {}) {
         assembleDocument(
           shellHtml,
           meta.preloads,
+          meta.preloadLinks,
           meta.inlineStyles,
           meta.tasks.length ? meta.tasks : "",
           nonce,
@@ -1711,6 +1822,11 @@ export function renderToStream(code, options = {}) {
       );
     },
     registerAsset(type, value) {
+      if (type === "preload") {
+        const entry = registerPreloadLink(tracking, headRegistry, value, nonce);
+        if (entry && firstFlushed) sink.asset("preload", entry);
+        return;
+      }
       if (type === "inline-style") {
         const entry = tracking.registerInlineStyle(value);
         // Boundary-attributed inline styles flush with their fragment; a late
@@ -1983,6 +2099,7 @@ export function renderToStream(code, options = {}) {
     const head = renderShellHead(headRegistry, nonce, k => registry.has(k), noScripts);
     sink.shell(resolveSSRSelectValues(html), {
       preloads: tracking.emittedAssets,
+      preloadLinks: tracking.preloadLinks,
       inlineStyles: tracking.inlineStyles,
       tasks,
       head
@@ -3699,7 +3816,16 @@ function allSettled(promises) {
 // output passes through with only the script splice. When the output does
 // contain `</head>`, splicing is automatic and `onHead` is not called: one
 // mode or the other, decided by the render output itself.
-function assembleDocument(html, emittedAssets, inlineStyles, scripts, nonce, headTags, onHead) {
+function assembleDocument(
+  html,
+  emittedAssets,
+  preloadLinks,
+  inlineStyles,
+  scripts,
+  nonce,
+  headTags,
+  onHead
+) {
   const scriptTag = scripts ? `<script${nonceAttr(nonce, "script")}>${scripts}</script>` : "";
   const title = headTags ? headTags.title : null;
   let headTagsHtml = headTags ? headTags.html : "";
@@ -3710,6 +3836,7 @@ function assembleDocument(html, emittedAssets, inlineStyles, scripts, nonce, hea
     !headTagsHtml &&
     !headPrelude &&
     !(emittedAssets && emittedAssets.size) &&
+    !preloadLinks &&
     !(inlineStyles && inlineStyles.size)
   ) {
     // Nothing head-bound: never look for `</head>`. Body-only renders (no
@@ -3754,7 +3881,7 @@ function assembleDocument(html, emittedAssets, inlineStyles, scripts, nonce, hea
         headPrelude +
           headTagsHtml +
           titleHtml +
-          renderHeadAssets(emittedAssets, inlineStyles, nonce)
+          renderHeadAssets(emittedAssets, preloadLinks, inlineStyles, nonce)
       );
     }
     // No head to splice into: without `onHead`, assets/preloads/styles are
@@ -3793,7 +3920,7 @@ function assembleDocument(html, emittedAssets, inlineStyles, scripts, nonce, hea
       headTagsHtml = `<title data-dh="title">${winner}</title>` + headTagsHtml;
     }
   }
-  const head = headTagsHtml + renderHeadAssets(emittedAssets, inlineStyles, nonce);
+  const head = headTagsHtml + renderHeadAssets(emittedAssets, preloadLinks, inlineStyles, nonce);
   if (!scriptTag) return html.slice(0, headIdx) + head + html.slice(headIdx);
   const xsIdx = html.indexOf("<!--xs-->");
   if (xsIdx === -1) return html.slice(0, headIdx) + head + html.slice(headIdx) + scriptTag;
@@ -3805,7 +3932,7 @@ function assembleDocument(html, emittedAssets, inlineStyles, scripts, nonce, hea
 // Tracked asset links (stylesheet/modulepreload by URL) and unconsumed inline
 // styles, rendered for a head splice or an `onHead` delivery. Inline-style
 // entries are consumed (marked emitted) by whichever path renders them first.
-function renderHeadAssets(emittedAssets, inlineStyles, nonce) {
+function renderHeadAssets(emittedAssets, preloadLinks, inlineStyles, nonce) {
   let head = "";
   const styleAttr = nonceAttr(nonce, "style");
   const scriptAttr = nonceAttr(nonce, "script");
@@ -3815,6 +3942,9 @@ function renderHeadAssets(emittedAssets, inlineStyles, nonce) {
         ? `<link rel="stylesheet" href="${url}"${styleAttr}>`
         : `<link rel="modulepreload" href="${url}"${scriptAttr}>`;
     }
+  }
+  if (preloadLinks) {
+    for (const entry of preloadLinks) head += `<link${entry.attrHtml}>`;
   }
   if (inlineStyles && inlineStyles.size) {
     for (const entry of inlineStyles.values()) {

--- a/packages/web/test/preload-links-frame-client.spec.ts
+++ b/packages/web/test/preload-links-frame-client.spec.ts
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { afterEach, describe, expect, it } from "vitest";
-import { createFrame } from "../frames/src/frame-client.js";
+import { createFrame, createFrameHost } from "../frames/src/frame-client.js";
 
 afterEach(() => {
   document.head.replaceChildren();
@@ -68,5 +68,38 @@ describe("frame preload links", () => {
     document.head.querySelector('link[href="/late.woff2"]')!.remove();
     frame.apply({ version: 2, r: { "seg::assets": lateAssets } });
     expect(document.head.querySelector('link[href="/late.woff2"]')).not.toBeNull();
+  });
+
+  it("retains every late root asset record until a frame registers", () => {
+    const host = createFrameHost();
+    host.apply({
+      type: "assets",
+      id: "warm-assets",
+      version: 1,
+      key: "",
+      modules: ["/warm-module-a.js"]
+    });
+    host.apply({
+      type: "assets",
+      id: "warm-assets",
+      version: 1,
+      key: "",
+      modules: ["/warm-module-b.js"]
+    });
+    host.apply({
+      type: "assets",
+      id: "warm-assets",
+      version: 1,
+      key: "",
+      preloads: [{ href: "/warm-font.woff2", attrs: { as: "font", crossorigin: "" } }]
+    });
+
+    expect(document.head.querySelector("link")).toBeNull();
+    const boundary = document.createElement("div");
+    document.body.appendChild(boundary);
+    createFrame(boundary, { id: "warm-assets", host });
+    expect(document.head.querySelector('link[href="/warm-module-a.js"]')).not.toBeNull();
+    expect(document.head.querySelector('link[href="/warm-module-b.js"]')).not.toBeNull();
+    expect(document.head.querySelector('link[href="/warm-font.woff2"]')).not.toBeNull();
   });
 });

--- a/packages/web/test/preload-links-frame-client.spec.ts
+++ b/packages/web/test/preload-links-frame-client.spec.ts
@@ -1,0 +1,72 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it } from "vitest";
+import { createFrame } from "../frames/src/frame-client.js";
+
+afterEach(() => {
+  document.head.replaceChildren();
+  document.body.replaceChildren();
+});
+
+describe("frame preload links", () => {
+  it("applies typed preloads by their full request identity", () => {
+    const boundary = document.createElement("div");
+    document.body.appendChild(boundary);
+    const frame = createFrame(boundary);
+
+    frame.apply({
+      version: 1,
+      r: {
+        "seg::assets": {
+          type: "assets",
+          key: "",
+          preloads: [
+            {
+              href: "/shared.bin",
+              attrs: { as: "image", type: "image/avif", fetchpriority: "high" }
+            },
+            { href: "/shared.bin", attrs: { as: "fetch", crossorigin: "anonymous" } }
+          ]
+        }
+      }
+    });
+
+    let links = [...document.head.querySelectorAll<HTMLLinkElement>('link[rel="preload"]')];
+    expect(links).toHaveLength(2);
+    expect(links.find(link => link.getAttribute("as") === "image")?.getAttribute("type")).toBe(
+      "image/avif"
+    );
+    expect(
+      links.find(link => link.getAttribute("as") === "image")?.getAttribute("fetchpriority")
+    ).toBe("high");
+    expect(
+      links.find(link => link.getAttribute("as") === "fetch")?.getAttribute("crossorigin")
+    ).toBe("anonymous");
+
+    const lateAssets = {
+      type: "assets",
+      key: "",
+      preloads: [{ href: "/late.woff2", attrs: { as: "font", crossorigin: "" } }]
+    };
+    frame.apply({ version: 1, r: { "seg::assets": lateAssets } });
+    expect(document.head.querySelector('link[href="/late.woff2"]')).not.toBeNull();
+
+    frame.apply({
+      version: 1,
+      r: {
+        "seg:duplicate:assets": {
+          type: "assets",
+          key: "duplicate",
+          preloads: [{ href: "/shared.bin", attrs: { as: "image", type: "image/avif" } }]
+        }
+      }
+    });
+    links = [...document.head.querySelectorAll<HTMLLinkElement>('link[rel="preload"]')].filter(
+      link => link.getAttribute("href") === "/shared.bin" && link.getAttribute("as") === "image"
+    );
+    expect(links).toHaveLength(1);
+
+    document.head.querySelector('link[href="/late.woff2"]')!.remove();
+    frame.apply({ version: 2, r: { "seg::assets": lateAssets } });
+    expect(document.head.querySelector('link[href="/late.woff2"]')).not.toBeNull();
+  });
+});

--- a/packages/web/test/preload-links.type-tests.ts
+++ b/packages/web/test/preload-links.type-tests.ts
@@ -1,0 +1,28 @@
+import type { AssetManifest, PreloadLink, ResolvedAssets } from "../src/server.js";
+
+const preload: PreloadLink = {
+  href: "/font.woff2",
+  as: "font",
+  type: "font/woff2",
+  crossorigin: true,
+  fetchpriority: "high",
+  referrerpolicy: "no-referrer"
+};
+
+const manifest: AssetManifest = {
+  entry: { file: "entry.js", preloads: [preload] }
+};
+
+const resolved: ResolvedAssets = { js: [], css: [], preloads: [preload] };
+void manifest;
+void resolved;
+
+// @ts-expect-error href is required until responsive image preloads add a source-only form
+const missingHref: PreloadLink = { as: "image" };
+// @ts-expect-error only HTML preload destinations are accepted
+const invalidDestination: PreloadLink = { href: "/movie.mp4", as: "video" };
+// @ts-expect-error arbitrary priorities are rejected
+const invalidPriority: PreloadLink = { href: "/hero.avif", as: "image", fetchpriority: "urgent" };
+void missingHref;
+void invalidDestination;
+void invalidPriority;

--- a/packages/web/test/runtime/preload-links.spec.js
+++ b/packages/web/test/runtime/preload-links.spec.js
@@ -1,0 +1,346 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as r from "../../src/server.js";
+import { renderToFrameStream } from "../../frames/src/frame-sink.js";
+import { sharedConfig } from "solid-js";
+import { describe, expect, it, vi } from "vitest";
+
+globalThis.TextEncoder = function () {
+  return { encode: value => value };
+};
+
+function pipeToString(stream) {
+  return new Promise(resolve => {
+    const chunks = [];
+    stream.pipe({
+      write(value) {
+        chunks.push(value);
+      },
+      end() {
+        resolve(chunks.join(""));
+      }
+    });
+  });
+}
+
+describe("typed preload links", () => {
+  it("collects explicit links from the static manifest graph", () => {
+    const manifest = {
+      _base: "/assets/",
+      "app.tsx": {
+        file: "app.js",
+        imports: ["shared.tsx"],
+        dynamicImports: ["lazy.tsx"],
+        assets: ["not-automatically-preloaded.png"],
+        isEntry: true,
+        preloads: [
+          { href: "", as: "image" },
+          { href: "hero.avif", as: "image", type: "image/avif", fetchpriority: "high" }
+        ]
+      },
+      "shared.tsx": {
+        file: "shared.js",
+        preloads: [
+          {
+            href: "fonts/app.woff2?v=1",
+            as: "font",
+            type: "font/woff2",
+            crossorigin: ""
+          }
+        ]
+      },
+      "lazy.tsx": {
+        file: "lazy.js",
+        preloads: [{ href: "hidden.webp", as: "image" }]
+      }
+    };
+
+    let resolved;
+    const html = r.renderToString(
+      () => {
+        resolved = sharedConfig.context.resolveAssets("app.tsx");
+        return r.ssr`<html><head></head><body></body></html>`;
+      },
+      { manifest }
+    );
+
+    expect(resolved.preloads).toEqual([
+      { href: "/assets/hero.avif", as: "image", type: "image/avif", fetchpriority: "high" },
+      {
+        href: "/assets/fonts/app.woff2?v=1",
+        as: "font",
+        type: "font/woff2",
+        crossorigin: ""
+      }
+    ]);
+    expect(html).toContain(
+      '<link rel="preload" href="/assets/hero.avif" as="image" type="image/avif" fetchpriority="high">'
+    );
+    expect(html).toContain(
+      '<link rel="preload" href="/assets/fonts/app.woff2?v=1" as="font" type="font/woff2" crossorigin="">'
+    );
+    expect(html).not.toContain("hidden.webp");
+    expect(html).not.toContain("not-automatically-preloaded.png");
+  });
+
+  it("preserves fetch metadata and dedupes by resource identity", () => {
+    const html = r.renderToString(() => {
+      const ctx = sharedConfig.context;
+      const image = {
+        href: '/hero.avif?size="wide"',
+        as: "image",
+        type: "image/avif",
+        integrity: "sha384-image",
+        referrerpolicy: "no-referrer",
+        fetchpriority: "high",
+        media: "(min-width: 60rem)"
+      };
+      ctx.registerAsset("preload", image);
+      ctx.registerAsset("preload", image);
+      ctx.registerAsset("preload", { ...image, integrity: "sha384-conflict" });
+      ctx.registerAsset("preload", {
+        href: image.href,
+        as: "fetch",
+        crossorigin: "anonymous"
+      });
+      ctx.registerAsset("preload", { ...image, crossorigin: true });
+      ctx.registerAsset("preload", { ...image, crossorigin: "" });
+      return r.ssr`<html><head></head><body></body></html>`;
+    });
+
+    expect(html.match(/href="\/hero\.avif\?size=&quot;wide&quot;"/g)).toHaveLength(3);
+    const image = html.match(/<link[^>]*sha384-image[^>]*>/)[0];
+    expect(image).toContain('as="image"');
+    expect(image).toContain('type="image/avif"');
+    expect(image).toContain('referrerpolicy="no-referrer"');
+    expect(image).toContain('fetchpriority="high"');
+    expect(image).toContain('media="(min-width: 60rem)"');
+    expect(image).not.toContain("nonce");
+    expect(html.match(/crossorigin=""/g)).toHaveLength(1);
+    expect(html).not.toContain("sha384-conflict");
+  });
+
+  it("routes nonces and delivers links through onHead", () => {
+    let embeddedHead;
+    const html = r.renderToString(
+      () => {
+        const ctx = sharedConfig.context;
+        ctx.registerAsset("preload", { href: "/script.bin", as: "SCRIPT" });
+        ctx.registerAsset("preload", { href: "/style.bin", as: "style" });
+        ctx.registerAsset("preload", {
+          href: "/font.bin",
+          as: "font",
+          crossorigin: ""
+        });
+        return r.ssr`<main>embedded</main>`;
+      },
+      {
+        nonce: { script: "script-nonce", style: "style-nonce" },
+        onHead: value => (embeddedHead = value)
+      }
+    );
+
+    expect(html).toBe("<main>embedded</main>");
+    expect(embeddedHead.match(/<link[^>]*\/script\.bin[^>]*>/)[0]).toContain(
+      'nonce="script-nonce"'
+    );
+    expect(embeddedHead.match(/<link[^>]*\/style\.bin[^>]*>/)[0]).toContain('nonce="style-nonce"');
+    expect(embeddedHead.match(/<link[^>]*\/font\.bin[^>]*>/)[0]).not.toContain("nonce");
+  });
+
+  it("dedupes against useHead in either registration order", () => {
+    const before = r.renderToString(() => {
+      const link = {
+        href: "/before.avif",
+        as: "image",
+        type: "image/avif",
+        crossorigin: true
+      };
+      sharedConfig.context.registerAsset("preload", link);
+      r.useHead({
+        tag: "link",
+        props: { rel: "preload", ...link, crossorigin: "" }
+      });
+      return r.ssr`<html><head></head><body></body></html>`;
+    });
+    const after = r.renderToString(() => {
+      const link = { href: "/after.avif", as: "image", type: "image/avif", crossorigin: "" };
+      r.useHead({ tag: "link", props: { rel: "preload", ...link, crossorigin: true } });
+      sharedConfig.context.registerAsset("preload", link);
+      return r.ssr`<html><head></head><body></body></html>`;
+    });
+
+    expect(before.match(/href="\/before\.avif"/g)).toHaveLength(1);
+    expect(after.match(/href="\/after\.avif"/g)).toHaveLength(1);
+  });
+
+  it("warns for request-mode mismatches and rejects invalid descriptors", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let html;
+    let warnings;
+    try {
+      html = r.renderToString(() => {
+        const ctx = sharedConfig.context;
+        ctx.registerAsset("preload", { href: "/a.woff2", as: "font" });
+        ctx.registerAsset("preload", { href: "/a.woff2", as: "font" });
+        ctx.registerAsset("preload", { href: "/b.json", as: "fetch" });
+        ctx.registerAsset("preload", { href: "/c.woff2", as: "font", crossorigin: "" });
+        ctx.registerAsset("preload", "/untyped.bin");
+        ctx.registerAsset("preload", { href: "/missing-as.bin" });
+        ctx.registerAsset("preload", { href: "/invalid.bin", as: " style " });
+        return r.ssr`<html><head></head><body></body></html>`;
+      });
+    } finally {
+      warnings = warn.mock.calls.map(call => String(call[0]));
+      warn.mockRestore();
+    }
+
+    expect(html).not.toContain("untyped.bin");
+    expect(html).not.toContain("missing-as.bin");
+    expect(html).not.toContain("invalid.bin");
+    expect(warnings).toHaveLength(5);
+    const corsWarnings = warnings.filter(message => message.includes("crossorigin"));
+    expect(corsWarnings).toHaveLength(2);
+  });
+
+  it("writes a link registered after the shell to the document stream", async () => {
+    let done;
+    const html = await pipeToString(
+      r.renderToStream(() => {
+        const ctx = sharedConfig.context;
+        done = ctx.registerFragment("late-document-link");
+        setTimeout(() => {
+          ctx.registerAsset("preload", {
+            href: "/late-document.woff2",
+            as: "font",
+            type: "font/woff2",
+            crossorigin: ""
+          });
+          done("<span>done</span>");
+        }, 10);
+        return r.ssr`<div><template id="pl-late-document-link"></template><!--pl-late-document-link--></div>`;
+      })
+    );
+
+    expect(html).toContain(
+      '<link rel="preload" href="/late-document.woff2" as="font" type="font/woff2" crossorigin="">'
+    );
+  });
+
+  it("keeps typed links separate in custom sinks and streams late links", async () => {
+    const shells = [];
+    const late = [];
+    let done;
+    const html = await pipeToString(
+      r.renderToStream(
+        () => {
+          const ctx = sharedConfig.context;
+          ctx.registerAsset("module", "/entry.js");
+          ctx.registerAsset("preload", { href: "/hero.webp", as: "image" });
+          done = ctx.registerFragment("late");
+          setTimeout(() => {
+            ctx.registerAsset("preload", {
+              href: "/late.woff2",
+              as: "font",
+              type: "font/woff2",
+              crossorigin: ""
+            });
+            done("<span>done</span>");
+          }, 10);
+          return r.ssr`<div><template id="pl-late"></template><!--pl-late--></div>`;
+        },
+        {
+          sink: {
+            shell: (value, meta) => shells.push([value, meta]),
+            asset: (type, value) => late.push([type, value])
+          }
+        }
+      )
+    );
+
+    const meta = shells[0][1];
+    expect([...meta.preloads]).toEqual(["/entry.js"]);
+    expect(meta.preloadLinks[0]).toEqual(
+      expect.objectContaining({ href: "/hero.webp", attrs: { as: "image" } })
+    );
+    expect(late).toEqual([
+      [
+        "preload",
+        expect.objectContaining({
+          href: "/late.woff2",
+          attrs: { as: "font", type: "font/woff2", crossorigin: "" }
+        })
+      ]
+    ]);
+    expect(html).not.toContain("/hero.webp");
+    expect(html).not.toContain("/late.woff2");
+  });
+
+  it("carries shell and late links through frame asset chunks", async () => {
+    const chunks = await renderToFrameStream(
+      () => {
+        const ctx = sharedConfig.context;
+        ctx.registerAsset("preload", {
+          href: "/font.woff2",
+          as: "font",
+          type: "font/woff2",
+          crossorigin: ""
+        });
+        ctx.registerAsset("preload", { href: "/critical.js", as: "script" });
+        ctx.registerAsset("preload", { href: "/critical.css", as: "style" });
+        return r.ssr`<div>app</div>`;
+      },
+      {
+        frame: { id: "links", version: 1 },
+        nonce: { script: "script-nonce", style: "style-nonce" }
+      }
+    );
+
+    expect(chunks.find(chunk => chunk.type === "assets").preloads).toEqual([
+      {
+        href: "/font.woff2",
+        attrs: { as: "font", type: "font/woff2", crossorigin: "" }
+      },
+      { href: "/critical.js", attrs: { as: "script", nonce: "script-nonce" } },
+      { href: "/critical.css", attrs: { as: "style", nonce: "style-nonce" } }
+    ]);
+
+    let done;
+    const late = [];
+    await new Promise(resolve => {
+      renderToFrameStream(
+        () => {
+          const ctx = sharedConfig.context;
+          done = ctx.registerFragment("late-frame-link");
+          return r.ssr`<div><template id="pl-late-frame-link"></template><!--pl-late-frame-link--></div>`;
+        },
+        { frame: { id: "late-links", version: 1 } }
+      ).pipe({
+        write(chunk) {
+          late.push(chunk);
+          if (chunk.type === "html") {
+            setTimeout(() => {
+              sharedConfig.context.registerAsset("preload", {
+                href: "/late-frame.webp",
+                as: "image",
+                fetchpriority: "high"
+              });
+              done("<span>done</span>");
+            }, 0);
+          }
+        },
+        end: resolve
+      });
+    });
+    expect(late.filter(chunk => chunk.type === "assets")).toEqual([
+      {
+        type: "assets",
+        id: "late-links",
+        version: 1,
+        key: "",
+        preloads: [{ href: "/late-frame.webp", attrs: { as: "image", fetchpriority: "high" } }]
+      }
+    ]);
+  });
+});

--- a/packages/web/test/server-mock.type-tests.ts
+++ b/packages/web/test/server-mock.type-tests.ts
@@ -63,9 +63,17 @@ mutual<typeof rt.resolveSSRNode>(mock.resolveSSRNode, rt.resolveSSRNode);
 mutual<typeof rt.escape>(mock.escape, rt.escape);
 
 // Manifest option forms stay in lockstep.
+mutual<runtime.PreloadLink>(
+  null as unknown as mock.PreloadLink,
+  null as unknown as runtime.PreloadLink
+);
 mutual<runtime.AssetManifest>(
   null as unknown as mock.AssetManifest,
   null as unknown as runtime.AssetManifest
+);
+mutual<runtime.ResolvedAssets>(
+  null as unknown as mock.ResolvedAssets,
+  null as unknown as runtime.ResolvedAssets
 );
 mutual<runtime.AssetResolver>(
   null as unknown as mock.AssetResolver,

--- a/packages/web/test/server/client-only-preload.spec.tsx
+++ b/packages/web/test/server/client-only-preload.spec.tsx
@@ -33,7 +33,18 @@ const NeverRendered = (_props: any) => <i>never</i>;
 
 describe("clientOnly preload hints", () => {
   const manifest = {
-    "./Chart.tsx": { file: "assets/chart.js", css: ["assets/chart.css"] },
+    "./Chart.tsx": {
+      file: "assets/chart.js",
+      css: ["assets/chart.css"],
+      preloads: [
+        {
+          href: "assets/chart-font.woff2",
+          as: "font" as const,
+          type: "font/woff2",
+          crossorigin: "" as const
+        }
+      ]
+    },
     "./Widget.tsx": { file: "assets/widget.js" }
   };
 
@@ -65,6 +76,9 @@ describe("clientOnly preload hints", () => {
     // Plain hints in the head, fallback in the body.
     expect(html).toContain('<link rel="modulepreload" href="/assets/chart.js">');
     expect(html).toContain('<link rel="stylesheet" href="/assets/chart.css">');
+    expect(html).toContain(
+      '<link rel="preload" href="/assets/chart-font.woff2" as="font" type="font/woff2" crossorigin="">'
+    );
     expect(html).toContain("<span");
 
     // The contrast: lazy's module rides as both the preload link and the

--- a/packages/web/test/server/ssr-stream.spec.tsx
+++ b/packages/web/test/server/ssr-stream.spec.tsx
@@ -1297,7 +1297,15 @@ describe("SSR Streaming — Asset Discovery", () => {
       "./Route.tsx": {
         file: "assets/Route-abc.js",
         css: ["assets/Route.css"],
-        imports: ["_dep"]
+        imports: ["_dep"],
+        preloads: [
+          {
+            href: "assets/Route.woff2",
+            as: "font" as const,
+            type: "font/woff2",
+            crossorigin: "" as const
+          }
+        ]
       },
       _dep: { file: "assets/dep-def.js" }
     };
@@ -1323,6 +1331,9 @@ describe("SSR Streaming — Asset Discovery", () => {
     expect(shell).toContain('<link rel="modulepreload" href="/assets/Route-abc.js">');
     expect(shell).toContain('<link rel="modulepreload" href="/assets/dep-def.js">');
     expect(shell).toContain('<link rel="stylesheet" href="/assets/Route.css">');
+    expect(shell).toContain(
+      '<link rel="preload" href="/assets/Route.woff2" as="font" type="font/woff2" crossorigin="">'
+    );
     // Hints only — the component itself never rendered.
     expect(shell).not.toContain("route body");
   });

--- a/scripts/size/.size-limit.js
+++ b/scripts/size/.size-limit.js
@@ -421,8 +421,13 @@ module.exports = [
     // client plus server-function call observers (pr-570) in the transport.
     // Verified via metafile that the bundle is still exactly the two dist
     // files (no seroval creep — the regression this scenario guards).
+    //
+    // Typed preload links: 11.1 -> 11.28 KB, measured at 11.269. Frames now
+    // preserve request metadata, adopt matching document links, and retain
+    // every late root asset record for mounts that register after the
+    // stream arrives.
     path: "../../packages/web/frames/dist/client.js",
-    limit: "11.1 KB",
+    limit: "11.28 KB",
     modifyEsbuildConfig: framesEsbuildConfig
   }
 ];


### PR DESCRIPTION
## Summary

This reopens the work from [dom-expressions#582](https://github.com/ryansolid/dom-expressions/pull/582) in its new home after the DOM runtime was absorbed into the Solid monorepo. It also completes the typed-resource follow-up from [#3031](https://github.com/solidjs/solid/pull/3031), which taught `lazy().preload()` to register a module's full static JS/CSS closure. The remaining gap was resources whose request cannot be described by a URL alone.

The SSR asset pipeline tracked stylesheets and modulepreloads as bare URLs and inferred the link kind from the `.css` suffix. That works for JS and CSS, but leaves no way to carry fonts, images, MIME types, CORS mode, SRI, or fetch priority through the same pipeline.

Static manifests and `AssetResolver` results can now attach explicit `PreloadLink[]` entries:

```ts
preloads: [
  { href: "/assets/inter.woff2", as: "font", type: "font/woff2", crossorigin: "" },
  { href: "/assets/hero.avif", as: "image", type: "image/avif", fetchpriority: "high" }
]
```

The links are forwarded through the entry manifest, `lazy()`'s render and `preload()` paths, its synchronous `moduleUrl` path for islands, and `clientOnly()`. Under `NoHydration`, CSS and non-script preloads are kept while script preloads are skipped unless `moduleUrl` access explicitly signals that the client will load the module.

`as`, MIME type, CORS mode, integrity, referrer policy, fetch priority, and media survive `renderToString`, streaming, embedded-head and custom-sink output, as well as frame transport and late frame delivery. Script and style preloads also receive the matching split CSP nonce.

Links share the existing head resource identity set, so a manifest link and a `useHead` link dedupe in either registration order. `integrity`, `referrerpolicy`, and `fetchpriority` remain first-registration metadata rather than part of the preload identity; the browser's reuse key is determined by the URL, destination, mode, and credentials mode.

Preloads stay explicit. Raw manifest `assets` are not preloaded automatically and `dynamicImports` are not traversed, so the runtime never guesses a request destination or defeats code splitting. The integration that knows the asset type and preload policy selects the links.

The existing stylesheet/modulepreload path stays unchanged: it still uses `Set<string>`, and the typed-link array is allocated only when the first link is registered. Validation and identity dedupe happen before the document and frame output forms are built.

This also exports the six HTML preload destinations as `JSX.HTMLPreloadAs` and fetch priority as `JSX.HTMLFetchPriority` for reuse across the public types.

The second commit fixes late root assets in frames. Root asset chunks share one wire key, so each arrival previously replaced the retained record and a frame mounted later could see only the last one. The warm store now extends the retained record in place and consumes every arrival.

Responsive image preloads (`imagesrcset` / `imagesizes`, including the standard form without `href`) remain a separate follow-up.

## How did you test this change?

Added runtime and type coverage for:

- typed font, image, script, style, fetch, and track preloads
- MIME type, CORS mode, integrity, referrer policy, fetch priority, media, and nonce routing
- invalid or missing destinations and empty manifest URLs
- `_base` resolution through the static import graph while `assets` and `dynamicImports` remain untouched
- dedupe with `useHead` in both registration orders and conflicting first-registration metadata
- pre-shell, late streaming, embedded-head, custom-sink, and frame delivery
- repeated late root asset chunks in both cold and already-mounted frame stores
- forwarding through `lazy()` render, `lazy().preload()`, `moduleUrl`, `clientOnly()`, and `NoHydration`
- public server/server-mock type parity

Validation:

- `pnpm exec turbo run build test test-types typecheck --filter=solid-js --filter=@solidjs/web --filter=@solidjs/h --force` — 14/14 tasks passed, 0 cached
- `pnpm test` — 33/33 workspace tasks passed
- size limits passed; client scenarios are unchanged and the full frame consumer is 11.19 kB within its 11.22 kB limit
- Prettier and `git diff --check` passed

One generator note: `pnpm --filter @solidjs/web run jsx-sync` also removes a `$key` block that is present in `jsx.d.ts` but missing from `jsx-h.d.ts`. That drift predates this branch and is intentionally not included here.
