### PR TITLE
fix(signals): draft reads compose overrides over a truth-staged backing

### DIFF
--- a/.changeset/optimistic-draft-reads-compose-over-staged-truth.md
+++ b/.changeset/optimistic-draft-reads-compose-over-staged-truth.md
@@ -1,0 +1,16 @@
+---
+"@solidjs/signals": patch
+---
+
+Optimistic increments keep stacking after a sibling landing. With several
+optimistic-store actions in flight (optimistic `votes++`, server confirm,
+`refresh(store)`), the first vote's truth landing is staged into the
+transaction that still retains the second vote, and that vote's increment
+replays over it. A third click's draft then read the staged truth WITHOUT
+the replayed override: draft reads composed live overrides only while no
+pending backing existed, and `votes++` reads before the first write triggers
+the view-reseed hand-off. It read base, wrote base + 1, and its override
+landed on the value already on screen — the click was invisible and the
+count stuck (or fell back) until truth caught up. Draft reads now compose
+overrides whenever the pending backing is not the draft's own view-seeded
+clone.

--- a/packages/signals/src/store/next/store.ts
+++ b/packages/signals/src/store/next/store.ts
@@ -635,6 +635,22 @@ export const stagedTruthPB = new WeakMap<StoreNextTarget, Record<PropertyKey, an
  * are consumed at setter exit. */
 const tentativePBs = new WeakSet<object>();
 
