### PR TITLE
fix(signals): refresh() after a held manual write stays a quiet re-ask

### DIFF
--- a/.changeset/refresh-held-write-stays-reask.md
+++ b/.changeset/refresh-held-write-stays-reask.md
@@ -1,0 +1,12 @@
+---
+"@solidjs/signals": patch
+---
+
+`refresh()` after a held manual write stays a quiet re-ask. When an action
+wrote to a derived store and later called `refresh(store)`, the lift of the
+manual-write mask (#3026) dropped the re-ask classification, so the refetch
+was treated as a brand-new question and pended every leaf — every sibling
+row lit up `isPending`, and a row-scoped `affects()` could not narrow it.
+The lift now keeps the classification: same-question motion stays silent,
+and only the written slot and any declared `affects()` mark read pending
+until the truth lands. Same-tick precedence (#2692) is unchanged.

--- a/packages/signals/src/core/core.ts
+++ b/packages/signals/src/core/core.ts
@@ -1504,8 +1504,14 @@ export function markRefresh(node: Computed<any>): void {
       // for the rest of the transaction (#3026).
       if (node._manualWriteTime === clock) return;
       node._flags &= ~REACTIVE_MANUAL_WRITE;
-      // No REASK below: the batch carries a manual value change, so the
-      // recompute is not a quiet re-ask of an unchanged question.
+      // The lift falls through to the re-ask classification below. The held
+      // write's value change already rides the transaction; the refetch it
+      // asks for is the same question with unchanged inputs. Skipping the
+      // mark here classified that refetch as a NEW question, which pends
+      // every leaf (3.1) — an action doing setStore + yield + refresh(store)
+      // lit up every sibling row, and affects() could not narrow it (a mark
+      // only turns pending on). Same-question motion stays silent (3.4);
+      // the written slot and any declared mark carry the pending instead.
     }
     // A refresh with no value-change dirt already queued is a re-ask of the
     // same question: mark it so the recompute classifies any resulting
@@ -1514,7 +1520,7 @@ export function markRefresh(node: Computed<any>): void {
     // REACTIVE_IN_HEAP counts as dirt: insertSubs schedules subscribers by
     // heap insertion alone (no DIRTY/CHECK flag), so a same-batch value
     // change followed by refresh() must not be laundered into a quiet re-ask.
-    else if (!(node._flags & (REACTIVE_DIRTY | REACTIVE_CHECK | REACTIVE_IN_HEAP))) {
+    if (!(node._flags & (REACTIVE_DIRTY | REACTIVE_CHECK | REACTIVE_IN_HEAP))) {
       node._flags |= REACTIVE_REASK;
       armReaskClear();
     }

--- a/packages/signals/tests/question-scoped-pending.test.ts
+++ b/packages/signals/tests/question-scoped-pending.test.ts
@@ -132,6 +132,98 @@ describe("same-question motion is silent", () => {
     t.dispose();
   });
 
+  it("3.4-held-write: refresh() after a held manual write is still a re-ask — siblings silent, affects() scopes it", async () => {
+    // A plain derived store written manually inside an action, then
+    // refetched after the yield: the refresh lifts the manual-write mask
+    // (#3026). The lift must keep the re-ask classification — dropping it
+    // made the refetch a NEW question that pended every leaf (both rows'
+    // ids, labels, the array length), and the row-scoped affects() could not
+    // narrow it. Verdicts are observed through tracked readers, as JSX reads
+    // them: the subscribed reader is what keeps the action's transaction —
+    // and its mark — alive until the refetch lands.
+    type Row = { id: number; label: string; votes: number };
+    const db: Row[] = [
+      { id: 1, label: "Tacos", votes: 0 },
+      { id: 2, label: "Burritos", votes: 0 }
+    ];
+    const fetcher = deferredFetcher(() => db.map(r => ({ ...r })));
+    let confirm!: () => void;
+    let list!: Row[];
+    let vote!: (id: number) => unknown;
+    let dispose!: () => void;
+    const seen: Record<string, boolean> = {};
+    createRoot(d => {
+      dispose = d;
+      let setList!: (fn: (l: Row[]) => void) => void;
+      [list, setList] = createStore<Row[]>(() => fetcher.fetch(0), []);
+      vote = action(function* (id: number) {
+        affects(list.find(r => r.id === id)!, "id");
+        setList(l => {
+          l.find(r => r.id === id)!.votes++;
+        });
+        yield new Promise<void>(r => (confirm = r));
+        db.find(r => r.id === id)!.votes++;
+        refresh(list as any);
+      });
+      const row = (label: string) => list.find(r => r.label === label);
+      const watch = (name: string, q: () => unknown) =>
+        createRenderEffect(
+          () => isPending(q),
+          p => {
+            seen[name] = p;
+          }
+        );
+      watch("tacos.id", () => row("Tacos")?.id);
+      watch("burritos.id", () => row("Burritos")?.id);
+      watch("burritos.votes", () => row("Burritos")?.votes);
+      watch("burritos.label", () => row("Burritos")?.label);
+      watch("length", () => list.length);
+    });
+    flush();
+    fetcher.resolveAll();
+    await tick();
+    expect(seen).toEqual({
+      "tacos.id": false,
+      "burritos.id": false,
+      "burritos.votes": false,
+      "burritos.label": false,
+      length: false
+    });
+
+    vote(1);
+    flush();
+    // Held write: the declared mark pends; the sibling row does not.
+    expect(seen["tacos.id"]).toBe(true);
+    expect(seen["burritos.id"]).toBe(false);
+
+    // Server confirms, the action refreshes: the refetch is in flight. The
+    // mark still pends; every other leaf stays silent.
+    confirm();
+    await tick();
+    await tick();
+    expect(fetcher.calls).toBe(2);
+    expect(seen).toEqual({
+      "tacos.id": true,
+      "burritos.id": false,
+      "burritos.votes": false,
+      "burritos.label": false,
+      length: false
+    });
+
+    fetcher.resolveAll();
+    await tick();
+    await tick();
+    expect(list.find(r => r.label === "Tacos")!.votes).toBe(1);
+    expect(seen).toEqual({
+      "tacos.id": false,
+      "burritos.id": false,
+      "burritos.votes": false,
+      "burritos.label": false,
+      length: false
+    });
+    dispose();
+  });
+
   it("3.4: polling (repeated refresh) stays silent every cycle", async () => {
     const t = createThing();
     await settleInitial(t);


### PR DESCRIPTION
## Summary

An action doing `affects(row, "id"); setList(...); yield save(); refresh(list)` on a plain derived store lit up `isPending(() => item.id)` on **every** row during the refetch, not just the marked one.

## Root cause

The `setList` puts a manual-write mask on the derived store, held open by the action's transaction. When `refresh(list)` runs after the yield it lifts that mask (#3026), and the lift deliberately skipped the re-ask classification. Without it the refetch was treated as a brand-new question, and a new question pends every leaf. A mark can only turn pending on, so `affects()` could not narrow it.

Measured on the app shape:

| variant | during the refetch |
|---|---|
| plain store, no write, `refresh` | silent |
| plain store, `setList` + `refresh`, with or without `affects` | every leaf pends, both rows |
| optimistic store, write + `affects(row,"id")` + `refresh` | only the marked slot pends |

## Fix

The lift falls through to the normal re-ask marking. Same-question motion stays silent; only the written slot and any declared `affects()` mark read pending until the truth lands. Same-tick precedence (#2692) is unchanged, and the #3026 refresh-in-action tests still pass.

## Tests

`tests/question-scoped-pending.test.ts` gains `3.4-held-write`: the marked slot pends from click through landing, every sibling leaf and the array length stay silent. Verdicts are observed through tracked readers, as JSX reads them; a bare `isPending()` after the generator returns sees the mark as already released because nothing subscribed keeps the transaction alive through the refetch. Fails without the fix at the refetch-window assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
