### PR TITLE
test(web): pin four unprotected server-function surfaces

### DIFF
--- a/packages/web/test/server/server-functions-body-formats.spec.tsx
+++ b/packages/web/test/server/server-functions-body-formats.spec.tsx
@@ -1,0 +1,236 @@
+/**
+ * Arguments that have a natural HTTP encoding — the upload path. A call
+ * whose only argument is a `File`, `Blob`, `FormData`, `URLSearchParams`,
+ * `Uint8Array` skips the codec entirely and rides the wire
+ * as that body, and the handler hands the function back the same kind of
+ * value. Nothing here is opt-in: this is what `upload(file)` does out of the
+ * box, without `enableRichArguments`.
+ *
+ * The bound shape rides along: `action.with(id)` posting a form sends the
+ * JSON-safe leading arguments in the url's `?args=` and the trailing value
+ * AS the body, and the handler reassembles the list in the order the
+ * function declared it — the same wire shape the no-JS form fallback
+ * produces, which is why a bound form action needs no codec.
+ *
+ * `enableRichArguments`, the opt-in codec for Dates and cycles, is a
+ * different surface and remains uncovered.
+ *
+ * Like the other server-function specs, these run against the built bundles
+ * (server-functions/dist/*, wired up in vite.config.server.mjs).
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  handleServerFunctionRequest,
+  registerServerFunction
+} from "@solidjs/web/server-functions/server";
+import { createServerReference } from "@solidjs/web/server-functions/client";
+
+const RequestContext = Symbol.for("solid.RequestContext");
+const BODY_FORMAT_HEADER = "X-Server-Function-Format";
+const FILE_FORMAT = "5";
+const BLOB_FORMAT = "4";
+const BYTES_FORMAT = "7";
+const FORM_DATA_FORMAT = "2";
+const URL_PARAMS_FORMAT = "3";
+
+beforeAll(() => {
+  (globalThis as any)[RequestContext] = new AsyncLocalStorage();
+});
+
+afterAll(() => {
+  delete (globalThis as any)[RequestContext];
+});
+
+// The client transport's fetch dispatches into the built server handler —
+// a full round trip through both published bundles — and every request is
+// captured so the tests can assert what the encoding actually put on the
+// wire, not only what came back.
+function connectTransport() {
+  const original = globalThis.fetch;
+  const requests: Request[] = [];
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const request =
+      input instanceof Request
+        ? input
+        : new Request(new URL(input.toString(), "https://app.example"), init);
+    request.headers.set("Sec-Fetch-Site", "same-origin");
+    requests.push(request.clone());
+    return handleServerFunctionRequest(request);
+  }) as typeof fetch;
+  return {
+    requests,
+    restore() {
+      globalThis.fetch = original;
+    }
+  };
+}
+
+describe("an argument with a natural HTTP encoding", () => {
+  it("carries a File whole: name, type and bytes, as a File", async () => {
+    let ran = 0;
+    registerServerFunction("rich-file", async (upload: File) => {
+      ran++;
+      return {
+        isFile: upload instanceof File,
+        name: upload.name,
+        type: upload.type,
+        text: await upload.text()
+      };
+    });
+    const transport = connectTransport();
+    try {
+      const call = createServerReference("rich-file");
+      const result = await call(new File(["hello bytes"], "note.txt", { type: "text/plain" }));
+      expect(ran).toBe(1);
+      expect(result).toEqual({
+        isFile: true,
+        name: "note.txt",
+        type: "text/plain",
+        text: "hello bytes"
+      });
+      // the file kept its own branch: without it a File matches `instanceof
+      // Blob` and ships as a bare Blob, losing its name
+      expect(transport.requests[0].headers.get(BODY_FORMAT_HEADER)).toBe(FILE_FORMAT);
+      expect(transport.requests[0].headers.get("content-type")).toMatch(/^multipart\/form-data/);
+    } finally {
+      transport.restore();
+    }
+  });
+
+  it("keeps a Blob's content type — the half a bare byte body would lose", async () => {
+    let ran = 0;
+    registerServerFunction("rich-blob", async (blob: Blob) => {
+      ran++;
+      return { isBlob: blob instanceof Blob, type: blob.type, text: await blob.text() };
+    });
+    const transport = connectTransport();
+    try {
+      const call = createServerReference("rich-blob");
+      expect(await call(new Blob(["blobby"], { type: "application/x-thing" }))).toEqual({
+        isBlob: true,
+        type: "application/x-thing",
+        text: "blobby"
+      });
+      expect(ran).toBe(1);
+      expect(transport.requests[0].headers.get(BODY_FORMAT_HEADER)).toBe(BLOB_FORMAT);
+    } finally {
+      transport.restore();
+    }
+  });
+
+  it("sends a typed array's own bytes, not the buffer behind it", async () => {
+    // A Uint8Array is a VIEW. `chunk.subarray(2, 5)` of an eight-byte
+    // buffer is three bytes; sending the backing buffer would ship all
+    // eight and silently shift every offset the function reads.
+    let ran = 0;
+    registerServerFunction("rich-bytes", async (bytes: Uint8Array) => {
+      ran++;
+      return { isBytes: bytes instanceof Uint8Array, bytes: Array.from(bytes) };
+    });
+    const transport = connectTransport();
+    try {
+      const call = createServerReference("rich-bytes");
+      const backing = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+      expect(await call(backing.subarray(2, 5))).toEqual({ isBytes: true, bytes: [3, 4, 5] });
+      expect(ran).toBe(1);
+      expect(transport.requests[0].headers.get(BODY_FORMAT_HEADER)).toBe(BYTES_FORMAT);
+    } finally {
+      transport.restore();
+    }
+  });
+
+  it("round-trips FormData and URLSearchParams as themselves", async () => {
+    let ran = 0;
+    registerServerFunction("rich-form", async (form: FormData) => {
+      ran++;
+      return { isForm: form instanceof FormData, title: form.get("title") };
+    });
+    registerServerFunction("rich-query", async (query: URLSearchParams) => {
+      ran++;
+      return { isQuery: query instanceof URLSearchParams, page: query.get("page") };
+    });
+    const transport = connectTransport();
+    try {
+      const form = new FormData();
+      form.append("title", "a post");
+      expect(await createServerReference("rich-form")(form)).toEqual({
+        isForm: true,
+        title: "a post"
+      });
+      const query = new URLSearchParams();
+      query.set("page", "3");
+      expect(await createServerReference("rich-query")(query)).toEqual({
+        isQuery: true,
+        page: "3"
+      });
+      expect(ran).toBe(2);
+      expect(transport.requests[0].headers.get(BODY_FORMAT_HEADER)).toBe(FORM_DATA_FORMAT);
+      expect(transport.requests[1].headers.get(BODY_FORMAT_HEADER)).toBe(URL_PARAMS_FORMAT);
+    } finally {
+      transport.restore();
+    }
+  });
+});
+
+describe("a bound call ending in a natural encoding", () => {
+  it("puts the leading arguments in the url and the body last, in declared order", async () => {
+    let ran = 0;
+    let seen: unknown[] = [];
+    registerServerFunction("rich-bound", async (...args: unknown[]) => {
+      ran++;
+      seen = args;
+      const form = args[args.length - 1] as FormData;
+      return { argc: args.length, album: args[0], caption: args[1], file: form.get("f") };
+    });
+    const transport = connectTransport();
+    try {
+      const call = createServerReference("rich-bound");
+      const form = new FormData();
+      form.append("f", "payload");
+      // the transport normalizes `undefined` to null before the leading list
+      // can ride the url — without it the list is not JSON-safe and the call
+      // falls off the bound path entirely
+      const result = await call("holiday", undefined, form);
+      expect(ran).toBe(1);
+      expect(result).toEqual({
+        argc: 3,
+        album: "holiday",
+        caption: null,
+        file: "payload"
+      });
+      // the trailing argument really is the body, and only the leading ones
+      // are in the query
+      expect(seen[2]).toBeInstanceOf(FormData);
+      expect(new URL(transport.requests[0].url).searchParams.get("args")).toBe('["holiday",null]');
+      expect(transport.requests[0].headers.get(BODY_FORMAT_HEADER)).toBe(FORM_DATA_FORMAT);
+    } finally {
+      transport.restore();
+    }
+  });
+
+  it("keeps a File last behind its leading arguments", async () => {
+    let ran = 0;
+    registerServerFunction("rich-bound-file", async (folder: string, upload: File) => {
+      ran++;
+      return {
+        folder,
+        isFile: upload instanceof File,
+        name: upload.name,
+        text: await upload.text()
+      };
+    });
+    const transport = connectTransport();
+    try {
+      const call = createServerReference("rich-bound-file");
+      expect(
+        await call("/inbox", new File(["scan"], "scan.pdf", { type: "application/pdf" }))
+      ).toEqual({ folder: "/inbox", isFile: true, name: "scan.pdf", text: "scan" });
+      expect(ran).toBe(1);
+      expect(new URL(transport.requests[0].url).searchParams.get("args")).toBe('["/inbox"]');
+      expect(transport.requests[0].headers.get(BODY_FORMAT_HEADER)).toBe(FILE_FORMAT);
+    } finally {
+      transport.restore();
+    }
+  });
+});

--- a/packages/web/test/server/server-functions-invocation-wrap.spec.tsx
+++ b/packages/web/test/server/server-functions-invocation-wrap.spec.tsx
@@ -1,0 +1,270 @@
+/**
+ * `wrapInvocation` — the per-invocation seam frameworks hang policy on
+ * (per-function middleware, auth, logging, error mapping). Two properties
+ * make it usable as a GATE rather than as a logger, and both are load-bearing:
+ *
+ *  - it wraps DIRECT SSR calls too, not only HTTP dispatch, so a policy
+ *    cannot be walked around by calling the function during a render; and
+ *  - a wrapper that declines never lets the function body run, and what it
+ *    threw does not reach the caller unless it chose an HTTP shape.
+ *
+ * The direct leg also has to stay transparent: a synchronous function called
+ * during a render must still return its value, not a promise, or wrapping
+ * the whole app in a policy would make every server call async.
+ *
+ * `wrapInvocation` had no coverage on either dispatch leg.
+ *
+ * Like the other server-function specs, these run against the built bundles
+ * (server-functions/dist/*, wired up in vite.config.server.mjs).
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createRequestEvent } from "@solidjs/web";
+import {
+  ERROR_HEADER,
+  GENERIC_SERVER_ERROR_MESSAGE,
+  configureServerFunctionsServer,
+  createServerReference as createServerSideReference,
+  decodeResponse,
+  getEventServerFunctionInvocation,
+  getServerFunctionInvocation,
+  handleServerFunctionRequest,
+  registerServerFunction,
+  registerServerReference
+} from "@solidjs/web/server-functions/server";
+
+const RequestContext = Symbol.for("solid.RequestContext");
+
+beforeAll(() => {
+  (globalThis as any)[RequestContext] = new AsyncLocalStorage();
+});
+
+afterEach(() => {
+  configureServerFunctionsServer({ wrapInvocation: undefined });
+});
+
+afterAll(() => {
+  delete (globalThis as any)[RequestContext];
+});
+
+/** A scripted POST call, the shape the client transport produces. */
+function post(id: string, args: unknown[]) {
+  return new Request(`https://app.example/_server/data/${id}`, {
+    method: "POST",
+    body: JSON.stringify(args),
+    headers: {
+      "Sec-Fetch-Site": "same-origin",
+      "content-type": "application/json",
+      "X-Server-Function-Format": "8",
+      "X-Server-Function-Instance": "server-function:test"
+    }
+  });
+}
+
+/** The per-call event an integration supplies; not a configure() key. */
+const createEvent = (request: Request) => createRequestEvent(request);
+
+/** Runs `fn` under an established request scope, as a render would. */
+function underRender<T>(fn: () => T): T {
+  const storage = (globalThis as any)[RequestContext] as AsyncLocalStorage<unknown>;
+  return storage.run({ request: new Request("https://app.example/page"), locals: {} }, fn);
+}
+
+describe("the wrap reaches both dispatch paths", () => {
+  it("wraps a direct SSR call — a render cannot walk around the policy", () => {
+    const seen: any[] = [];
+    configureServerFunctionsServer({
+      wrapInvocation: (run, context) => {
+        seen.push({
+          id: context.id,
+          args: context.args,
+          direct: context.direct,
+          hasRequest: context.request !== undefined,
+          serverOnly: context.event.serverOnly
+        });
+        return run();
+      }
+    });
+    const call = createServerSideReference(
+      registerServerReference("wrap-direct", (n: number) => n * 2)
+    );
+
+    const result = underRender(() => (call as any)(21));
+
+    // the policy ran, and it can tell an in-process call from a wire one
+    expect(seen).toStrictEqual([
+      { id: "wrap-direct", args: [21], direct: true, hasRequest: false, serverOnly: true }
+    ]);
+    // and the direct leg stayed synchronous: a sync function keeps its value
+    expect(result).toBe(42);
+  });
+
+  it("wraps HTTP dispatch, naming the request and the decoded arguments", async () => {
+    const seen: any[] = [];
+    registerServerFunction("wrap-http", async (a: number, b: number) => a + b);
+
+    const response = await handleServerFunctionRequest(post("wrap-http", [20, 22]), {
+      createEvent,
+      wrapInvocation: (run, context) => {
+        seen.push({
+          id: context.id,
+          args: context.args,
+          direct: context.direct,
+          hasRequest: context.request !== undefined,
+          serverOnly: context.event.serverOnly
+        });
+        return run();
+      }
+    });
+
+    expect(response.status).toBe(200);
+    expect(seen).toStrictEqual([
+      { id: "wrap-http", args: [20, 22], direct: false, hasRequest: true, serverOnly: undefined }
+    ]);
+  });
+
+  it("lets a per-handler wrap replace the configured one instead of stacking", async () => {
+    const configured: string[] = [];
+    const perHandler: string[] = [];
+    configureServerFunctionsServer({
+      wrapInvocation: (run, context) => {
+        configured.push(context.id);
+        return run();
+      }
+    });
+    registerServerFunction("wrap-override", async () => "ok");
+
+    // no per-handler option: the configured wrap owns the call
+    await handleServerFunctionRequest(post("wrap-override", []), { createEvent });
+    expect(configured).toStrictEqual(["wrap-override"]);
+
+    // with one: it replaces the configured wrap rather than running inside it
+    await handleServerFunctionRequest(post("wrap-override", []), {
+      createEvent,
+      wrapInvocation: (run, context) => {
+        perHandler.push(context.id);
+        return run();
+      }
+    });
+    expect(perHandler).toStrictEqual(["wrap-override"]);
+    expect(configured).toStrictEqual(["wrap-override"]);
+  });
+});
+
+describe("a wrap that answers instead of the function", () => {
+  it("never runs the function, and does not leak what it threw", async () => {
+    let ran = 0;
+    registerServerFunction("wrap-deny", async () => {
+      ran++;
+      return "the secret";
+    });
+
+    const response = await handleServerFunctionRequest(post("wrap-deny", []), {
+      createEvent,
+      wrapInvocation: () => {
+        throw new Error("policy denied for tenant acme-42");
+      }
+    });
+
+    expect(ran).toBe(0);
+    expect(response.status).toBe(500);
+    // the policy's own message is server-side detail, not the caller's
+    const body = await response.text();
+    expect(body).not.toContain("acme-42");
+    // paired with the positive: the negative alone passes on an empty or
+    // undecodable body, which is how a broken sanitizer goes green
+    expect(body).toContain(GENERIC_SERVER_ERROR_MESSAGE);
+    expect(response.headers.get(ERROR_HEADER)).toBe(GENERIC_SERVER_ERROR_MESSAGE);
+  });
+
+  it("stops a direct SSR call too — the walk-around the gate exists to close", () => {
+    let ran = 0;
+    configureServerFunctionsServer({
+      wrapInvocation: () => {
+        throw new Error("policy denied");
+      }
+    });
+    const call = createServerSideReference(
+      registerServerReference("wrap-direct-deny", () => {
+        ran++;
+        return "the secret";
+      })
+    );
+
+    // a render reaches the function in-process, so the gate has to hold on a
+    // leg that never touches the transport
+    expect(() => underRender(() => (call as any)())).toThrow("policy denied");
+    expect(ran).toBe(0);
+  });
+
+  it("keeps the HTTP shape when it declines with a Response", async () => {
+    let ran = 0;
+    registerServerFunction("wrap-gate", async () => {
+      ran++;
+      return "the secret";
+    });
+
+    const response = await handleServerFunctionRequest(post("wrap-gate", []), {
+      createEvent,
+      wrapInvocation: () => {
+        throw new Response(null, {
+          status: 401,
+          headers: { "WWW-Authenticate": 'Bearer realm="app"' }
+        });
+      }
+    });
+
+    expect(ran).toBe(0);
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toBe('Bearer realm="app"');
+  });
+
+  it("substitutes the result when it answers in the function's place", async () => {
+    let ran = 0;
+    registerServerFunction("wrap-substitute", async () => {
+      ran++;
+      return "from the function";
+    });
+
+    const response = await handleServerFunctionRequest(post("wrap-substitute", []), {
+      createEvent,
+      wrapInvocation: () => "from the policy"
+    });
+
+    expect(ran).toBe(0);
+    expect(response.status).toBe(200);
+    expect(await decodeResponse(response)).toBe("from the policy");
+  });
+});
+
+describe("the invocation identity a policy keys on", () => {
+  it("answers inside the wrap, before and after the function runs", async () => {
+    let insideWrap: unknown;
+    let insideFunction: unknown;
+    let afterRun: unknown;
+    let event!: ReturnType<typeof createEvent>;
+    registerServerFunction("wrap-identity", async () => {
+      insideFunction = getServerFunctionInvocation();
+      return "ok";
+    });
+
+    await handleServerFunctionRequest(post("wrap-identity", []), {
+      createEvent: request => (event = createEvent(request)),
+      wrapInvocation: run => {
+        insideWrap = getServerFunctionInvocation();
+        return Promise.resolve(run()).then(value => {
+          afterRun = getServerFunctionInvocation();
+          return value;
+        });
+      }
+    });
+
+    expect(insideWrap).toEqual({ id: "wrap-identity" });
+    expect(insideFunction).toEqual({ id: "wrap-identity" });
+    expect(afterRun).toEqual({ id: "wrap-identity" });
+    // and off the event, for a policy holding the event rather than the scope
+    expect(getEventServerFunctionInvocation(event)).toEqual({ id: "wrap-identity" });
+    // outside any call there is nothing to read
+    expect(getServerFunctionInvocation()).toBeUndefined();
+  });
+});

