### PR TITLE
fix(signals): an optimistic store's first flight declares no transaction

### DIFF
--- a/.changeset/optimistic-store-first-flight-no-transaction.md
+++ b/.changeset/optimistic-store-first-flight-no-transaction.md
@@ -1,0 +1,16 @@
+---
+"@solidjs/signals": patch
+---
+
+An optimistic store's first flight suspends into its Loading boundary again.
+The flight-owned transaction (#3146) was declared for the uninitialized
+first ask too, so every transition-riding consumer — `render()`'s scheduled
+root insert included — was held until the initial fetch landed: the page
+stayed blank (content outside the boundary included) and the boundary's
+fallback never showed, while `createStore(fn, seed)` and
+`createOptimistic(fn, seed)` in the same spot showed it. Nothing has
+committed on a first flight, so there is no truth to keep on screen and no
+optimistic state to protect: it now declares nothing, like the loading
+window (#2933). Refetch flights declare exactly as before, so bare
+optimistic writes during an in-flight refetch still ride the flight's
+transaction (#2951) and content stays put until the new truth lands.

--- a/packages/signals/src/store/next/optimistic.ts
+++ b/packages/signals/src/store/next/optimistic.ts
@@ -27,6 +27,7 @@ import {
   CONFIG_OPTIMISTIC,
   NOT_PENDING,
   STATUS_PENDING,
+  STATUS_UNINITIALIZED,
   unwrapOverride
 } from "../../core/constants.js";
 import {
@@ -277,7 +278,16 @@ export function createOptimisticStoreNext<T extends object = {}>(
         if (!self._loading) fam.ft = null;
         return;
       }
-      if (self._loading) return;
+      // First flight (#3146 carve-out): nothing has ever committed, so there
+      // is no truth to keep on screen and no optimistic state to protect. An
+      // uninitialized ask suspends its readers into their Loading boundary
+      // exactly like a plain derived store's first flight — declaring a
+      // transaction here instead held the ROOT MOUNT (render()'s scheduled
+      // insert rides transitions) until the fetch landed, so the boundary's
+      // fallback never showed and the whole page stayed blank. The loading
+      // window (#2933) already declares nothing for the same reason; once
+      // the first truth lands, every refetch flight declares as before.
+      if (self._loading || self._statusFlags & STATUS_UNINITIALIZED) return;
       let txn = activeTransition;
       if (txn === null) globalQueue.initTransition((txn = createTransition()));
       fam.ft = txn;

--- a/packages/signals/tests/store/flight-owned-transaction.test.ts
+++ b/packages/signals/tests/store/flight-owned-transaction.test.ts
@@ -13,10 +13,13 @@
 import { expect, test } from "vitest";
 import {
   createEffect,
+  createLoadingBoundary,
   createOptimisticStore,
   createRoot,
   createSignal,
-  flush
+  createStore,
+  flush,
+  isPending
 } from "../../src/index.js";
 import type { Store } from "../../src/store.js";
 
@@ -136,5 +139,115 @@ test("#3146: per-yield landings still reveal on arrival under the flight-owned t
   flush();
   expect(views.at(-1)).toEqual(["one", "two", "three"]);
   dispose();
+  flush();
+});
+
+// The FIRST flight is the carve-out: nothing has committed yet, so there is
+// no truth to keep on screen and no optimistic state to protect. Declaring
+// the owned transaction for the uninitialized ask held every
+// transition-riding consumer — render()'s scheduled root insert included —
+// until the fetch landed: the page stayed blank and the Loading boundary's
+// fallback never showed, while createStore(fn, seed) and
+// createOptimistic(fn, seed) in the same spot showed it. A first flight
+// declares nothing, like the loading window (#2933); refetch flights
+// (initialized) declare exactly as the tests above pin.
+type Resolver = (items: string[]) => void;
+
+function boundaryHarness(make: (dep: () => number, resolvers: Resolver[]) => { items: string[] }) {
+  const resolvers: Resolver[] = [];
+  let setDep!: (v: number) => void;
+  let result: unknown = "never-ran";
+  let store!: { items: string[] };
+  let dispose!: () => void;
+  createRoot(d => {
+    dispose = d;
+    const [dep, _setDep] = createSignal(0);
+    setDep = _setDep;
+    store = make(dep, resolvers);
+    const boundary = createLoadingBoundary(
+      () => store.items.join(","),
+      () => "loading"
+    );
+    // A USER effect, like render()'s scheduled root insert: its apply is
+    // stashed by an open transition until that transition settles.
+    createEffect(
+      () => boundary(),
+      v => {
+        result = v;
+      }
+    );
+  });
+  return {
+    resolvers,
+    setDep,
+    get result() {
+      return result;
+    },
+    get store() {
+      return store;
+    },
+    dispose
+  };
+}
+
+test("#3146 carve-out: the first flight shows the boundary fallback; the refetch keeps content", async () => {
+  const h = boundaryHarness((dep, resolvers) => {
+    const [store] = createOptimisticStore<{ items: string[] }>(
+      async () => {
+        dep();
+        const items = await new Promise<string[]>(r => resolvers.push(r));
+        return { items };
+      },
+      { items: [] }
+    );
+    return store;
+  });
+  flush();
+  // The boundary's effect must APPLY on the initial flush (not be stashed
+  // by a flight transaction) and show the fallback.
+  expect(h.result).toBe("loading");
+
+  h.resolvers[0](["A"]);
+  await tick();
+  flush();
+  expect(h.result).toBe("A");
+
+  // Refetch: stale-while-revalidate — content stays, isPending flips.
+  h.setDep(1);
+  flush();
+  await tick();
+  expect(h.result).toBe("A");
+  expect(isPending(() => h.store.items.length)).toBe(true);
+
+  h.resolvers[1](["A", "B"]);
+  await tick();
+  flush();
+  await tick();
+  flush();
+  expect(h.result).toBe("A,B");
+  expect(isPending(() => h.store.items.length)).toBe(false);
+  h.dispose();
+  flush();
+});
+
+test("#3146 carve-out control: createStore(fn, seed) first flight shows the same fallback", async () => {
+  const h = boundaryHarness((dep, resolvers) => {
+    const [store] = createStore<{ items: string[] }>(
+      async () => {
+        dep();
+        const items = await new Promise<string[]>(r => resolvers.push(r));
+        return { items };
+      },
+      { items: [] }
+    );
+    return store;
+  });
+  flush();
+  expect(h.result).toBe("loading");
+  h.resolvers[0](["A"]);
+  await tick();
+  flush();
+  expect(h.result).toBe("A");
+  h.dispose();
   flush();
 });

--- a/packages/web/test/loading.spec.tsx
+++ b/packages/web/test/loading.spec.tsx
@@ -7,8 +7,11 @@ import { describe, expect, test, beforeEach, afterEach, vi } from "vitest";
 import {
   lazy,
   type Component,
+  createOptimisticStore,
   createSignal,
   createMemo,
+  createStore,
+  For,
   Loading,
   Errored,
   Show,
@@ -823,5 +826,97 @@ describe("Testing Loading", () => {
   test("dispose", () => {
     div.innerHTML = "";
     disposer();
+  });
+});
+
+// An optimistic store's first flight must suspend into the nearest <Loading>
+// like createStore(fn, seed) does. Its flight-owned transaction (#3146),
+// declared for the uninitialized first ask too, held render()'s scheduled
+// root insert until the fetch landed: the page stayed blank — not even
+// content OUTSIDE the boundary mounted — and the fallback never showed.
+describe("<Loading> around an optimistic store's first flight", () => {
+  // Real timers: the fetches below settle on their own schedule.
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+  const wait = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+  type Item = { id: number; label: string; votes: number };
+  function poll(make: typeof createStore | typeof createOptimisticStore) {
+    const [tick, setTick] = createSignal(0);
+    let fetches = 0;
+    const [list] = make<Item[]>(async () => {
+      tick();
+      const n = ++fetches;
+      await wait(10);
+      return [{ id: 1, label: "Tacos", votes: n - 1 }];
+    }, [] as Item[]);
+    return { list, setTick };
+  }
+
+  function mount(make: typeof createStore | typeof createOptimisticStore) {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const div = document.createElement("div");
+    let setTick!: (v: number) => void;
+    const dispose = render(() => {
+      const p = poll(make);
+      setTick = p.setTick;
+      return (
+        <>
+          <h1>Poll</h1>
+          <Loading fallback={<div>Loading...</div>}>
+            <ul>
+              <For each={p.list}>
+                {item => (
+                  <li>
+                    {item.label} - {item.votes}
+                  </li>
+                )}
+              </For>
+            </ul>
+          </Loading>
+        </>
+      );
+    }, div);
+    flush();
+    // Comment markers from insert() are noise for these assertions.
+    const html = () => div.innerHTML.replace(/<!---->/g, "");
+    return {
+      html,
+      refetch: () => setTick(1),
+      dispose: () => {
+        dispose();
+        warn.mockRestore();
+      }
+    };
+  }
+
+  test("createOptimisticStore(fn, seed) in the component body: fallback at mount, list after landing, content kept on refetch", async () => {
+    const { html, dispose, refetch } = mount(createOptimisticStore);
+    expect(html()).toBe("<h1>Poll</h1><div>Loading...</div>");
+
+    await wait(30);
+    flush();
+    expect(html()).toBe("<h1>Poll</h1><ul><li>Tacos - 0</li></ul>");
+
+    // Refetch: stale-while-revalidate — no fallback, then the new truth.
+    refetch();
+    flush();
+    await wait(2);
+    flush();
+    expect(html()).toBe("<h1>Poll</h1><ul><li>Tacos - 0</li></ul>");
+    await wait(30);
+    flush();
+    expect(html()).toBe("<h1>Poll</h1><ul><li>Tacos - 1</li></ul>");
+    dispose();
+  });
+
+  test("control: createStore(fn, seed) in the same spot", async () => {
+    const { html, dispose } = mount(createStore);
+    expect(html()).toBe("<h1>Poll</h1><div>Loading...</div>");
+    await wait(30);
+    flush();
+    expect(html()).toBe("<h1>Poll</h1><ul><li>Tacos - 0</li></ul>");
+    dispose();
   });
 });


### PR DESCRIPTION
## Summary

`<Loading fallback={...}>` around a `createOptimisticStore(fn, seed)` never showed its fallback in client mode. The whole page stayed blank until the initial fetch landed — content **outside** the boundary included — while `createStore(fn, seed)` and `createOptimistic(fn, seed)` in the same spot showed the fallback. `ssr: true` masked it because the server streams the fallback and hydration is not a scheduled mount.

## Root cause

#3146 gave optimistic-store truth flights an owned, declared transaction. `declareFlight` opened one for the uninitialized first flight too. `render()`'s root insert is scheduled and rides transitions, so the mount was stashed until the flight settled.

## Fix

A first flight declares nothing, the same rule the loading window (#2933) already follows: nothing has committed yet, so there is no truth to keep on screen and no optimistic state to protect. Refetch flights declare exactly as before; bare optimistic writes during an in-flight refetch still ride the flight's transaction (#2951).

## Tests

- `tests/store/flight-owned-transaction.test.ts`: first flight shows the boundary fallback, refetch keeps content, plus a `createStore` control. A **user** effect is what reproduces the hold; a render effect is not stashed by the transition.
- `packages/web/test/loading.spec.tsx`: the exact app shape through `render()`, asserting `<h1>Poll</h1><div>Loading...</div>` at mount and the list after landing.

Both fail without the fix. The existing #3146 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
