### PR TITLE
fix: assign static select values through DOM property

### DIFF
--- a/.changeset/fix-static-select-value.md
+++ b/.changeset/fix-static-select-value.md
@@ -1,0 +1,6 @@
+---
+"@solidjs/babel-plugin": patch
+"@solidjs/compiler": patch
+---
+
+Assign static `<select value>` values through the live DOM property so the matching option is selected consistently with reactive values.

--- a/packages/babel-plugin/src/dom/element.ts
+++ b/packages/babel-plugin/src/dom/element.ts
@@ -1217,7 +1217,10 @@ function transformAttributes(
         }
 
         // properties
-        if (staticValue && ChildProperties.has(key)) {
+        if (
+          staticValue &&
+          (ChildProperties.has(key) || (tagName === "select" && key === "value"))
+        ) {
           results.exprs.push(
             t.expressionStatement(
               setAttr(attribute, elem, key, staticValue as babelTypes.Expression, { tagName })

--- a/packages/babel-plugin/test/staticSelectValue.spec.js
+++ b/packages/babel-plugin/test/staticSelectValue.spec.js
@@ -1,0 +1,28 @@
+const babel = require("@babel/core");
+const plugin = require("../index");
+
+function compile(code) {
+  return babel.transformSync(code, {
+    babelrc: false,
+    configFile: false,
+    filename: "input.jsx",
+    plugins: [[plugin, { moduleName: "r-dom", generate: "dom" }]]
+  }).code;
+}
+
+test("assigns static select values through the DOM property", () => {
+  const code = compile(`
+    const stringAttribute = <select value="2"><option value="2">Two</option></select>;
+    const stringExpression = <select value={"2"}><option value="2">Two</option></select>;
+    const numberExpression = <select value={2}><option value="2">Two</option></select>;
+    const multipleString = <select multiple value="2"><option value="2">Two</option></select>;
+    const multipleArray = <select multiple value={["1", "2"]}><option value="2">Two</option></select>;
+    const dynamicChildren = <select value="2">{options()}</select>;
+  `);
+
+  expect(code).not.toMatch(/_\$template\(`<select value=/);
+  expect(code.match(/queueMicrotask/g)).toHaveLength(6);
+  expect(code.match(/\.value = (?:"2"|2)/g)).toHaveLength(10);
+  expect(code.match(/\.value = \["1", "2"\]/g)).toHaveLength(2);
+  expect(code.indexOf("queueMicrotask")).toBeLessThan(code.indexOf("_$insert("));
+});

--- a/packages/compiler/__tests__/transform.test.js
+++ b/packages/compiler/__tests__/transform.test.js
@@ -182,6 +182,29 @@ describe("@solidjs/compiler transform", () => {
     expect(result.code).not.toContain("</input>");
   });
 
+  it("assigns static select values through the DOM property", () => {
+    const result = transform(
+      `
+        const stringAttribute = <select value="2"><option value="2">Two</option></select>;
+        const stringExpression = <select value={"2"}><option value="2">Two</option></select>;
+        const numberExpression = <select value={2}><option value="2">Two</option></select>;
+        const multipleString = <select multiple value="2"><option value="2">Two</option></select>;
+        const multipleArray = <select multiple value={["1", "2"]}><option value="2">Two</option></select>;
+        const dynamicChildren = <select value="2">{options()}</select>;
+      `,
+      {
+        filename: "static-select-value.jsx",
+        moduleName: "r-dom"
+      }
+    );
+
+    expect(result.code).not.toMatch(/_\$template\(`<select value=/);
+    expect(result.code.match(/queueMicrotask/g)).toHaveLength(6);
+    expect(result.code.match(/\.value = (?:"2"|2)/g)).toHaveLength(10);
+    expect(result.code.match(/\.value = \["1", "2"\]/g)).toHaveLength(2);
+    expect(result.code.indexOf("queueMicrotask")).toBeLessThan(result.code.indexOf("_$insert("));
+  });
+
   it("compiles the supported simpleElements fixture subset from Babel sources", () => {
     const source = readFixture("simpleElements");
     const subset = source.slice(

--- a/packages/compiler/src/dom/attrs.rs
+++ b/packages/compiler/src/dom/attrs.rs
@@ -165,7 +165,7 @@ impl<'a> AstDomTransform<'a, '_> {
             if has_children && plan.key == "textContent" {
                 continue;
             }
-            match self.classify_plan(&plan) {
+            match self.classify_plan(&plan, tag_name) {
                 PlanDisposition::Skip => {}
                 PlanDisposition::Inline(value) => match value {
                     None => append_bare_attribute(template, &plan.key, self.omit_attribute_spacing),
@@ -200,7 +200,7 @@ impl<'a> AstDomTransform<'a, '_> {
 
     /// Pure classification of one planned attribute, mirroring Babel's
     /// static-vs-expression branch in the attribute loop.
-    fn classify_plan(&self, plan: &AttrPlan<'a>) -> PlanDisposition {
+    fn classify_plan(&self, plan: &AttrPlan<'a>, tag_name: &str) -> PlanDisposition {
         if self.hydratable && plan.key == "$ServerOnly" {
             return PlanDisposition::Skip;
         }
@@ -211,6 +211,7 @@ impl<'a> AstDomTransform<'a, '_> {
             return PlanDisposition::Skip;
         }
         let reserved = plan.style_property || plan.class_property || plan.key.starts_with("prop:");
+        let select_value = tag_name == "select" && plan.key == "value";
         match &plan.value {
             PlanValue::None => {
                 if reserved {
@@ -222,7 +223,7 @@ impl<'a> AstDomTransform<'a, '_> {
                 }
             }
             PlanValue::Literal(value) => {
-                if reserved || child_properties(&plan.key) {
+                if reserved || child_properties(&plan.key) || select_value {
                     PlanDisposition::Runtime
                 } else {
                     PlanDisposition::Inline(Some(value.clone()))
@@ -243,14 +244,14 @@ impl<'a> AstDomTransform<'a, '_> {
                         }
                     }
                     Expression::StringLiteral(literal) => {
-                        if child_properties(&plan.key) {
+                        if child_properties(&plan.key) || select_value {
                             PlanDisposition::Runtime
                         } else {
                             PlanDisposition::Inline(Some(literal.value.to_string()))
                         }
                     }
                     Expression::NumericLiteral(literal) => {
-                        if child_properties(&plan.key) {
+                        if child_properties(&plan.key) || select_value {
                             PlanDisposition::Runtime
                         } else {
                             PlanDisposition::Inline(Some(format_number(literal.value)))
@@ -586,7 +587,7 @@ impl<'a> AstDomTransform<'a, '_> {
         } = self.plan_attributes(attributes, tag_name)?;
         let mut pending: std::vec::Vec<(String, Option<String>)> = std::vec::Vec::new();
         for plan in &plans {
-            match self.classify_plan(plan) {
+            match self.classify_plan(plan, tag_name) {
                 PlanDisposition::Skip => {}
                 PlanDisposition::Inline(value) => pending.push((plan.key.clone(), value)),
                 PlanDisposition::Runtime => return Ok(None),

--- a/packages/web/test/element.spec.tsx
+++ b/packages/web/test/element.spec.tsx
@@ -37,6 +37,41 @@ describe("Basic element attributes", () => {
     expect(d.innerHTML).toBe("<p>Hi</p>");
   });
 
+  test("static select value selects the matching option (#3167)", () => {
+    const select = (
+      <select value="2">
+        <option value="">None</option>
+        <option value="1">One</option>
+        <option value="2">Two</option>
+      </select>
+    ) as unknown as HTMLSelectElement;
+
+    expect(select.value).toBe("2");
+    expect(select.selectedIndex).toBe(2);
+  });
+
+  test("static select value is reapplied after dynamic children (#3167)", async () => {
+    const options = () => [<option value="1">One</option>, <option value="2">Two</option>];
+    const select = (<select value="2">{options()}</select>) as unknown as HTMLSelectElement;
+
+    await Promise.resolve();
+
+    expect(select.value).toBe("2");
+    expect(select.selectedIndex).toBe(1);
+  });
+
+  test("static select value selects one option in a multiple select (#3167)", () => {
+    const select = (
+      <select multiple value="2">
+        <option value="1">One</option>
+        <option value="2">Two</option>
+      </select>
+    ) as unknown as HTMLSelectElement;
+
+    expect(select.multiple).toBe(true);
+    expect(Array.from(select.options, option => option.selected)).toEqual([false, true]);
+  });
+
   test("class", () => {
     const classes = { first: true, second: false, "third fourth": true },
       d = (<div class={classes} />) as unknown as HTMLDivElement;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

fix #3167

Static `<select value="...">` values were previously inlined into the client HTML template. Since HTML does not define meaningful `value` attribute for `<select>`, the browser ignored it when determining the selected option.
Reactive values already use the live DOM property and are applied again in microtask after the options have been created.

Regression coverage includes:
  - String literals
  - Static string expressions
  - Numeric expressions
  - Dynamic children
  - `multiple` selects with static string and array values
  - Runtime selection of the matching option

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

Ran the complete Babel compiler suite:

  ```sh
  cd packages/babel-plugin
  pnpm test
```
  Result: 154 tests passed.

  Ran the native compiler Rust and JavaScript suites:
  
```sh
  cd packages/compiler
  pnpm test
```

  The standard run completed 4,335 JavaScript tests, with eight option-matrix cases exceeding the default
  five-second timeout. Those cases were rerun with a larger timeout:

```
  ../../node_modules/.bin/vitest run \
    __tests__/option-matrix.test.js \
    --testTimeout=20000
```

  Result: 165 option-matrix tests passed. All Rust tests also passed.

  Built and tested @solidjs/web:
```
  cd packages/web
  pnpm build
  ../../node_modules/.bin/vitest run
  ../../node_modules/.bin/vitest run --config vite.config.server.mjs
  ../../node_modules/.bin/vitest run --config vite.config.hydrate.mjs
```

  Results:

  - Client: 702 tests passed
  - Server: 536 tests passed, 2 skipped
  - Hydration: 151 tests passed

  Formatting and diff checks also passed.