--- a/packages/web/test/server/server-functions-nojs-destination.spec.tsx
+++ b/packages/web/test/server/server-functions-nojs-destination.spec.tsx
@@ -1,0 +1,179 @@
+/**
+ * `createNoJSHandler` — where a form post lands when the client runtime
+ * never loaded. A browser submitting a `<form action={fn.url} method="post">`
+ * has no channel to receive a return value, so the convention answers a
+ * redirect and flashes the outcome into a one-shot cookie for the next
+ * render to read.
+ *
+ * The choice of destination is the whole contract, and every branch of it is
+ * a way to strand the user: a form post that answered 200 would leave the
+ * browser sitting on `/_server/data/<id>` looking at a serialized payload,
+ * so the handler redirects even when it has nothing good to redirect TO —
+ * an absent referer, an unparseable one, a result that is already a
+ * `Response`. `303 See Other` is what turns the POST back into a GET
+ * (RFC 9110 §15.4.4) unless the result named a redirect status itself.
+ *
+ * `handleServerFunctionRequest` applies this to browser form posts already;
+ * the constructor is public so an app can set a `base` or extend the
+ * convention to direct HTTP callers.
+ *
+ * `createNoJSHandler`'s destination choice had no coverage;
+ * `server-functions-redirect-status.spec.tsx` pins the same convention
+ * end-to-end through the handler (#3139).
+ *
+ * Like the other server-function specs, these run against the built bundles
+ * (server-functions/dist/*, wired up in vite.config.server.mjs).
+ */
+import { describe, expect, it } from "vitest";
+import { redirect } from "@solidjs/web";
+import {
+  FLASH_COOKIE,
+  createNoJSHandler,
+  decodeFlashCookie
+} from "@solidjs/web/server-functions/server";
+
+/** A browser form post to a server function, as the no-JS leg receives it. */
+function formPost(headers: Record<string, string> = {}) {
+  // fn.url is the BARE address; /data/ is the scripted transport's own (#3094)
+  return new Request("https://app.example/app/_server/save-profile", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded", ...headers },
+    body: "name=Ada"
+  });
+}
+
+/** The flash payload the next render would decode from the answer. */
+function flashed(response: Response) {
+  const cookie = response.headers
+    .getSetCookie()
+    .find(entry => entry.startsWith(`${FLASH_COOKIE}=`));
+  return cookie ? decodeFlashCookie(cookie.split(";")[0]) : undefined;
+}
+
+describe("the browser is never left on the endpoint", () => {
+  it("returns to the referring page, carrying the outcome in the flash cookie", () => {
+    const handler = createNoJSHandler({ base: "/app" });
+
+    const response = handler(
+      { saved: true },
+      formPost({ referer: "https://app.example/app/settings" }),
+      ["Ada"],
+      false
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("Location")).toBe("https://app.example/app/settings");
+    expect(flashed(response)).toEqual({
+      result: { saved: true },
+      input: ["Ada"],
+      url: "/app/_server/save-profile"
+    });
+  });
+
+  it("falls back to the app's mount when there is no referer to return to", () => {
+    const response = createNoJSHandler({ base: "/app" })({ saved: true }, formPost(), []);
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("Location")).toBe("https://app.example/app");
+  });
+
+  it("falls back rather than trusting a referer it cannot parse", () => {
+    const response = createNoJSHandler({ base: "/app" })(
+      { saved: true },
+      formPost({ referer: "://not a url" }),
+      []
+    );
+
+    expect(response.headers.get("Location")).toBe("https://app.example/app");
+  });
+
+  it("uses the origin root when the app has no mount path", () => {
+    const response = createNoJSHandler()({ saved: true }, formPost(), []);
+
+    expect(response.headers.get("Location")).toBe("https://app.example/");
+  });
+
+  it("carries a thrown outcome as an error, not as a result", () => {
+    const response = createNoJSHandler({ base: "/app" })(
+      new Error("the field is required"),
+      formPost({ referer: "https://app.example/app/settings" }),
+      ["Ada"],
+      true
+    );
+
+    expect(response.status).toBe(303);
+    const submission = flashed(response);
+    expect(submission?.error).toBeInstanceOf(Error);
+    expect((submission?.error as Error).message).toBe("the field is required");
+    expect(submission?.result).toBeUndefined();
+  });
+});
+
+describe("a result that is already a Response", () => {
+  it("navigates to its Location and keeps its redirect status", () => {
+    const response = createNoJSHandler()(
+      redirect("/orders/9", 307),
+      formPost({ referer: "https://app.example/app/cart" }),
+      []
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("Location")).toBe("https://app.example/orders/9");
+    // a Response carries its own meaning — nothing is flashed
+    expect(flashed(response)).toBeUndefined();
+  });
+
+  it("still turns the POST into a GET when the status is not a redirect", () => {
+    // a 201's Location is where the thing was CREATED, not a navigation the
+    // browser may repeat as a POST
+    const response = createNoJSHandler()(
+      new Response(null, { status: 201, headers: { Location: "/orders/9" } }),
+      formPost({ referer: "https://app.example/app/cart" }),
+      []
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("Location")).toBe("https://app.example/orders/9");
+  });
+
+  it("returns to the referring page when it names no Location at all", () => {
+    const response = createNoJSHandler()(
+      new Response(null, { status: 200 }),
+      formPost({ referer: "https://app.example/app/cart" }),
+      []
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("Location")).toBe("https://app.example/app/cart");
+  });
+
+  it("keeps its cookies and headers but never advertises a body it dropped", () => {
+    const result = new Response("<h1>saved</h1>", {
+      status: 200,
+      headers: {
+        "Content-Type": "text/html",
+        "Content-Length": "14",
+        "X-Trace": "abc123"
+      }
+    });
+    result.headers.append("Set-Cookie", "session=fresh; Path=/");
+    result.headers.append("Set-Cookie", "theme=dark; Path=/");
+
+    const response = createNoJSHandler()(
+      result,
+      formPost({ referer: "https://app.example/app/cart" }),
+      []
+    );
+
+    // the redirect it builds has no body, so these would be lies
+    expect(response.headers.get("Content-Type")).toBeNull();
+    expect(response.headers.get("Content-Length")).toBeNull();
+    // a login that answers a Response still gets its cookies to the browser,
+    // each as its own entry
+    expect(response.headers.getSetCookie()).toEqual([
+      "session=fresh; Path=/",
+      "theme=dark; Path=/"
+    ]);
+    expect(response.headers.get("X-Trace")).toBe("abc123");
+  });
+});

