### PR TITLE
fix: add selectedcontent to JSX types

### DIFF
--- a/.changeset/add-selectedcontent-jsx-type.md
+++ b/.changeset/add-selectedcontent-jsx-type.md
@@ -1,0 +1,6 @@
+---
+"@solidjs/web": patch
+"@solidjs/h": patch
+---
+
+Add the `selectedcontent` HTML element to the JSX intrinsic element types.

--- a/packages/h/jsx-runtime/src/jsx.d.ts
+++ b/packages/h/jsx-runtime/src/jsx.d.ts
@@ -3502,6 +3502,11 @@ export namespace JSX {
      */
     select: SelectHTMLAttributes<HTMLSelectElement> & Properties<HTMLSelectElement>;
     /**
+     * @url https://developer.mozilla.org/en-US/docs/Web/HTML/Element/selectedcontent
+     * @url https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectedContentElement
+     */
+    selectedcontent: HTMLAttributes<HTMLElement> & Properties<HTMLElement>;
+    /**
      * @url https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot
      * @url https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement
      */

--- a/packages/web/jsx/jsx-h.d.ts
+++ b/packages/web/jsx/jsx-h.d.ts
@@ -3503,6 +3503,11 @@ export namespace JSX {
      */
     select: SelectHTMLAttributes<HTMLSelectElement> & Properties<HTMLSelectElement>;
     /**
+     * @url https://developer.mozilla.org/en-US/docs/Web/HTML/Element/selectedcontent
+     * @url https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectedContentElement
+     */
+    selectedcontent: HTMLAttributes<HTMLElement> & Properties<HTMLElement>;
+    /**
      * @url https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot
      * @url https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement
      */

--- a/packages/web/jsx/jsx.d.ts
+++ b/packages/web/jsx/jsx.d.ts
@@ -3491,6 +3491,11 @@ export namespace JSX {
      */
     select: SelectHTMLAttributes<HTMLSelectElement> & Properties<HTMLSelectElement>;
     /**
+     * @url https://developer.mozilla.org/en-US/docs/Web/HTML/Element/selectedcontent
+     * @url https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectedContentElement
+     */
+    selectedcontent: HTMLAttributes<HTMLElement> & Properties<HTMLElement>;
+    /**
      * @url https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot
      * @url https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement
      */

--- a/packages/web/test/web-jsx.type-tests.tsx
+++ b/packages/web/test/web-jsx.type-tests.tsx
@@ -14,3 +14,5 @@ function Parent(props: ParentProps) {
 
 <Parent>{text}</Parent>;
 <Parent>{[text, span]}</Parent>;
+
+<selectedcontent />;


### PR DESCRIPTION
## Summary

- add the standard `selectedcontent` HTML element to Solid's JSX intrinsic element types
- regenerate the `@solidjs/web` and `@solidjs/h` JSX declarations
- add a type test covering `<selectedcontent />`

The element is typed as `HTMLElement` because the TypeScript DOM library currently used by the repository does not yet expose `HTMLSelectedContentElement`.

Closes #3184

## How did you test this change?

```sh
pnpm build
pnpm --filter @solidjs/web test-types
pnpm --filter @solidjs/web test
pnpm --filter @solidjs/h types
pnpm --filter @solidjs/h test
./node_modules/.bin/prettier --check \
  packages/web/jsx/jsx-h.d.ts \
  packages/web/jsx/jsx.d.ts \
  packages/h/jsx-runtime/src/jsx.d.ts \
  packages/web/test/web-jsx.type-tests.tsx \
  .changeset/add-selectedcontent-jsx-type.md
```

Results:

- `@solidjs/web`: 63 client files / 699 tests passed; 48 server files / 524 tests passed with 2 skipped; 24 hydration files / 151 tests passed
- `@solidjs/h`: 4 files / 61 tests passed
- type checks, full build, and Prettier check passed
