### PR TITLE
fix(web): track in-place class mutations

### DIFF
--- a/.changeset/track-applied-classes.md
+++ b/.changeset/track-applied-classes.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/web": patch
+---
+
+Update object-valued class bindings after in-place mutations by tracking a separate snapshot of the classes applied to each element.

--- a/packages/web/src/client.ts
+++ b/packages/web/src/client.ts
@@ -562,27 +562,39 @@ export function setAttributeNS(node, namespace, name, value) {
 export function className(node: Element, value: JSX.ClassValue, prev?: JSX.ClassValue): void;
 
 export function className(node, value, prev) {
-  if (isHydrating(node)) return;
   // Numbers stringify like the compiler's static output (`class={1}`
   // inlines as `class="1"` in the template) so static and dynamic forms of
   // the same ClassValue behave identically (#3189).
   if (typeof value === "number") value = "" + value;
   if (typeof prev === "number") prev = "" + prev;
+  if (isHydrating(node)) {
+    // Seed applied state without touching the claimed DOM so later in-place
+    // mutations can still be diffed after hydration completes.
+    node._$classes = value && typeof value === "object" ? classListToObject(value) : undefined;
+    return;
+  }
   if (value == null || value === false) {
-    prev && node.removeAttribute("class");
+    if (prev || node._$classes) {
+      node.removeAttribute("class");
+      node._$classes = undefined;
+    }
     return;
   }
   if (typeof value === "string") {
+    node._$classes = undefined;
     value !== prev && node.setAttribute("class", value);
     return;
   }
+  // Track classes applied by className() itself. value/prev are user-owned
+  // and may be the same object on shared-effect reruns.
+  let applied;
   if (typeof prev === "string") {
-    prev = {};
+    applied = {};
     node.removeAttribute("class");
-  } else prev = classListToObject(prev || {});
+  } else applied = node._$classes || classListToObject(prev || {});
   value = classListToObject(value);
   const classKeys = Object.keys(value || {});
-  const prevKeys = Object.keys(prev);
+  const prevKeys = Object.keys(applied);
   let i, len;
   for (i = 0, len = prevKeys.length; i < len; i++) {
     const key = prevKeys[i];
@@ -592,9 +604,10 @@ export function className(node, value, prev) {
   for (i = 0, len = classKeys.length; i < len; i++) {
     const key = classKeys[i],
       classValue = !!value[key];
-    if (!key || key === "undefined" || prev[key] === classValue || !classValue) continue;
+    if (!key || key === "undefined" || applied[key] === classValue || !classValue) continue;
     node.classList.add(key);
   }
+  node._$classes = value;
 } /** Compiler-emitted primitive; not for hand-written code. @internal */
 export function addEvent(
   node: Element,

--- a/packages/web/test/class.spec.tsx
+++ b/packages/web/test/class.spec.tsx
@@ -1,0 +1,50 @@
+/**
+ * @jsxImportSource @solidjs/web
+ * @vitest-environment jsdom
+ */
+import { describe, expect, test } from "vitest";
+import { render } from "@solidjs/web";
+import { createSignal, flush } from "solid-js";
+
+describe("class", () => {
+  test("updates an object value after an in-place mutation", () => {
+    const classes = { before: true, after: false };
+    const [value, setValue] = createSignal(classes, { equals: false });
+    const container = document.createElement("div");
+    const dispose = render(() => <div class={value()} />, container);
+    const element = container.firstElementChild as HTMLDivElement;
+
+    expect(element.className).toBe("before");
+    element.classList.add("external");
+
+    classes.before = false;
+    classes.after = true;
+    setValue(classes);
+    flush();
+
+    expect(element.className).toBe("external after");
+    dispose();
+  });
+
+  test("resets the applied snapshot when switching value forms", () => {
+    const [value, setValue] = createSignal<string | Record<string, boolean> | null>({
+      first: true
+    });
+    const container = document.createElement("div");
+    const dispose = render(() => <div class={value()} />, container);
+    const element = container.firstElementChild as HTMLDivElement;
+
+    setValue("second");
+    flush();
+    expect(element.className).toBe("second");
+
+    setValue({ third: true });
+    flush();
+    expect(element.className).toBe("third");
+
+    setValue(null);
+    flush();
+    expect(element.hasAttribute("class")).toBe(false);
+    dispose();
+  });
+});

--- a/packages/web/test/hydration/class.spec.tsx
+++ b/packages/web/test/hydration/class.spec.tsx
@@ -1,0 +1,41 @@
+/**
+ * @jsxImportSource @solidjs/web
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { hydrate } from "@solidjs/web";
+import { createSignal, flush } from "solid-js";
+
+describe("class hydration", () => {
+  const container = document.createElement("div");
+  let dispose: (() => void) | undefined;
+
+  beforeEach(() => {
+    (globalThis as any)._$HY = { events: [], completed: new WeakSet(), r: {}, fe() {} };
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    dispose?.();
+    dispose = undefined;
+    container.remove();
+    container.innerHTML = "";
+  });
+
+  test("updates an object value after an in-place mutation", () => {
+    const classes = { before: true, after: false };
+    const [value, setValue] = createSignal(classes, { equals: false });
+    container.innerHTML = '<div class="before" _hk="0"></div>';
+
+    dispose = hydrate(() => <div class={value()} />, container);
+    const element = container.firstElementChild as HTMLDivElement;
+    element.classList.add("external");
+
+    classes.before = false;
+    classes.after = true;
+    setValue(classes);
+    flush();
+
+    expect(element.className).toBe("external after");
+  });
+});

--- a/scripts/size/.size-limit.js
+++ b/scripts/size/.size-limit.js
@@ -283,8 +283,13 @@ module.exports = [
     //
     // Fold relocation pass (2026-09-01): 10.73 -> 10.72 KB, measured at
     // 10.71 — the core-floor relocation (see that note).
+    //
+    // In-place class mutation fix (#3188): 10.80 -> 10.84 KB, measured at
+    // 10.834. className() retains the last applied object/array snapshot so
+    // shared-reference reruns can diff mutations without deleting external
+    // classes.
     path: "minimal-app.js",
-    limit: "10.80 KB",
+    limit: "10.84 KB",
     modifyEsbuildConfig
   },
   {
@@ -334,7 +339,11 @@ module.exports = [
     // Fold relocation pass (2026-09-01): 17.6 -> 17.56 KB, measured at
     // 17.54 — this bundle's import graph retained the scheduler-resident
     // ledger; the relocation lets it shake.
-    limit: "17.67 KB",
+    //
+    // In-place class mutation fix (#3188): 17.67 -> 17.68 KB, measured at
+    // 17.673. Hydration seeds the applied-class snapshot without mutating
+    // the claimed DOM so the first live in-place change still diffs.
+    limit: "17.68 KB",
     modifyEsbuildConfig
   },
   {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

fix #3188

Object-valued `class` bindings did not update correctly when the same object was mutated in place and passed through a signal using `{ equals: false }`.

The previous value retained the same object reference, so the class diff compared the mutated object against itself and could no longer determine which classes had previously been applied.

This change stores an independent snapshot of the classes applied by `className()`. It allows in-place mutations to be diffed correctly while preserving classes added by external code.

The snapshot is also initialized during hydration so subsequent in-place updates behave consistently on claimed DOM nodes.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

Added regression tests covering:

  - In-place mutation of an object-valued `class` binding
  - Preservation of classes added by external code
  - Transitions between object, string, and null class values
  - In-place mutation after hydration

  Ran:

  ```sh
  pnpm --filter @solidjs/web build
  pnpm --filter @solidjs/web types
  cd packages/web
  ../../node_modules/.bin/vitest run
  ../../node_modules/.bin/vitest run --config vite.config.server.mjs
  ../../node_modules/.bin/vitest run --config vite.config.hydrate.mjs
  ../../node_modules/.bin/tsc --project tsconfig.test.json
  ../../node_modules/.bin/prettier --check \
    src/client.ts \
    test/class.spec.tsx \
    test/hydration/class.spec.tsx \
    ../../.changeset/track-applied-classes.md
```

  Results:
  - Client: 701 tests passed
  - Server: 536 tests passed, 2 skipped
  - Hydration: 152 tests passed
  - TypeScript and Prettier checks passed
