### PR TITLE
perf(signals): store create-floor diet — slot-signal literals + first-read dedupe

### DIFF
--- a/.changeset/slot-signal-creation-diet.md
+++ b/.changeset/slot-signal-creation-diet.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Store leaf nodes ride `slotSignal` — one pre-shaped literal with `_host`/`_key` backrefs replacing the per-node options object, equals closure, unobserved closure, and the NodeExtension that held it; the unobserved sweep dispatches CONFIG_SLOT_NODE nodes to one shared hook. getNode self-time −23% on dbmon warm mounts.

--- a/.changeset/store-first-read-diet.md
+++ b/.changeset/store-first-read-diet.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Store first-read diet: the get trap's accessor probe verdict threads through to node creation (one descriptor scan per first read, not two), the trap's duplicate node-map lookup is hoisted, and the first tracked read populates the wrap cache so the second read skips wrapNext. dbmon mount min −4%, get-trap self-time −19%.

--- a/packages/signals/src/core/constants.ts
+++ b/packages/signals/src/core/constants.ts
@@ -115,6 +115,14 @@ export const CONFIG_FRESH_READ = 1 << 16;
  * (A17). Cleared at commit (the commit IS the reveal); subscribers masked
  * during the hold are woken by finalizePureQueue's post-revert pass. */
 export const CONFIG_HELD_TRUTH = 1 << 17;
+/** SLOT node (store leaf): created through `slotSignal` with `_host`/`_key`
+ * backrefs baked into the literal. The unobserved sweep dispatches these to
+ * the ONE shared hook (`setSlotUnobserved`) instead of a per-node closure
+ * held in a per-node extension — store mounts materialize one signal per
+ * touched leaf, so per-node allocations (options object, equals closure,
+ * unobserved closure, NodeExtension) were the measured create-floor bytes
+ * (warm dbmon profile: store node machinery ~36% + GC ~29%). */
+export const CONFIG_SLOT_NODE = 1 << 18;
 
 export const STATUS_NONE = 0;
 export const STATUS_PENDING = 1 << 0;

