### PR TITLE
fix(signals): exempt the thenable probe from the store strict-read check

### DIFF
--- a/.changeset/store-thenable-probe-strict-read.md
+++ b/.changeset/store-thenable-probe-strict-read.md
@@ -1,0 +1,15 @@
+---
+"@solidjs/signals": patch
+---
+
+Stop the store proxy's dev strict-read check from firing on the engine's
+thenable probe. Resolving a promise with a store proxy — `refresh(store)`'s
+waiter delivers the store, `Promise.resolve(store)`, `return store` from an
+async function — makes the engine read `store.then` synchronously in the
+caller's scope. When that scope carries a strict-read label (an effect
+callback, a component body) the read produced a spurious
+`STRICT_READ_UNTRACKED` warning, and against a refetching derived store it
+could escalate to the `PENDING_ASYNC_UNTRACKED_READ` throw, rejecting the
+promise being resolved. `await refresh(list)` inside an action logged the
+warning on every call. The `then` probe is not a read the user wrote and is
+now exempt from both.

--- a/packages/signals/src/store/next/store.ts
+++ b/packages/signals/src/store/next/store.ts
@@ -1536,11 +1536,18 @@ const traps: ProxyHandler<StoreNextTarget> = {
     }
     // Dev strictRead: untracked store reads in labeled scopes (component
     // bodies, effect callbacks) warn — the value can never update the reader.
+    // `then` is exempt: resolving a promise with a store proxy (refresh()'s
+    // waiter delivers the store, `Promise.resolve(store)`, `return store`
+    // from an async function) makes the engine probe `.then` for
+    // thenable-ness synchronously in the caller's scope. That is not a read
+    // the user wrote, and it must neither warn nor escalate to the pending
+    // throw — a throw out of promise resolution rejects the promise.
     if (
       __DEV__ &&
       strictRead &&
       !inDraft(target) &&
       typeof key === "string" &&
+      key !== "then" &&
       getObserver() === null
     ) {
       // Safeguard parity with core read() (#2897): a component-body read of

--- a/packages/signals/tests/strict-read-pending-store.test.ts
+++ b/packages/signals/tests/strict-read-pending-store.test.ts
@@ -4,6 +4,7 @@ import {
   createOptimisticStore,
   createRoot,
   createStore,
+  DEV,
   flush,
   isPending,
   refresh,
@@ -243,5 +244,117 @@ describe("uninitialized derived stores never leak the seed (#2897)", () => {
       }, "App");
     });
     warn.mockRestore();
+  });
+});
+
+/**
+ * Resolving a promise with a store proxy makes the engine read `.then` to
+ * decide whether the value is a thenable. The read goes through the store's
+ * get trap synchronously, in whatever scope the resolution happens — so
+ * refresh(store)'s waiter callback (an "effect callback" strict-read scope),
+ * `Promise.resolve(store)` in a component body, or `return store` from an
+ * async function all probe `.then` under a strict-read label. The probe is
+ * not a read the user wrote: it must neither warn (STRICT_READ_UNTRACKED)
+ * nor escalate to the pending throw (PENDING_ASYNC_UNTRACKED_READ), which
+ * would reject the promise being resolved.
+ */
+describe("thenable probe on a store proxy in a strict-read scope", () => {
+  it("await refresh(store) on a derived store emits no strict-read diagnostic", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const capture = DEV!.diagnostics.capture();
+    let fetches = 0;
+    let dispose!: () => void;
+    let list!: { id: number }[];
+    createRoot(d => {
+      dispose = d;
+      [list] = createStore(
+        async () => {
+          fetches++;
+          await wait(5);
+          return [{ id: fetches }];
+        },
+        [] as { id: number }[]
+      );
+    });
+    flush();
+    await wait(20);
+    flush();
+    expect(fetches).toBe(1);
+
+    const delivered = await refresh(list);
+    flush();
+
+    expect(delivered).toBe(list);
+    expect(fetches).toBe(2);
+    const events = capture.stop();
+    expect(events.filter(e => e.code === "STRICT_READ_UNTRACKED")).toEqual([]);
+    expect(events.filter(e => e.code === "PENDING_ASYNC_UNTRACKED_READ")).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+    dispose();
+  });
+
+  it("Promise.resolve(store) in a component body neither warns nor rejects", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const capture = DEV!.diagnostics.capture();
+    let dispose!: () => void;
+    let p!: Promise<unknown>;
+    let control!: number;
+    createRoot(d => {
+      dispose = d;
+      const [store] = createStore({ count: 1 });
+      untrack(() => {
+        p = Promise.resolve(store);
+        // Control: a real untracked read still warns.
+        control = store.count;
+      }, "App");
+    });
+    await expect(p).resolves.toEqual({ count: 1 });
+    expect(control).toBe(1);
+    const events = capture.stop();
+    const strict = events.filter(e => e.code === "STRICT_READ_UNTRACKED");
+    expect(strict).toHaveLength(1);
+    expect(strict[0].data?.property).toBe("count");
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+    dispose();
+  });
+
+  it("thenable probe on a refetching derived store does not throw the pending error", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const capture = DEV!.diagnostics.capture();
+    let dispose!: () => void;
+    let list!: { id: number }[];
+    let fetches = 0;
+    createRoot(d => {
+      dispose = d;
+      [list] = createStore(
+        async () => {
+          fetches++;
+          await wait(5);
+          return [{ id: fetches }];
+        },
+        [] as { id: number }[]
+      );
+    });
+    flush();
+    await wait(20);
+    flush();
+
+    // A component-body probe while the store is REFETCHING must still be a
+    // no-op — the pending escalation would reject the promise.
+    const first = refresh(list);
+    let p!: Promise<unknown>;
+    untrack(() => {
+      p = Promise.resolve(list);
+    }, "App");
+    await expect(p).resolves.toBe(list);
+    await first;
+    flush();
+    const events = capture.stop();
+    expect(events.filter(e => e.code === "PENDING_ASYNC_UNTRACKED_READ")).toEqual([]);
+    expect(events.filter(e => e.code === "STRICT_READ_UNTRACKED")).toEqual([]);
+    warn.mockRestore();
+    dispose();
   });
 });


### PR DESCRIPTION
## Summary

Resolving a promise with a store proxy makes the engine read `store.then` synchronously to check for a thenable. That read goes through the store's get trap in whatever scope the resolution happens. `refresh(store)`'s waiter effect resolves with the store from its callback, which carries the `an effect callback` strict-read label, so every `await refresh(list)` inside an action logged:

```
[STRICT_READ_UNTRACKED] Reactive value read directly in an effect callback will not update.
```

The diagnostic payload is `{ property: "then", source: "store" }` — the engine's probe, not a read the user wrote. `Promise.resolve(store)` or `return store` from an async function in a component body hit the same path, and against a refetching derived store the probe could escalate to the `PENDING_ASYNC_UNTRACKED_READ` throw, rejecting the promise being resolved.

## Fix

The store trap's strict-read branch skips the `then` key. Real untracked reads still warn.

## Tests

Three cases folded into `tests/strict-read-pending-store.test.ts`: `await refresh(store)` on a derived store, `Promise.resolve(store)` in a component body next to a control read that still warns, and a probe on a refetching derived store. All three fail without the fix.

Verified in a client-mode app on rc.6: one Vote click logged the warning with the pristine bundle and nothing with the patched one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
