### PR TITLE
fix(web): ignore inherited DOM properties

### DIFF
--- a/.changeset/ignore-inherited-dom-properties.md
+++ b/.changeset/ignore-inherited-dom-properties.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/web": patch
+---
+
+Ignore inherited enumerable properties in client-side style objects and JSX spreads to match SSR output.

--- a/packages/web/src/client.ts
+++ b/packages/web/src/client.ts
@@ -666,7 +666,7 @@ export function style(node, value, prev) {
   }
   let v, s;
   for (s in applied) {
-    if (value[s] == null) {
+    if (!Object.prototype.hasOwnProperty.call(value, s) || value[s] == null) {
       nodeStyle.removeProperty(s);
       delete applied[s];
     }
@@ -674,6 +674,7 @@ export function style(node, value, prev) {
   // Diff against applied state so in-place mutations are detected without
   // rewriting unchanged DOM styles.
   for (s in value) {
+    if (!Object.prototype.hasOwnProperty.call(value, s)) continue;
     v = value[s];
     if (v != null && v !== applied[s]) {
       nodeStyle.setProperty(s, v);
@@ -713,6 +714,7 @@ export function spread(node, props = {}, skipChildren) {
       const source = get();
       const newProps = {};
       for (const prop in source) {
+        if (!Object.prototype.hasOwnProperty.call(source, prop)) continue;
         if (prop === "children" || prop === "ref") continue;
         newProps[prop] = source[prop];
       }

--- a/packages/web/test/inherited-dom-properties.spec.ts
+++ b/packages/web/test/inherited-dom-properties.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, test } from "vitest";
+import { createRoot, flush } from "solid-js";
+import { spread, style } from "../src/client.js";
+import { ssrElement, ssrStyle } from "../src/server.js";
+
+describe("inherited DOM properties", () => {
+  test("style objects ignore inherited enumerable declarations consistently with SSR", () => {
+    const value = Object.assign(Object.create({ color: "red" }), { display: "block" });
+    const element = document.createElement("div");
+
+    expect(ssrStyle(value)).toBe("display:block");
+
+    style(element, { color: "blue" });
+    style(element, value);
+
+    expect(element.style.display).toBe("block");
+    expect(element.style.color).toBe("");
+  });
+
+  test("spread props ignore inherited enumerable attributes consistently with SSR", () => {
+    const props = Object.assign(Object.create({ title: "inherited" }), {
+      "data-own": "present"
+    });
+    const element = document.createElement("div");
+
+    expect(ssrElement("div", props, undefined, false).t).not.toContain("title");
+
+    const dispose = createRoot(dispose => {
+      spread(element, props, true);
+      return dispose;
+    });
+    flush();
+
+    expect(element.getAttribute("data-own")).toBe("present");
+    expect(element.hasAttribute("title")).toBe(false);
+    dispose();
+  });
+});


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Client-side `style()` and `spread()` used `for...in`, which caused inherited enumerable properties to be applied to the DOM.
SSR serialization only processes own properties, so the same props object could produce different server and client output. This change filters inherited properties in both client-side code paths. It also removes a previously applied style when that property is only inherited by the next style object.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

Added regression tests covering:
  - inherited properties in style objects
  - removal of a previously applied own style
  - inherited properties in spread props
  - consistency between client rendering and SSR

  Commands run:
  - `pnpm build`
  - `pnpm types`
  - `pnpm test-types`
  - `vitest run test/inherited-dom-properties.spec.ts`
  - `prettier --check src/client.ts test/inherited-dom-properties.spec.ts ../../.changeset/ignore-inherited-dom-properties.md`