+/** A draft read composes the live optimistic view until the draft has opened
+ * its OWN view-seeded backing (ensurePB seeds that clone from the view and
+ * registers it in tentativePBs; from then on reads must see the draft's
+ * writes, not the overrides they superseded). A pending backing that exists
+ * for any other reason is not that clone — a truth landing staged into a
+ * retaining transaction (#3164 fold) is authoritative truth WITHOUT the
+ * live overrides. ensurePB parks such a backing on the draft's first WRITE
+ * and reseeds from the view, but the reads that precede that write went to
+ * the staged truth: `votes++` read base, wrote base+1, and the override it
+ * emitted landed on the value already displayed — a second in-flight
+ * increment made after a sibling's landing was invisible (#2951's compose
+ * half, one landing later). */
+function draftSeesOverrides(target: StoreNextTarget): boolean {
+  return target.pb === null || !tentativePBs.has(target.pb);
+}
+
 /** Committed-time privatization for parent-chain slot updates (path copying). */
 function privatizeCommitted(target: StoreNextTarget): void {
   if (ownedRaw.has(target.v)) return;
@@ -1392,7 +1408,7 @@ function serveDataKey(
     // #2951). Once ensurePB runs, the seeded clone carries the view.
     // AUTHORITATIVE drafts (projection derive) never overlay — ensurePB's
     // seeding rule, applied to the read side (#3108).
-    if (target.fam?.opt && target.pb === null && !authoritativeServe()) {
+    if (target.fam?.opt && draftSeesOverrides(target) && !authoritativeServe()) {
       const node = target.n?.[key as any];
       if (node !== undefined && hasActiveOverride(node))
         v = unwrapOverride(node._x?._overrideValue);
@@ -1614,7 +1630,7 @@ const traps: ProxyHandler<StoreNextTarget> = {
         v === undefined &&
         inDraft(target) &&
         target.fam?.opt &&
-        target.pb === null &&
+        draftSeesOverrides(target) &&
         // AUTHORITATIVE drafts (landing folds) never seed from overrides —
         // the caller's optimism is not truth (has-trap twin below).
         !authoritativeServe()
@@ -1655,7 +1671,7 @@ const traps: ProxyHandler<StoreNextTarget> = {
         if (node !== undefined && hasActiveOverride(node))
           present = !!unwrapOverride(node._x?._overrideValue);
       }
-    } else if (target.fam?.opt && target.pb === null && !authoritativeServe()) {
+    } else if (target.fam?.opt && draftSeesOverrides(target) && !authoritativeServe()) {
       const node = target.h?.[key as any];
       if (node !== undefined && hasActiveOverride(node))
         present = !!unwrapOverride(node._x?._overrideValue);
@@ -1688,7 +1704,7 @@ const traps: ProxyHandler<StoreNextTarget> = {
       !authoritativeServe() &&
       target.fam?.opt &&
       target.h !== null &&
-      (!inDraft(target) || target.pb === null)
+      (!inDraft(target) || draftSeesOverrides(target))
     ) {
       let set: Set<PropertyKey> | null = null;
       for (const key of Reflect.ownKeys(target.h)) {

--- a/packages/signals/tests/optimistic-store-refetch-hold.test.ts
+++ b/packages/signals/tests/optimistic-store-refetch-hold.test.ts
@@ -16,11 +16,13 @@
  */
 import { expect, test } from "vitest";
 import {
+  action,
   createEffect,
   createOptimisticStore,
   createRoot,
   createSignal,
-  flush
+  flush,
+  refresh
 } from "../src/index.js";
 
 const tick = () => new Promise(r => setTimeout(r, 0));
@@ -187,4 +189,95 @@ test("#2951: bare write on a derived store with settled truth keeps flash semant
   flush();
   expect(views.at(-1)).toEqual(["A"]);
   dispose();
+});
+
+// The compose half, one landing later: three votes in flight as actions
+// (optimistic `votes++`, server confirm, `refresh(store)`). When the first
+// vote's truth lands while the second is still retained, the landing is
+// staged into the retaining transaction and the second vote's increment is
+// replayed over it. A THIRD click's draft then read the staged truth WITHOUT
+// that replayed override (draft reads composed overrides only while no
+// pending backing existed — ensurePB's hand-off reseeds from the view on
+// the first write, but `votes++` reads first): base 1, wrote 2, and the
+// override landed on the value already displayed — the click was invisible
+// and the count stuck until truth caught up.
+test("#2951 compose half: an increment made after a sibling landing still stacks on the retained increment", async () => {
+  type Row = { id: number; votes: number };
+  const db: Row[] = [{ id: 1, votes: 0 }];
+  const fetches: Array<() => void> = [];
+  const getList = () => new Promise<Row[]>(res => fetches.push(() => res(structuredClone(db))));
+  const confirms: Array<() => void> = [];
+  const addVote = () =>
+    new Promise<void>(res =>
+      confirms.push(() => {
+        db[0].votes++;
+        res();
+      })
+    );
+  const views: number[] = [];
+  let list!: Row[];
+  let vote!: () => unknown;
+  let dispose!: () => void;
+  createRoot(d => {
+    dispose = d;
+    let setList!: (fn: (l: Row[]) => void) => void;
+    [list, setList] = createOptimisticStore<Row[]>(() => getList(), []);
+    vote = action(function* () {
+      setList(l => {
+        l[0].votes++;
+      });
+      yield addVote();
+      refresh(list as any);
+    });
+    createEffect(
+      () => list[0]?.votes,
+      v => {
+        views.push(v);
+      }
+    );
+  });
+  flush();
+  fetches.shift()!();
+  await tick();
+  flush();
+  const settle = async () => {
+    await tick();
+    flush();
+    await tick();
+    flush();
+  };
+
+  vote(); // A
+  await settle();
+  vote(); // B
+  await settle();
+  expect(list[0].votes).toBe(2);
+
+  confirms.shift()!(); // A confirmed → A refreshes
+  await settle();
+  fetches.shift()!(); // A's truth (1) lands; B still in flight, its +1 replays
+  await settle();
+  expect(list[0].votes).toBe(2);
+
+  vote(); // C: must stack on B's retained increment, not on the staged truth
+  await settle();
+  expect(list[0].votes).toBe(3);
+
+  confirms.shift()!();
+  await settle();
+  fetches.shift()!(); // B's truth (2) lands; C's +1 replays
+  await settle();
+  expect(list[0].votes).toBe(3);
+
+  confirms.shift()!();
+  await settle();
+  fetches.shift()!(); // C's truth (3) lands
+  await settle();
+  expect(list[0].votes).toBe(3);
+  // Every visible value is monotonic — no click ever reads back a smaller
+  // count (equal-value re-runs at a landing's override → committed swap are
+  // fine).
+  expect(views.filter((v, i) => i === 0 || v !== views[i - 1])).toEqual([0, 1, 2, 3]);
+  dispose();
+  flush();
 });


### PR DESCRIPTION
## Summary

With several optimistic-store actions in flight (optimistic `votes++`, server confirm, `refresh(store)`), rapid clicks rendered 1, 2, 3, 4, then **fell back to 2**, then 5, while the server counted every vote. Reproduces identically at the core with a plain promise source and with an async-generator (live stream) source, so the transport is not involved.

## Root cause

When the first vote's truth lands while the second is still retained, the landing is staged into the retaining transaction (#3164 fold) and the second vote's `+1` replays over it. A third click's draft then read the staged truth **without** the replayed override: the four draft-read paths (data key, hot path, `has`, `ownKeys`) composed live overrides only while `target.pb === null`, on the assumption that an existing pending backing was the draft's own view-seeded clone. A truth-staged backing is authoritative truth without overrides. `ensurePB`'s hand-off parks such a backing and reseeds from the view on the draft's first **write**, but `votes++` reads first — it read base, wrote base + 1, and the override it emitted landed on the value already displayed. The click was invisible and the count stuck (or fell back) until truth caught up.

Minimal sequence:

| step | expected | before |
|---|---|---|
| click A | 1 | 1 |
| click B | 2 | 2 |
| A's truth (1) lands, B retained | 2 | 2 |
| click C | 3 | **2** |
| B's truth (2) lands | 3 | **2** |
| C's truth (3) lands | 3 | 3 |

## Fix

`draftSeesOverrides(target)`: draft reads compose overrides whenever the pending backing is not the draft's own tentative clone (`tentativePBs`), applied to all four draft paths. Nothing changes for a draft that has opened its own backing (reads must see its writes) or for authoritative drafts.

## Tests

`tests/optimistic-store-refetch-hold.test.ts` gains "#2951 compose half": three votes in flight, the third made after the first landing, every visible value monotonic. Fails without the fix at click C (`expected 2 to be 3`). A ten-click replay on the app's exact schedule renders 1 through 10 with each click instant. Full signals suite, solid suite, and the web Loading/optimistic/store specs pass on the rebuilt dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
