### PR TITLE
fix(web): preserve reusable bound event tuples

### DIFF
--- a/.changeset/preserve-bound-event-tuples.md
+++ b/.changeset/preserve-bound-event-tuples.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/web": patch
+---
+
+Keep bound handler tuples reusable across non-delegated events by leaving the user-provided tuple unchanged when installing a listener.

--- a/packages/web/src/client.ts
+++ b/packages/web/src/client.ts
@@ -614,7 +614,7 @@ export function addEvent(
   name: string,
   handler: EventListener | EventListenerObject | (EventListenerObject & AddEventListenerOptions),
   delegate: boolean
-): void;
+): EventListener | EventListenerObject | void;
 
 export function addEvent(node, name, handler, delegate) {
   if (delegate) {
@@ -624,8 +624,11 @@ export function addEvent(node, name, handler, delegate) {
     } else node[`$$${name}`] = handler;
   } else if (Array.isArray(handler)) {
     const handlerFn = handler[0];
-    node.addEventListener(name, (handler[0] = e => handlerFn.call(node, handler[1], e)));
+    const listener = e => handlerFn.call(node, handler[1], e);
+    node.addEventListener(name, listener);
+    return listener;
   } else node.addEventListener(name, handler, typeof handler !== "function" && handler);
+  return delegate ? undefined : handler;
 } /** Compiler-emitted primitive; not for hand-written code. @internal */
 export function style(
   node: Element,
@@ -2042,8 +2045,9 @@ function assignProp(node, prop, value, prev, skipRef, nodeName) {
       node.removeEventListener(name, h);
     }
     if (delegate || value) {
-      addEvent(node, name, value, delegate);
+      const attached = addEvent(node, name, value, delegate);
       delegate && delegateEvents([name]);
+      if (!delegate) return attached;
     }
   } else if (
     (hasNamespace && prop.slice(0, 5) === "prop:") ||

--- a/packages/web/src/client.ts
+++ b/packages/web/src/client.ts
@@ -2041,13 +2041,16 @@ function assignProp(node, prop, value, prev, skipRef, nodeName) {
     const name = prop.slice(2).toLowerCase();
     const delegate = DelegatedEvents.has(name);
     if (!delegate && prev) {
+      // Bound tuples keep an internal [attached listener, authored tuple]
+      // record so an unrelated spread rerun can preserve listener identity.
+      if (Array.isArray(prev) && prev[1] === value) return prev;
       const h = Array.isArray(prev) ? prev[0] : prev;
       node.removeEventListener(name, h);
     }
     if (delegate || value) {
       const attached = addEvent(node, name, value, delegate);
       delegate && delegateEvents([name]);
-      if (!delegate) return attached;
+      if (!delegate) return Array.isArray(value) ? [attached, value] : attached;
     }
   } else if (
     (hasNamespace && prop.slice(0, 5) === "prop:") ||

--- a/packages/web/test/event-handler.spec.tsx
+++ b/packages/web/test/event-handler.spec.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jsxImportSource @solidjs/web
+ * @vitest-environment jsdom
+ */
+import { describe, expect, test } from "vitest";
+import { render } from "@solidjs/web";
+import { createSignal, flush } from "solid-js";
+import type { JSX } from "../src/index.js";
+
+describe("Event handlers", () => {
+  test("reuses a bound handler tuple across non-delegated events", () => {
+    const calls: Array<[string, HTMLDivElement, Event]> = [];
+    const originalHandler = (data: string, event: Event) => {
+      calls.push([data, event.currentTarget as HTMLDivElement, event]);
+    };
+    const handler: JSX.BoundEventHandler<HTMLDivElement, Event> = [originalHandler, "shared"];
+    const container = document.createElement("div");
+    const dispose = render(
+      () => (
+        <>
+          <div onScroll={handler} />
+          <div onScroll={handler} />
+        </>
+      ),
+      container
+    );
+    const [first, second] = Array.from(container.children) as HTMLDivElement[];
+    const firstEvent = new Event("scroll");
+    const secondEvent = new Event("scroll");
+
+    first.dispatchEvent(firstEvent);
+    second.dispatchEvent(secondEvent);
+
+    expect(calls).toEqual([
+      ["shared", first, firstEvent],
+      ["shared", second, secondEvent]
+    ]);
+    expect(handler).toEqual([originalHandler, "shared"]);
+    dispose();
+  });
+
+  test("removes the previous non-delegated bound handler when a spread rebinds", () => {
+    type Handler = JSX.BoundEventHandler<HTMLDivElement, Event>;
+    const calls: string[] = [];
+    const handlers: Handler[] = ["first", "second", "third"].map(data => [
+      value => calls.push(value),
+      data
+    ]);
+    const [props, setProps] = createSignal<{ onScroll?: Handler }>({
+      onScroll: handlers[0]
+    });
+    const container = document.createElement("div");
+    const dispose = render(() => <div {...props()} />, container);
+    const element = container.firstElementChild as HTMLDivElement;
+
+    element.dispatchEvent(new Event("scroll"));
+
+    setProps({ onScroll: handlers[1] });
+    flush();
+    element.dispatchEvent(new Event("scroll"));
+
+    setProps({ onScroll: handlers[2] });
+    flush();
+    element.dispatchEvent(new Event("scroll"));
+
+    setProps({});
+    flush();
+    element.dispatchEvent(new Event("scroll"));
+
+    expect(calls).toEqual(["first", "second", "third"]);
+    expect(handlers.map(handler => handler[1])).toEqual(["first", "second", "third"]);
+    dispose();
+  });
+});

--- a/packages/web/test/event-handler.spec.tsx
+++ b/packages/web/test/event-handler.spec.tsx
@@ -2,9 +2,9 @@
  * @jsxImportSource @solidjs/web
  * @vitest-environment jsdom
  */
-import { describe, expect, test } from "vitest";
-import { render } from "@solidjs/web";
-import { createSignal, flush } from "solid-js";
+import { describe, expect, test, vi } from "vitest";
+import { render, spread } from "@solidjs/web";
+import { createRoot, createSignal, flush } from "solid-js";
 import type { JSX } from "../src/index.js";
 
 describe("Event handlers", () => {
@@ -69,6 +69,28 @@ describe("Event handlers", () => {
 
     expect(calls).toEqual(["first", "second", "third"]);
     expect(handlers.map(handler => handler[1])).toEqual(["first", "second", "third"]);
+    dispose();
+  });
+
+  test("does not rebind an unchanged tuple when another spread property updates", () => {
+    const handler: JSX.BoundEventHandler<HTMLDivElement, Event> = [() => {}, "shared"];
+    const [props, setProps] = createSignal({ onScroll: handler, title: "first" });
+    const element = document.createElement("div");
+    const add = vi.spyOn(element, "addEventListener");
+    const remove = vi.spyOn(element, "removeEventListener");
+    const dispose = createRoot(dispose => {
+      spread(element, props, true);
+      return dispose;
+    });
+
+    flush();
+    expect(add).toHaveBeenCalledTimes(1);
+
+    setProps({ onScroll: handler, title: "second" });
+    flush();
+
+    expect(add).toHaveBeenCalledTimes(1);
+    expect(remove).not.toHaveBeenCalled();
     dispose();
   });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

fix #3186

Avoid mutating user-provided bound event handler tuples when installing non-delegated event listeners.

Previously, the direct-listener path replaced `handler[0]` with an element-specific wrapper. Reusing the same tuple on another element therefore wrapped the already wrapped function and caused the bound data to be passed in place of the `Event`.

The listener wrapper is now kept local to each element, leaving the original tuple unchanged and reusable.

Regression test and patch changeset are included.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

 Built the web package:

  ```sh
  pnpm --filter @solidjs/web build
  cd packages/web
  ../../node_modules/.bin/vitest run test/event-handler.spec.tsx
  JSX_COMPILER=babel ../../node_modules/.bin/vitest run test/event-handler.spec.tsx
```

  Checked test types and formatting:

```sh
  ../../node_modules/.bin/tsc --project tsconfig.test.json
  ../../node_modules/.bin/prettier --check \
    src/client.ts \
    test/event-handler.spec.tsx \
    ../../.changeset/preserve-bound-event-tuples.md
```

  Ran the complete @solidjs/web test suites:

```sh
  ../../node_modules/.bin/vitest run
  ../../node_modules/.bin/vitest run --config vite.config.server.mjs
  ../../node_modules/.bin/vitest run --config vite.config.hydrate.mjs
```

  Results:

  - Client: 700 tests passed
  - Server: 536 passed, 2 skipped
  - Hydration: 151 tests passed
