### PR TITLE
fix(compiler): align ref spread hydration ids

### DIFF
--- a/.changeset/align-ref-spread-sources.md
+++ b/.changeset/align-ref-spread-sources.md
@@ -1,0 +1,6 @@
+---
+"@solidjs/babel-plugin": patch
+"@solidjs/compiler": patch
+---
+
+Keep hydration IDs aligned when an intrinsic element has a ref and one reactive spread.

--- a/packages/babel-plugin/src/ssr/element.ts
+++ b/packages/babel-plugin/src/ssr/element.ts
@@ -1002,9 +1002,15 @@ function createElement(
       return memo;
     }, []);
 
+  // The DOM transform handles `ref` outside its spread prop sources.
+  const propAttributes = attributes.filter(attribute => {
+    const node = attribute.node;
+    return !(t.isJSXAttribute(node) && t.isJSXIdentifier(node.name) && node.name.name === "ref");
+  });
+
   let props: babelTypes.Expression[];
-  if (attributes.length === 1 && t.isJSXSpreadAttribute(attributes[0].node)) {
-    props = [attributes[0].node.argument];
+  if (propAttributes.length === 1 && t.isJSXSpreadAttribute(propAttributes[0].node)) {
+    props = [propAttributes[0].node.argument];
   } else {
     props = [];
     let runningObject: Array<babelTypes.ObjectProperty | babelTypes.ObjectMethod> = [],

--- a/packages/babel-plugin/test/ref-spread.spec.js
+++ b/packages/babel-plugin/test/ref-spread.spec.js
@@ -1,0 +1,82 @@
+const babel = require("@babel/core");
+const plugin = require("../index");
+
+function compile(code, generate = "ssr", hydratable = true) {
+  return babel.transformSync(code, {
+    plugins: [[plugin, { generate, hydratable }]],
+    configFile: false,
+    babelrc: false,
+    filename: "input.jsx"
+  }).code;
+}
+
+describe("intrinsic ref and spread sources", () => {
+  test.each([
+    ["a spread", "const view = <div {...attrs()} />;"],
+    [
+      "an assignment ref before a spread",
+      "let node; const view = <div ref={node} {...attrs()} />;"
+    ],
+    ["an assignment ref after a spread", "let node; const view = <div {...attrs()} ref={node} />;"],
+    [
+      "a callback ref and children",
+      "let node; const view = <div ref={el => (node = el)} {...attrs()}>child</div>;"
+    ],
+    ["a directive ref", "const view = <div ref={directive(source)} {...attrs()} />;"],
+    [
+      "a static spread marker",
+      "let node; const view = <div ref={node} {/* @static */ ...attrs()} />;"
+    ]
+  ])("passes one effective source through for %s", (_, source) => {
+    for (const hydratable of [true, false]) {
+      const output = compile(source, "ssr", hydratable);
+      expect(output).toContain('ssrElement("div", attrs()');
+      expect(output).not.toContain("mergeProps");
+    }
+  });
+
+  test("passes a static object source through with a ref", () => {
+    const output = compile(
+      'let node; const attrs = { class: "example" }; const view = <div ref={node} {...attrs} />;'
+    );
+    expect(output).toContain('ssrElement("div", attrs,');
+    expect(output).not.toContain("mergeProps");
+  });
+
+  test.each([
+    ["an ordinary attribute", 'const view = <div id="x" {...attrs()} />;'],
+    [
+      "a ref and an ordinary attribute",
+      'let node; const view = <div ref={node} id="x" {...attrs()} />;'
+    ],
+    ["two spreads", "const view = <div {...a()} {...b()} />;"],
+    ["an event", "let node; const view = <div ref={node} onClick={click} {...attrs()} />;"],
+    [
+      "a property",
+      "let node; const view = <input ref={node} prop:value={value()} {...attrs()} />;"
+    ],
+    [
+      "an explicit children source",
+      "let node; const view = <div ref={node} children={fallback()} {...attrs()}>child</div>;"
+    ],
+    [
+      "several attributes and spreads",
+      'let node; const view = <div ref={node} id="x" {...a()} title="y" {...b()} />;'
+    ]
+  ])("keeps mergeProps for %s", (_, source) => {
+    expect(compile(source)).toContain("mergeProps");
+    expect(compile(source, "dom")).toContain("mergeProps");
+  });
+
+  test("does not change component ref props", () => {
+    const output = compile("let node; const view = <Comp ref={node} {...attrs()} />;");
+    expect(output).toContain("Comp(");
+    expect(output).toContain("mergeProps");
+  });
+
+  test("keeps the client direct-source rule", () => {
+    const output = compile("let node; const view = <div ref={node} {...attrs()} />;", "dom");
+    expect(output).toMatch(/spread\([^,]+, attrs, false\)/);
+    expect(output).not.toContain("mergeProps");
+  });
+});

--- a/packages/compiler/__tests__/parity-probes.test.js
+++ b/packages/compiler/__tests__/parity-probes.test.js
@@ -497,6 +497,16 @@ const b = <span {...one} {...two()} />;
   "spread with events and refs": `
 const a = <div {...props} onClick={click} ref={r} class={c()}>{x()}</div>;
 `,
+  "reactive lone spread with intrinsic refs": `
+let node;
+const a = <div ref={node} {...props()} />;
+const b = <div {...props()} ref={node}>child</div>;
+const c = <div ref={el => (node = el)} {/* @static */ ...props()} />;
+const d = <div ref={node} id="x" {...props()} />;
+const e = <Comp ref={node} {...props()} />;
+const f = <input ref={node} prop:value={value()} {...props()} />;
+const g = <div ref={directive(source)} {...props()} />;
+`,
   "conditional attribute chains": `
 const a = <div class={cond() ? "a" : cond2() ? "b" : "c"} title={x() && y() || z()}>{t()}</div>;
 `,

--- a/packages/compiler/src/ssr/transform.rs
+++ b/packages/compiler/src/ssr/transform.rs
@@ -1308,9 +1308,14 @@ impl<'a, 'source> AstSsrTransform<'a, 'source> {
         attributes: &[JSXAttributeItem<'a>],
         has_children: bool,
     ) -> Result<Expression<'a>> {
-        // A lone spread attribute passes its argument straight through.
-        if attributes.len() == 1
-            && let JSXAttributeItem::SpreadAttribute(spread) = &attributes[0]
+        // The DOM transform handles `ref` outside its spread prop sources.
+        let mut prop_attributes = attributes.iter().filter(|attr| {
+            !matches!(attr, JSXAttributeItem::Attribute(attr)
+                if matches!(&attr.name, oxc_ast::ast::JSXAttributeName::Identifier(name)
+                    if name.name == "ref"))
+        });
+        if let (Some(JSXAttributeItem::SpreadAttribute(spread)), None) =
+            (prop_attributes.next(), prop_attributes.next())
         {
             return Ok(spread.argument.clone_in(self.allocator));
         }

--- a/packages/web/test/harness/__artifacts__/reactive-ref-lone-spread-id-parity.json
+++ b/packages/web/test/harness/__artifacts__/reactive-ref-lone-spread-id-parity.json
@@ -1,0 +1,5 @@
+{
+  "name": "reactive-ref-lone-spread-id-parity",
+  "shell": "<div _hk=0 class=\"example\"><span>spread</span></div><button _hk=1>before</button>",
+  "rest": ""
+}

--- a/packages/web/test/harness/scenarios.tsx
+++ b/packages/web/test/harness/scenarios.tsx
@@ -1520,6 +1520,25 @@ function ReactiveLoneSpread() {
   );
 }
 
+// An explicit ref does not add a spread prop source on the client. SSR must
+// make the same lone-source decision so the next element keeps the same key.
+let refSpreadButton!: HTMLButtonElement;
+function ReactiveRefLoneSpread() {
+  const attrs = () => ({ class: "example" });
+  const [label, setLabel] = createSignal("before");
+  let node!: HTMLDivElement;
+  return (
+    <>
+      <div ref={node} {...attrs()}>
+        <span>spread</span>
+      </div>
+      <button ref={refSpreadButton} onClick={() => setLabel("after")}>
+        {label()}
+      </button>
+    </>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // solidjs/solid#3033: a conditional expression in a JSX prop compiles to a
 // condition memo INSIDE the prop getter, minted when the getter is first
@@ -2074,6 +2093,14 @@ export const scenarios: Scenario[] = [
     App: ReactiveLoneSpread,
     expectedText: "spreadbefore",
     update: () => setLoneSpreadLabel("after"),
+    expectedTextAfterUpdate: "spreadafter",
+    stableSelector: "div, span, button"
+  },
+  {
+    name: "reactive-ref-lone-spread-id-parity",
+    App: ReactiveRefLoneSpread,
+    expectedText: "spreadbefore",
+    update: () => refSpreadButton.click(),
     expectedTextAfterUpdate: "spreadafter",
     stableSelector: "div, span, button"
   },


### PR DESCRIPTION
## Summary

An explicit intrinsic `ref` makes SSR miss the lone-spread fast path. The DOM transform handles `ref` separately and still passes one source directly to `spread()`. SSR counts the raw JSX attributes and sends the same source through `mergeProps`.

This change makes the Babel and native SSR transforms ignore explicit `ref` attributes only when they decide if one spread source can pass through. Other attributes still keep the merge path.

## Reproduction

```tsx
const attrs = () => ({ class: "example" });
let node;

const view = () => (
  <>
    <div ref={node} {...attrs()} />
    <button onClick={() => 1}>go</button>
  </>
);
```

Before this change, the relevant output is:

```js
// DOM
_$spread(_el$, attrs, false);

// SSR
_$ssrElement("div", () => _$mergeProps(attrs), undefined, true);
```

`mergeProps` creates a memo for the function source. On the server, the `div` gets key `0`, that memo consumes ID `1`, and the button gets key `2`. The client does not create the memo and expects the button at key `1`. In the hydration harness, the server button stayed at `before` after its click because the client did not claim it with the expected key.

After this change, SSR emits:

```js
_$ssrElement("div", attrs(), undefined, true);
```

The server output now has consecutive keys `0` and `1`. The same nodes hydrate without warnings, the following click handler runs, and the signal update changes the text to `after`.

## Invariant

A single effective DOM spread source passes directly to `spread()` and `ssrElement()`. An explicit intrinsic `ref`, including a ref directive factory, is not a spread source because the DOM transform applies it through the ref path. Ordinary attributes, events, `prop:*`, explicit children, and additional spreads still add DOM sources. They still use `mergeProps` on both sides.

The compiler is the narrow layer that knows this source count. A runtime change to `mergeProps` would also change valid multi-source and component behavior. Restoring a client merge for this case would undo the single-source direction established by 52306662c448dc9a3d9e3e4061cf175c0ba30234.

PR #3105 found the memo and hydration-ID mismatch, but it proposed adding the missing merge to SSR. Commit 52306662 fixed that case in the other direction: it removed the unnecessary client merge. This change keeps that direction and covers the explicit-`ref` edge that its regression case did not include.

## Coverage

- Babel output for assignment refs before and after the spread, callback refs, ref directive factories, children, static objects, the static marker, hydratable and non-hydratable SSR, and client-only output.
- Merge preservation for ordinary attributes, events, `prop:*`, explicit children, multiple attributes and spreads, and components.
- Babel/native parity in all compiler modes.
- An end-to-end hydration scenario that checks consecutive server keys, server-node reuse, no warnings, a following button click, and a signal update.

## How did you test this change?

These commands passed:

- `pnpm install --frozen-lockfile`
- `pnpm --filter @solidjs/babel-plugin test`
- `pnpm --filter @solidjs/compiler test`
- `pnpm --filter @solidjs/compiler lint`
- `pnpm --filter @solidjs/web test`
- `JSX_COMPILER=babel pnpm --filter @solidjs/web test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm test:integration`
- `pnpm exec prettier --check packages/babel-plugin/src/ssr/element.ts packages/babel-plugin/test/ref-spread.spec.js packages/compiler/__tests__/parity-probes.test.js packages/web/test/harness/scenarios.tsx .changeset/align-ref-spread-sources.md packages/web/test/harness/__artifacts__/reactive-ref-lone-spread-id-parity.json`
- `rustfmt --edition 2024 --check packages/compiler/src/ssr/transform.rs`
- `git diff --check`

I also ran `npm run size` in `scripts/size`. It reports the same ten limit overruns on this commit and on the exact base commit, 981718be439d6d60e66066c0bfa1666cfdd107ef. The values are identical: 14–215 bytes over the current limits. This compiler-only change does not change those runtime bundles.
