### PR TITLE
fix(web): remove capturing event listeners

### DIFF
--- a/.changeset/remove-capturing-event-listeners.md
+++ b/.changeset/remove-capturing-event-listeners.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/web": patch
+---
+
+Remove replaced non-delegated event listener objects with their original capture option.

--- a/packages/web/src/client.ts
+++ b/packages/web/src/client.ts
@@ -2039,7 +2039,7 @@ function assignProp(node, prop, value, prev, skipRef, nodeName) {
     const delegate = DelegatedEvents.has(name);
     if (!delegate && prev) {
       const h = Array.isArray(prev) ? prev[0] : prev;
-      node.removeEventListener(name, h);
+      node.removeEventListener(name, h, typeof h !== "function" && h);
     }
     if (delegate || value) {
       addEvent(node, name, value, delegate);

--- a/packages/web/test/capturing-event-listener.spec.ts
+++ b/packages/web/test/capturing-event-listener.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, test, vi } from "vitest";
+import { assign } from "../src/client.js";
+
+describe("capturing event listeners", () => {
+  test("removes the previous non-delegated EventListenerObject when props change", () => {
+    const previous = vi.fn();
+    const current = vi.fn();
+    const previousListener = { capture: true, handleEvent: previous };
+    const currentListener = { capture: true, handleEvent: current };
+    const parent = document.createElement("div");
+    const child = document.createElement("span");
+    const prevProps = {};
+    parent.append(child);
+
+    assign(parent, { onScroll: previousListener }, true, prevProps);
+    assign(parent, { onScroll: currentListener }, true, prevProps);
+    child.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+    expect(previous).not.toHaveBeenCalled();
+    expect(current).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Replacing a non-delegated `EventListenerObject` registered with `capture: true` did not remove the previous listener. `removeEventListener()` was called without the listener's capture option, so the old capturing listener remained active alongside the replacement. This change passes the original listener object to `removeEventListener()`, preserving its capture setting.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

Added a regression test that replaces a capturing `EventListenerObject`, dispatches an event from a child element, and verifies that only the new listener is invoked.

  Commands run:
  - `pnpm build`
  - `pnpm types`
  - `pnpm test-types`
  - `vitest run test/capturing-event-listener.spec.ts`
  - `prettier --check src/client.ts test/capturing-event-listener.spec.ts ../../.changeset/remove-capturing-event-listeners.md`