--- a/packages/web/test/server/server-functions-outcome-digest.spec.tsx
+++ b/packages/web/test/server/server-functions-outcome-digest.spec.tsx
@@ -1,0 +1,240 @@
+/**
+ * The outcome a single-flight hook is handed. `collectFlightData` re-runs
+ * reads on the server immediately after a mutation, so the generic halves
+ * of that job arrive pre-digested on the outcome and the hook supplies only
+ * the data strategy. Each of those three is a correctness hazard the hook
+ * cannot fix for itself:
+ *
+ *  - `foldedHeaders` — the re-read starts from the request that TRIGGERED
+ *    the mutation, whose cookies are pre-mutation by definition. Without the
+ *    fold, a read behind a session the mutation just established sees the
+ *    logged-out state and the page renders as if the login failed.
+ *  - `targetUrl` — the page the data is for: the redirect's destination
+ *    when there is one, the referring page otherwise, and nothing at all
+ *    when the redirect leaves the origin (there is no page of ours to
+ *    produce data for).
+ *  - `revalidateKeys` — the invalidation scope the mutation declared.
+ *
+ * `foldSetCookies` is the same fold as a public helper, for integrations
+ * that assemble the re-read themselves.
+ *
+ * `foldedHeaders`, `targetUrl` and `revalidateKeys` had zero references
+ * anywhere in the test tree.
+ *
+ * Like the other server-function specs, these run against the built bundles
+ * (server-functions/dist/*, wired up in vite.config.server.mjs).
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createRequestEvent, getRequestEvent, redirect } from "@solidjs/web";
+import {
+  SINGLE_FLIGHT_HEADER,
+  foldSetCookies,
+  handleServerFunctionRequest,
+  registerServerFunction
+} from "@solidjs/web/server-functions/server";
+import type { ServerFunctionOutcome } from "@solidjs/web/server-functions/server";
+
+const RequestContext = Symbol.for("solid.RequestContext");
+
+beforeAll(() => {
+  (globalThis as any)[RequestContext] = new AsyncLocalStorage();
+});
+
+afterAll(() => {
+  delete (globalThis as any)[RequestContext];
+});
+
+// the handler's default event carries no `response`; the cookie writes below
+// set headers on it, so the tests must supply a real one
+const createEvent = (request: Request) => createRequestEvent(request);
+
+/** A scripted POST that opted into the single-flight fold. */
+function post(id: string, headers: Record<string, string> = {}) {
+  return new Request(`https://app.example/_server/data/${id}`, {
+    method: "POST",
+    body: "[]",
+    headers: {
+      "Sec-Fetch-Site": "same-origin",
+      "content-type": "application/json",
+      "X-Server-Function-Format": "8",
+      "X-Server-Function-Instance": "server-function:test",
+      [SINGLE_FLIGHT_HEADER]: "true",
+      ...headers
+    }
+  });
+}
+
+/** Dispatches `id` and hands back the outcome the flight hook saw. */
+async function collect(request: Request) {
+  let outcome!: ServerFunctionOutcome;
+  await handleServerFunctionRequest(request, {
+    createEvent,
+    collectFlightData: (_event, received) => {
+      outcome = received;
+      return { collected: true };
+    }
+  });
+  return outcome;
+}
+
+describe("the headers a re-read starts from", () => {
+  it("carries the mutation's own cookie, overriding the request's stale one", async () => {
+    let ran = 0;
+    registerServerFunction("digest-login", async () => {
+      ran++;
+      const event = getRequestEvent()! as ReturnType<typeof createEvent>;
+      event.response.headers.append("Set-Cookie", "session=fresh; Path=/; HttpOnly");
+      return "ok";
+    });
+
+    const outcome = await collect(post("digest-login", { cookie: "session=stale; theme=dark" }));
+
+    expect(ran).toBe(1);
+    // the re-read sees the session the mutation just established, and the
+    // cookies it did not touch survive
+    expect(outcome.foldedHeaders.get("cookie")).toBe("session=fresh; theme=dark");
+    // the original request is untouched — the fold is a copy
+    expect(outcome.request.headers.get("cookie")).toBe("session=stale; theme=dark");
+  });
+
+  it("carries a cookie the outcome's own Response set, not only the event's", async () => {
+    let ran = 0;
+    registerServerFunction("digest-outcome-cookie", async () => {
+      ran++;
+      const event = getRequestEvent()! as ReturnType<typeof createEvent>;
+      event.response.headers.append("Set-Cookie", "theme=dark; Path=/");
+      // a thrown redirect carries headers of its own, and they never reach
+      // the event response — the fold has to read both sources
+      throw redirect("/dashboard", {
+        headers: { "Set-Cookie": "session=fresh; Path=/; HttpOnly" }
+      });
+    });
+
+    const outcome = await collect(
+      post("digest-outcome-cookie", {
+        cookie: "session=stale",
+        referer: "https://app.example/login"
+      })
+    );
+
+    expect(ran).toBe(1);
+    expect(outcome.foldedHeaders.get("cookie")).toBe("session=fresh; theme=dark");
+  });
+
+  it("honours a deletion the mutation made", async () => {
+    let ran = 0;
+    registerServerFunction("digest-logout", async () => {
+      ran++;
+      const event = getRequestEvent()! as ReturnType<typeof createEvent>;
+      event.response.headers.append("Set-Cookie", "session=; Max-Age=0; Path=/");
+      return "ok";
+    });
+
+    const outcome = await collect(post("digest-logout", { cookie: "session=live; cart=3" }));
+
+    expect(ran).toBe(1);
+    expect(outcome.foldedHeaders.get("cookie")).toBe("cart=3");
+  });
+});
+
+describe("the page the data is for", () => {
+  it("names the redirect's destination, resolved against the call", async () => {
+    registerServerFunction("digest-redirect", async () => {
+      throw redirect("/orders/9");
+    });
+
+    const outcome = await collect(post("digest-redirect", { referer: "https://app.example/cart" }));
+
+    expect(outcome.targetUrl).toBe("https://app.example/orders/9");
+    expect(outcome.thrown).toBe(true);
+  });
+
+  it("names the referring page when the mutation stays put", async () => {
+    registerServerFunction("digest-plain", async () => "saved");
+
+    const outcome = await collect(post("digest-plain", { referer: "https://app.example/cart" }));
+
+    expect(outcome.targetUrl).toBe("https://app.example/cart");
+    expect(outcome.thrown).toBe(false);
+    expect(outcome.value).toBe("saved");
+  });
+
+  it("names nothing when the redirect leaves the origin — there is no page of ours", async () => {
+    registerServerFunction("digest-offsite", async () => {
+      throw redirect("https://payments.example/checkout");
+    });
+
+    const outcome = await collect(post("digest-offsite", { referer: "https://app.example/cart" }));
+
+    expect(outcome.targetUrl).toBeUndefined();
+  });
+
+  it("names nothing without a referer — a non-browser caller has no page", async () => {
+    registerServerFunction("digest-bare", async () => "saved");
+
+    const outcome = await collect(post("digest-bare"));
+
+    expect(outcome.targetUrl).toBeUndefined();
+  });
+});
+
+describe("the invalidation scope", () => {
+  it("splits the declared revalidate keys, and is absent when none were declared", async () => {
+    registerServerFunction("digest-keys", async () => {
+      throw redirect("/orders", { revalidate: ["orders", "cart"] });
+    });
+    registerServerFunction("digest-nokeys", async () => "saved");
+
+    const keyed = await collect(post("digest-keys", { referer: "https://app.example/cart" }));
+    expect(keyed.revalidateKeys).toEqual(["orders", "cart"]);
+
+    const bare = await collect(post("digest-nokeys", { referer: "https://app.example/cart" }));
+    expect(bare.revalidateKeys).toBeUndefined();
+  });
+});
+
+describe("foldSetCookies, the same fold as a public helper", () => {
+  it("applies the set in order, later winning, and leaves the input alone", () => {
+    const request = new Headers({ cookie: "sid=old; theme=dark" });
+
+    const folded = foldSetCookies(request, [
+      "sid=first; Path=/",
+      "sid=second; Path=/; HttpOnly",
+      "added=yes; Path=/"
+    ]);
+
+    expect(folded.get("cookie")).toBe("sid=second; theme=dark; added=yes");
+    expect(request.get("cookie")).toBe("sid=old; theme=dark");
+  });
+
+  it("deletes on an expiry that has passed, and only on one that has", () => {
+    const folded = foldSetCookies(new Headers({ cookie: "a=1; b=2; c=3; d=4" }), [
+      "a=; Max-Age=0; Path=/",
+      "b=; Max-Age=-1; Path=/",
+      // the comma inside an Expires date must not read as a second cookie
+      "c=; Expires=Wed, 09 Jun 2021 10:18:14 GMT; Path=/",
+      // and a future Expires is an ordinary SET: deleting on the attribute's
+      // mere presence would drop every persistent cookie from the re-read
+      "e=5; Expires=Sat, 01 Jan 2050 00:00:00 GMT; Path=/"
+    ]);
+
+    expect(folded.get("cookie")).toBe("d=4; e=5");
+  });
+
+  it("keeps a value containing '=' whole — a JWT or base64 payload survives", () => {
+    const folded = foldSetCookies(new Headers(), ["token=aGVsbG8=; Path=/; HttpOnly"]);
+
+    expect(folded.get("cookie")).toBe("token=aGVsbG8=");
+  });
+
+  it("copies through untouched when nothing was set", () => {
+    const request = new Headers({ cookie: "a=1", "x-trace": "abc" });
+
+    const folded = foldSetCookies(request, []);
+
+    expect(folded.get("cookie")).toBe("a=1");
+    expect(folded.get("x-trace")).toBe("abc");
+    expect(folded).not.toBe(request);
+  });
+});


