### PR TITLE
fix(signals): propagate async setter errors

### DIFF
--- a/.changeset/handle-async-setter-errors.md
+++ b/.changeset/handle-async-setter-errors.md
@@ -1,0 +1,8 @@
+---
+"@solidjs/signals": patch
+---
+
+Route errors thrown while applying asynchronous computed setters through the
+node's error state. This prevents user callbacks invoked during asynchronous
+projection reconciliation, such as key selectors, from escaping as unhandled
+promise rejections.

--- a/packages/signals/src/core/async.ts
+++ b/packages/signals/src/core/async.ts
@@ -449,7 +449,12 @@ export function handleAsync<T>(
     // change (and only then classify it as an async landing).
     if (__DEV__ && attrHooks !== null) attrHooks.asyncStart(el);
     if (setter) {
-      setter(value);
+      try {
+        setter(value);
+      } catch (error) {
+        handleError(error);
+        return;
+      }
       if (wasUninitialized) clearStatus(el, true);
     } else if (el._x?._overrideValue !== undefined) {
       // Optimistic node — resting OR covered by an active override — holds

--- a/packages/signals/tests/store/createProjection.async.test.ts
+++ b/packages/signals/tests/store/createProjection.async.test.ts
@@ -1031,6 +1031,29 @@ describe("errored derive follows memo rules", () => {
     flush();
   };
 
+  it("routes async reconciliation errors through the projection error state", async () => {
+    const boom = new Error("invalid projection key");
+    let store!: { id: number };
+    const dispose = createRoot(d => {
+      store = createProjection(
+        async () => ({ id: 2 }),
+        { id: 1 },
+        {
+          key: item => {
+            if (item.id === 2) throw boom;
+            return item.id;
+          }
+        }
+      );
+      return d;
+    });
+
+    flush();
+    await settle();
+    expect(() => untrack(() => store.id)).toThrow("invalid projection key");
+    dispose();
+  });
+
   it("untracked reads of a rejected uninitialized derive throw its error", async () => {
     const boom = new Error("boom");
     let store!: any;


### PR DESCRIPTION
## Summary

Errors thrown by a custom setter while applying an asynchronous computed result currently escape from the promise fulfillment callback. For store projections this can happen when reconciliation invokes a user-provided `key` selector: the application gets an unhandled rejection and the projection does not enter its error state.

This routes those errors through the existing async `handleError` path, matching rejected computations and the existing handling for errors from async comparators.

The regression test uses an ordinary seeded projection whose key selector throws during asynchronous reconciliation, so this fix is independent of the seedless-store proposal.

## Testing

- `pnpm exec vitest run tests/store/createProjection.async.test.ts --reporter=dot` (32 tests)
- `pnpm types` in `packages/signals`