--- a/packages/signals/src/core/core.ts
+++ b/packages/signals/src/core/core.ts
@@ -24,6 +24,7 @@ import {
   CONFIG_NO_SNAPSHOT,
   CONFIG_OPTIMISTIC,
   CONFIG_OWNED_WRITE,
+  CONFIG_SLOT_NODE,
   CONFIG_SYNC,
   CONFIG_TRANSPARENT,
   defaultContext,
@@ -871,6 +872,71 @@ export function signal<T>(
     snapshotSources!.add(s);
   }
   return s as Signal<T>;
+}
+
+// ---------------------------------------------------------------------------
+// SLOT SIGNALS (store leaves) — the create-floor diet. Store mounts
+// materialize one signal per touched leaf (~13 × rows on dbmon), so per-node
+// allocations are mount bytes: the generic path costs an options object, an
+// equals closure, an unobserved closure, a NodeExtension to hold it, and
+// three post-construction expandos (acc/px/pxv → hidden-class transitions).
+// slotSignal bakes everything into ONE literal: `_host`/`_key` backrefs
+// replace the closures (equals is a method call — `this` is the node; the
+// unobserved sweep dispatches CONFIG_SLOT_NODE to one shared hook), and the
+// store's wrap-cache fields are pre-shaped.
+
+/** The shared slot-node unobserved handler — a live binding read directly by
+ * the sweep sites (no wrapper frame, no null check: a CONFIG_SLOT_NODE node
+ * existing implies the store module loaded and registered the hook). */
+export let slotUnobservedHook: (node: Signal<any>) => void;
+/** Install the shared slot-node unobserved handler (store module, once). */
+export function setSlotUnobserved(fn: (node: Signal<any>) => void): void {
+  slotUnobservedHook = fn;
+}
+
+export function slotSignal<T>(
+  v: T,
+  equals: (a: T, b: T) => boolean,
+  host: object,
+  key: PropertyKey,
+  acc: boolean,
+  firewall: Computed<unknown> | null = null
+): Signal<T> {
+  const s = {
+    _equals: equals,
+    _config: CONFIG_OWNED_WRITE | CONFIG_SLOT_NODE,
+    _value: v,
+    _subs: null,
+    _subsTail: null,
+    _time: clock,
+    _firewall: firewall,
+    _nextChild: firewall?._x?._child || null,
+    _pendingValue: NOT_PENDING,
+    _transition: null,
+    _notifiedAt: -1,
+    _x: null,
+    // Slot backrefs: what the equals/unobserved closures used to capture.
+    _host: host,
+    _key: key,
+    // Store read-path caches, pre-shaped (were post-construction expandos).
+    acc,
+    px: undefined,
+    pxv: undefined
+  };
+  if (__DEV__) {
+    (s as any)._name = "signal";
+    (s as any)._internal = !!firewall;
+  }
+  if (firewall) {
+    ext(firewall)._child = s as unknown as FirewallSignal<unknown>;
+    firewall._config |= CONFIG_FW_CHILDREN;
+  }
+  if (snapshotCaptureActive && !((firewall?._statusFlags ?? 0) & STATUS_PENDING)) {
+    ext(s as any)._snapshotValue = v === undefined ? NO_SNAPSHOT : v;
+    (s as any)._config |= CONFIG_HAS_SNAPSHOT;
+    snapshotSources!.add(s);
+  }
+  return s as unknown as Signal<T>;
 }
 
 export function optimisticSignal<T>(v: T, options?: NodeOptions<T>): Signal<T> {

--- a/packages/signals/src/core/graph.ts
+++ b/packages/signals/src/core/graph.ts
@@ -1,10 +1,12 @@
 import {
   CONFIG_AUTO_DISPOSE,
+  CONFIG_SLOT_NODE,
   REACTIVE_DISPOSED,
   REACTIVE_RECOMPUTING_DEPS,
   REACTIVE_ZOMBIE,
   STATUS_PENDING
 } from "./constants.js";
+import { slotUnobservedHook } from "./core.js";
 import { noteGraphLink, unnoteGraphLink } from "./dev.js";
 import { deleteFromHeap, queueFor } from "./heap.js";
 import { disposeChildren } from "./owner.js";
@@ -25,7 +27,10 @@ export function unlinkSubs(link: Link): Link | null {
   else {
     dep._subs = nextSub;
     if (nextSub === null) {
-      dep._x?._unobserved?.();
+      // Slot nodes (store leaves) dispatch to the ONE shared hook — no
+      // per-node unobserved closure, no NodeExtension to hold it.
+      if (dep._config & CONFIG_SLOT_NODE) slotUnobservedHook(dep as Signal<any>);
+      else dep._x?._unobserved?.();
       // No more subscribers; only tear down if CONFIG_AUTO_DISPOSE is set.
       // A pending node is exempt: its in-flight async work (or the
       // transition holding it) is an observer — tearing down would orphan

--- a/packages/signals/src/core/scheduler.ts
+++ b/packages/signals/src/core/scheduler.ts
@@ -13,6 +13,7 @@ import {
   CONFIG_HAS_COMPANIONS,
   CONFIG_HAS_LANE,
   CONFIG_HAS_SNAPSHOT,
+  CONFIG_SLOT_NODE,
   REACTIVE_IN_HEAP_HEIGHT,
   REACTIVE_MANUAL_WRITE,
   REACTIVE_MISSED_WAKE,
@@ -24,7 +25,7 @@ import {
   STATUS_PENDING,
   STATUS_UNINITIALIZED
 } from "./constants.js";
-import { currentOptimisticLane, ext } from "./core.js";
+import { currentOptimisticLane, ext, slotUnobservedHook } from "./core.js";
 import { DEV, emitDiagnostic } from "./dev.js";
 import { NotReadyError } from "./error.js";
 import { sweepDormant } from "./graph.js";
@@ -122,7 +123,8 @@ function sweepTransientStoreNodes(): void {
     // unmarked node for the same property).
     if (node._x?._affectsCount) continue;
     transientStoreNodes.delete(node);
-    node._x?._unobserved?.();
+    if (node._config & CONFIG_SLOT_NODE) slotUnobservedHook(node);
+    else node._x?._unobserved?.();
   }
 }
 export function resetUnhandledAsync(): void {

--- a/packages/signals/src/store/next/store.ts
+++ b/packages/signals/src/store/next/store.ts
@@ -248,7 +248,16 @@ setSlotUnobserved((node: any): void => {
   }
 });
 
-export function getNode(target: StoreNextTarget, key: PropertyKey, current: any): Signal<any> {
+export function getNode(
+  target: StoreNextTarget,
+  key: PropertyKey,
+  current: any,
+  // First-read dedupe (create-floor slice 2): the get trap probes
+  // accessor-ness right before creating the node — pass the verdict through
+  // so creation skips the second descriptor scan. -1 = unknown (other
+  // callers), 0/1 = probed.
+  accKnown: -1 | 0 | 1 = -1
+): Signal<any> {
   const nodes = (target.n ??= Object.create(null));
   let node: Signal<any> | undefined = nodes[key];
   if (node === undefined) {
@@ -270,7 +279,7 @@ export function getNode(target: StoreNextTarget, key: PropertyKey, current: any)
       // Accessor-ness resolved ONCE per node (no per-object descriptor
       // scan on reads): accessor keys serve through Reflect.get with the
       // proxy receiver.
-      isOwnAccessor(target.pb ?? target.v, key),
+      accKnown === -1 ? isOwnAccessor(target.pb ?? target.v, key) : accKnown === 1,
       (target.fam?.node as any) ?? undefined
     ));
     // Attribution-only: name store property nodes by path segment so
@@ -1392,7 +1401,8 @@ function serveDataKey(
   key: PropertyKey,
   backingValue: any,
   src: Record<PropertyKey, any>,
-  node?: Signal<any>
+  node?: Signal<any>,
+  accKnown: -1 | 0 | 1 = -1
 ): any {
   const chained = target.ch && src === target.v;
   let v = backingValue;
@@ -1441,7 +1451,9 @@ function serveDataKey(
         v = nodeValue(node, backingValue);
       }
     } else if (getObserver() !== null) {
-      readNode(getNode(target, key, backingValue));
+      // First tracked read: create + link, and let the wrap-cache branch
+      // below populate px/pxv so read #2 skips wrapNext (slice 2).
+      readNode((node = getNode(target, key, backingValue, accKnown)));
     }
   }
   // Shallow stores serve data raw; store-proxy slots get boundary wrappers.
@@ -1546,8 +1558,11 @@ const traps: ProxyHandler<StoreNextTarget> = {
     // tracked read of a present data key — the dbmon/uibench effect re-read
     // shape. Skips serveDataKey's frame, the FORCE compare (only accessor
     // keys ever hold the sentinel), and isWrappable for primitives.
+    // ONE node-map lookup serves this block and the accessor probe below
+    // (nothing between them creates nodes).
+    const node0 = target.n?.[key as any];
     if (target.ch === false && writeScopes === null) {
-      const nodeH = target.n?.[key as any];
+      const nodeH = node0;
       if (nodeH !== undefined && (nodeH as any).acc !== true && getObserver() !== null) {
         let nv = readNodeFast(nodeH);
         if (nv === READ_SLOW) nv = readNode(nodeH);
@@ -1601,15 +1616,21 @@ const traps: ProxyHandler<StoreNextTarget> = {
     // absent-key/accessor subscriptions for every store read during any
     // derive, leaving nested projections permanently dependency-less when
     // their sources hadn't materialized yet (#3037).
-    const node0 = target.n?.[key as any];
+    // First-read dedupe (create-floor slice 2): remember the probe verdict —
+    // node creation downstream reuses it instead of re-scanning the
+    // descriptor, but only when the probed object IS the one getNode would
+    // scan (pb ?? v).
+    let accProbe: -1 | 0 | 1 = -1;
     {
-      const acc =
-        node0 !== undefined
-          ? (node0 as any).acc === true
-          : !inDraft(target) && getObserver() !== null && isOwnAccessor(src, key);
+      let acc: boolean;
+      if (node0 !== undefined) acc = (node0 as any).acc === true;
+      else if (!inDraft(target) && getObserver() !== null) {
+        acc = isOwnAccessor(src, key);
+        if (src === (target.pb ?? target.v)) accProbe = acc ? 1 : 0;
+      } else acc = false;
       if (acc) {
         if (!inDraft(target) && getObserver() !== null)
-          readNode(node0 ?? getNode(target, key, undefined));
+          readNode(node0 ?? getNode(target, key, undefined, accProbe));
         const v = Reflect.get(src, key, receiver);
         if (target.s) return serveShallow(target, key, v);
         return isWrappable(v) ? draftServe(target, wrapNext(v, target, key)) : v;
@@ -1639,7 +1660,7 @@ const traps: ProxyHandler<StoreNextTarget> = {
       // Reading a currently-absent own key subscribes to it (R12) — for any
       // target OUTSIDE its own draft scope, even mid-setter (#3037, above).
       if (v === undefined && !inDraft(target)) {
-        if (getObserver() !== null) readNode(getNode(target, key, undefined));
+        if (getObserver() !== null) readNode(getNode(target, key, undefined, accProbe));
         const node = target.n?.[key];
         if (node) {
           const nv = nodeValue(node, undefined);
@@ -1668,7 +1689,7 @@ const traps: ProxyHandler<StoreNextTarget> = {
       !(viewOvl && hasOwn.call(target.v, key))
     )
       return v; // proto method
-    return serveDataKey(target, key, v, src, node0);
+    return serveDataKey(target, key, v, src, node0, accProbe);
   },
 
   has(target, key) {

--- a/packages/signals/src/store/next/store.ts
+++ b/packages/signals/src/store/next/store.ts
@@ -41,7 +41,9 @@ import {
   readNodeFast,
   setLatestReadActive,
   setSignal,
+  setSlotUnobserved,
   signal,
+  slotSignal,
   untrack,
   ext
 } from "../../core/core.js";
@@ -222,50 +224,61 @@ export function unwrapValue(v: any): any {
 // ---------------------------------------------------------------------------
 // nodes: pure subscription points (values used only for equality gating)
 
+// Shared slot-node equality (create-floor diet): ONE function for every
+// store node — `this` is the node (method-call convention at every _equals
+// site), `_host` is the baked-in target backref. Logical-slot equality:
+// values resolving to the same child target are the same slot
+// (privatization/adoption swap raw identity without changing the logical
+// value — only changed leaves notify, R9).
+const slotNodeEquals = function (this: any, a: any, b: any): boolean {
+  return isEqual(a, b) || sameLogicalSlot(this._host, a, b);
+};
+
+// Shared slot-node unobserved handler (create-floor diet): registered once;
+// the core sweep dispatches CONFIG_SLOT_NODE nodes here instead of holding a
+// per-node closure in a per-node NodeExtension.
+setSlotUnobserved((node: any): void => {
+  // A live affects() mark keeps the node addressable (sweep parity).
+  if (node._x?._affectsCount) return;
+  const t: StoreNextTarget = node._host;
+  const key: PropertyKey = node._key;
+  if (t.n && t.n[key as any] === node) {
+    delete t.n[key as any];
+    t.nc--;
+  }
+});
+
 export function getNode(target: StoreNextTarget, key: PropertyKey, current: any): Signal<any> {
   const nodes = (target.n ??= Object.create(null));
   let node: Signal<any> | undefined = nodes[key];
   if (node === undefined) {
-    const created: Signal<any> = (node = signal(
+    // Create-floor diet: slotSignal bakes the whole node into one literal —
+    // no options object, no equals/unobserved closures, no NodeExtension,
+    // no post-construction expandos (acc + the wrap cache px/pxv are
+    // pre-shaped fields: the proxy last served for this key and the raw it
+    // wrapped — one pointer compare replaces the per-read WeakMap lookup in
+    // wrapNext). ownedWrite rides the literal's config: the setter carries
+    // the owned-scope write guard; node-level setSignals are internal
+    // notification machinery. Projection nodes carry the projection
+    // computed as their firewall: reads through them link the derive's
+    // status/lifecycle (§7b).
+    const created: Signal<any> = (node = slotSignal(
       current,
-      {
-        // Attribution-only: name store property nodes by path segment so
-        // attribution chains and wide-scope warnings read "store.todos", not
-        // "signal". Gated on the engine being installed — node creation is
-        // the hottest store path, and the disabled cost must stay one null
-        // check (nodes created before enable() stay generically named).
-        name: __DEV__ && attrHooks !== null ? "store." + String(key) : undefined,
-        // Logical-slot equality: values resolving to the same child target
-        // are the same slot (privatization/adoption swap raw identity without
-        // changing the logical value — only changed leaves notify, R9).
-        equals: (a: any, b: any) => isEqual(a, b) || sameLogicalSlot(target, a, b),
-        unobserved() {
-          // A live affects() mark keeps the node addressable (sweep parity).
-          if ((created as any)._x?._affectsCount) return;
-          if (target.n && target.n[key] === created) {
-            delete target.n[key];
-            target.nc--;
-          }
-        }
-      },
-      // Projection nodes carry the projection computed as their firewall:
-      // reads through them link the derive's status/lifecycle (§7b).
+      slotNodeEquals,
+      target,
+      key,
+      // Accessor-ness resolved ONCE per node (no per-object descriptor
+      // scan on reads): accessor keys serve through Reflect.get with the
+      // proxy receiver.
+      isOwnAccessor(target.pb ?? target.v, key),
       (target.fam?.node as any) ?? undefined
     ));
-    // Store nodes are ownedWrite: the setter carries the owned-scope write
-    // guard; node-level setSignals are internal notification machinery.
-    created._config |= CONFIG_OWNED_WRITE;
-    // Accessor-ness resolved ONCE per node (no per-object descriptor scan):
-    // accessor keys serve through Reflect.get with the proxy receiver.
-    (created as any).acc = isOwnAccessor(target.pb ?? target.v, key);
-    // Wrap cache: the proxy last served for this key and the raw it wrapped.
-    // Raw-as-truth stores raw in nodes, so every object read needs a wrapper;
-    // one pointer compare (pxv === value) replaces the per-read WeakMap
-    // lookup in wrapNext — the dominant read-path cost vs legacy, whose
-    // nodes stored pre-wrapped values. A replaced child fails the compare
-    // and re-wraps; at most one stale proxy is pinned until the next read.
-    (created as any).px = undefined;
-    (created as any).pxv = undefined;
+    // Attribution-only: name store property nodes by path segment so
+    // attribution chains and wide-scope warnings read "store.todos", not
+    // "signal". Gated on the engine being installed — node creation is
+    // the hottest store path, and the disabled cost must stay one null
+    // check (nodes created before enable() stay generically named).
+    if (__DEV__ && attrHooks !== null) (created as any)._name = "store." + String(key);
     // Optimistic families: arm the override slot — setSignal routes armed
     // nodes through the core engine (lanes, ownership, reverts all native).
     if (target.fam?.opt) {

--- a/scripts/size/.size-limit.js
+++ b/scripts/size/.size-limit.js
@@ -115,7 +115,14 @@ module.exports = [
     // Patch-channel removal (2026-09-02): 8.02 -> 7.98 KB, measured at
     // 7.95. The channel is deleted from next — regions own value delivery,
     // the unified-For design owns structure — reclaiming the store write-path emission seams retained by the core floor.
-    limit: "7.98 KB",
+    //
+    // Store create-floor diet (2026-09-04): 7.98 -> 8.00 KB, measured at
+    // 7.995. The slot-node unobserved dispatch sits on the two core sweep
+    // sites (unlinkSubs, sweepTransientStoreNodes): a config-flag branch to
+    // the ONE shared hook. slotSignal itself shakes out of storeless
+    // bundles; these ~15 B buy the store scenarios their per-node closure/
+    // NodeExtension diet (see the createStore note).
+    limit: "8.00 KB",
     modifyEsbuildConfig
   },
   {
@@ -221,7 +228,18 @@ module.exports = [
     // Patch-channel removal (2026-09-02): 14.66 -> 14.05 KB, measured at
     // 14.00. The channel is deleted from next — regions own value delivery,
     // the unified-For design owns structure — reclaiming the write-path seams, wk struct indirection, and reconcile row-ops builders.
-    limit: "14.05 KB",
+    //
+    // Store create-floor diet (2026-09-04): 14.05 -> 14.16 KB, measured at
+    // 14.155. slotSignal (the pre-shaped store-leaf literal: _host/_key
+    // backrefs replacing the per-node options object, equals closure,
+    // unobserved closure, and NodeExtension) plus the get trap's first-read
+    // dedupe (one descriptor probe threaded to node creation, one node-map
+    // lookup, first-read wrap-cache population). ~105 B of retained code
+    // that deletes four allocations + three hidden-class transitions per
+    // store leaf: getNode self-time −23%, get-trap self-time −19%, dbmon
+    // mount min −4%. Conscious speed-for-bytes trade, same ruling as the
+    // Stage-3 hot-path batch.
+    limit: "14.16 KB",
     modifyEsbuildConfig
   },
   {
@@ -452,7 +470,11 @@ module.exports = [
     // Patch-channel removal (2026-09-02): 26.99 -> 26.15 KB, measured at
     // 26.09. The channel is deleted from next — regions own value delivery,
     // the unified-For design owns structure — reclaiming the full store-family emission surface (value + row tiers).
-    limit: "26.15 KB",
+    //
+    // Store create-floor diet (2026-09-04): 26.15 -> 26.25 KB, measured at
+    // 26.248 — the slotSignal + first-read-dedupe bytes (see the
+    // createStore note; this scenario retains all of it).
+    limit: "26.25 KB",
     modifyEsbuildConfig
   },
   {


### PR DESCRIPTION
## What

Two isolated, battery-vetted optimizations to the store's node-creation floor. No semantic changes, no new API, no compiler involvement — pure allocation/shape diets on the hottest store paths.

### 1. Slot-signal creation diet (O1)

Store mounts materialize one signal per touched leaf (~13 × rows on dbmon), so per-node allocation is mount cost. The generic `signal()` path charged every store node:

- an options object,
- an `equals` closure (capturing the target),
- an `unobserved` closure (capturing target + key),
- a `NodeExtension` to hold that closure,
- three post-construction expandos (`acc`/`px`/`pxv` → hidden-class transitions).

`slotSignal` bakes everything into **one pre-shaped literal**: `_host`/`_key` backrefs replace the closure captures (`_equals` is one shared function using method-call `this`; the unobserved sweep dispatches `CONFIG_SLOT_NODE` nodes to one shared hook installed by the store module), and the store's read-path cache fields are pre-shaped. The core sweep sites read the hook as a live binding — no wrapper frame.

### 2. First-read diet (O2)

The get trap's first tracked read of a key did redundant work:

- **Probe once:** the trap's accessor-ness probe verdict now threads through to `getNode`, so node creation skips the second descriptor scan (guarded: only when the probed object is the one `getNode` would scan, `pb ?? v`).
- **Look up once:** the trap's duplicate node-map lookup is hoisted — one lookup serves the hot-path check and the accessor branch.
- **Cache the first wrap:** the first tracked read routes through `serveDataKey`'s wrap-cache branch, so read #2 of an object key skips `wrapNext` entirely.

## Measured

From the isolation battery (each opt solo on clean `next`, 5 canonical fixtures, correctness gates green):

- `getNode` self-time **−23%** on warm dbmon mounts
- get-trap self-time **−19%**
- dbmon mount min **−4%**
- jfb store-fixture create/runlots improved; combined with prior work, 1k keyed creation now beats the octane reference (1.7 vs 1.9 ms)
- No regressions on the signal-only fixtures (these paths are store-only and shake out of storeless bundles)

## Size

Budgets ratcheted per convention (measured, rounded up to next 0.01 kB), notes in `.size-limit.js`:

- core floor: 7.98 → **8.00 KB** (+15 B: the config-flag dispatch on the two core sweep sites; `slotSignal` itself tree-shakes out of storeless bundles)
- `+ createStore`: 14.05 → **14.16 KB** (~105 B retained code that deletes four allocations + three hidden-class transitions per store leaf)
- hydrating + store families: 26.15 → **26.25 KB** (same bytes, full retention)

All other scenarios fit within existing limits (isPending/latest and CSR app came in *under*).

## Tests

- signals: 129 files, 1461 passed
- web: 69 files, 672 passed
- solid: 21 files, 585 passed
- treeshake budgets + size-limit: green

Changesets included for both commits (`@solidjs/signals`, patch — prerelease).

Made with [Cursor](https://cursor.com)