### PR DESCRIPTION
Four areas of the server-function surface had **no coverage** in the tree. This adds 35 tests across four files, in the existing idiom, touching no existing test and no runtime code.

## What is pinned, and why each earned a place

| File | Tests | Why it was needed |
|---|---|---|
| `server-functions-body-formats.spec.tsx` | 6 | File/Blob/typed-array/FormData/URLSearchParams round trip, plus the bound `?args=` + trailing-body ordering — which had no test at all. Named after `BodyFormat`; `enableRichArguments` is a different, still-uncovered API |
| `server-functions-invocation-wrap.spec.tsx` | 8 | `wrapInvocation` on both dispatch legs, the deny gate on each, sync transparency, invocation identity. The direct SSR leg could skip the configured policy with nothing noticing |
| `server-functions-outcome-digest.spec.tsx` | 12 | `foldedHeaders`, `targetUrl` and `revalidateKeys` had **zero references anywhere in the test tree**, plus `foldSetCookies` |
| `server-functions-nojs-destination.spec.tsx` | 9 | `createNoJSHandler` destination choice and flash behaviour |

## Two regressions that escaped the whole suite

Both are inside `outcome-digest`'s own stated scope, and both were confirmed by mutating the runtime and watching all 557 existing tests stay green:

- **`foldSetCookies` deleting on a *future* `Expires`.** `parsed.expires != null && …getTime() <= Date.now()` → `parsed.expires != null` passed everything. A persistent session cookie — `Expires` a year out, the normal spelling — would have been silently dropped from every single-flight re-read.
- **`foldedHeaders` losing its second cookie source.** Dropping `...(response?.headers?.getSetCookie() ?? [])` passed everything. That is the leg a thrown `redirect(to, { headers })` writes, and it never reaches the event response.

