### PR TITLE
fix(solid): keep client stores pending during hydration

### DIFF
--- a/.changeset/client-store-hydration-pending.md
+++ b/.changeset/client-store-hydration-pending.md
@@ -1,0 +1,5 @@
+---
+"solid-js": patch
+---
+
+Keep client-sourced stores pending during hydration until their first client result unless `seedLoadingValue` exposes the seed as commit zero.

--- a/packages/solid/src/client/hydration.ts
+++ b/packages/solid/src/client/hydration.ts
@@ -1129,14 +1129,10 @@ function hydrateStoreLikeFn(
     return withHydrationGate(hydrated =>
       coreFn(
         (draft: any) => {
-          // Windowed (seedLoadingValue): UNASKED — a sync no-op derive would
-          // close the seed window before the real derive ever runs (see the
-          // signal gate above). Bare: a no-op derive — stores have no
-          // uninitialized state (reads always serve state), and without a
-          // window an UNASKED return would be treated as an async result and
-          // suspend the projection at creation; the seed shows until the gate
-          // flips and the real derive runs as a fresh first mount.
-          if (!hydrated()) return hasLoadingWindow(options) ? UNASKED : undefined;
+          // Keep client-only stores unasked through hydration. With
+          // seedLoadingValue the seed is commit #0 and remains readable;
+          // otherwise the store suspends until its first client result.
+          if (!hydrated()) return UNASKED;
           return fn(draft);
         },
         initialValue,

--- a/packages/solid/test/client-hydration.spec.ts
+++ b/packages/solid/test/client-hydration.spec.ts
@@ -1242,6 +1242,57 @@ describe("bare ssrSource 'client' — unasked through the gate, computes after",
     flush();
     expect(store.name).toBe("computed");
   });
+
+  test("createStore(fn) keeps Loading fallback through the first client flight", async () => {
+    startHydration({});
+    const read = (value: any): any => {
+      while (typeof value === "function") value = value();
+      return value;
+    };
+
+    let store: any;
+    let result: any;
+    let deriveRan = 0;
+    let resolveDerive!: (value: { name: string }) => void;
+    createRoot(
+      () => {
+        [store] = createStore<{ name: string }>(
+          () => {
+            deriveRan++;
+            return new Promise(resolve => (resolveDerive = resolve));
+          },
+          { name: "seed" },
+          { ssrSource: "client" }
+        );
+        result = Loading({
+          fallback: "loading" as any,
+          get children() {
+            return store.name;
+          }
+        });
+      },
+      { id: "t" }
+    );
+    flush();
+
+    expect(deriveRan).toBe(0);
+    expect(() => store.name).toThrow(NotReadyError);
+    expect(read(result)).toBe("loading");
+
+    stopHydration();
+    flush();
+
+    expect(deriveRan).toBe(1);
+    expect(() => store.name).toThrow(NotReadyError);
+    expect(read(result)).toBe("loading");
+
+    resolveDerive({ name: "landed" });
+    await new Promise<void>(resolve => setTimeout(resolve));
+    flush();
+
+    expect(store.name).toBe("landed");
+    expect(read(result)).toBe("landed");
+  });
 });
 
 // The hydration gate must not close the loading window: a sync prev-return

--- a/packages/solid/test/client-hydration.spec.ts
+++ b/packages/solid/test/client-hydration.spec.ts
@@ -1222,7 +1222,7 @@ describe("bare ssrSource 'client' — unasked through the gate, computes after",
     ).not.toThrow();
   });
 
-  test("bare client store: seed visible during hydration, derive runs after the gate", () => {
+  test("bare client store hides its seed until the client derive completes", () => {
     startHydration({});
     let store: any;
     createRoot(
@@ -1234,8 +1234,7 @@ describe("bare ssrSource 'client' — unasked through the gate, computes after",
           { name: "seed" },
           { ssrSource: "client" }
         );
-        // Gate closed: the derive has not run — the seed is what's there.
-        expect(store.name).toBe("seed");
+        expect(() => store.name).toThrow(NotReadyError);
       },
       { id: "t" }
     );


### PR DESCRIPTION
## Summary

Client-sourced stores currently expose their seed during hydration unless `seedLoadingValue` is enabled. This makes a value that was not declared as commit zero observable before the client derive has run.

Keep these stores unasked through hydration so that:

- without `seedLoadingValue`, reads suspend until the first client result
- with `seedLoadingValue: true`, the seed remains visible as commit zero

This is extracted from #3194 because the behavior applies independently to the existing seeded API and does not depend on the proposed seedless store API.

## How did you test this change?

From `packages/solid`:

- `pnpm exec vitest run test/client-hydration.spec.ts` (128 tests)
- `pnpm types`
- `pnpm test-types`