Both now have a case, and each was re-checked by re-applying the mutation and confirming the new test is the one that goes red.

## Every test is mutation-proven

A test that passes both before and after a regression is worthless, so each one was checked by mutating the **built** runtime and confirming it goes red, then reverting. Representative:

- `formData.append(FILE_FORM_KEY, body, body.name)` → a fixed name — File identity test red
- `new Uint8Array(body)` → `body.buffer` — typed-array view test red (ships 8 bytes instead of 3)
- `parsed.push(decoded)` → `unshift` — both `?args=` ordering tests red
- `config.wrapInvocation ? … : run()` → `run()` — both direct-leg tests red
- `sanitizeServerError` → passthrough — the policy's own message reaches the body, red
- cross-origin `targetUrl` guard removed — off-site redirect test red
- `new Headers(headers)` → `headers` — three tests red (the fold mutating its input)
- `validRedirectStatuses.has(...)` guard removed — a 201 becomes a 303, red

**Four candidate assertions were dropped** for failing that bar: a `Headers`-constructor Set-Cookie folding claim (modern undici does not fold, so nothing could regress), an `expect(response.body).toBeNull()` (guaranteed by the 303 status rather than by anything here), a `URLSearchParams` decode assertion whose "proof" turned out to be a no-op edit, and an `expect(result).not.toBeInstanceOf(Promise)` sitting beside `expect(result).toBe(42)` — no value satisfies both, so no mutation could ever redden it alone.

## Suite

```
before   Test Files 48 passed (48)    Tests 524 passed | 2 skipped (526)
after    Test Files 52 passed (52)    Tests 559 passed | 2 skipped (561)
```

`prettier --check` clean on the four files; `tsc --project packages/web/tsconfig.test.json` reports nothing attributable to them.

## Notes

These came out of a coverage comparison against another framework's server-function suite. Solid is ahead almost everywhere — method handling, response shapes, redirects, error sanitization, caching semantics and the CSRF gate are all substantially better covered here — so this PR is only the short list of places where the tree genuinely had nothing.

Two gaps found in that comparison are **not** addressed here because they are feature questions rather than test gaps: there is no argument-validation API, and `wrapInvocation` is a single slot rather than a composable chain. Happy to open issues for either if useful.
