### PR TITLE
ci: bump cve-lite-cli action from v1.29.0 to v1.32.0

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,36 @@
+name: CVE Lite dependency audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for vulnerabilities
+        uses: OWASP/cve-lite-cli@5304b338b624e23922c723b284a1b58c0a74f7fa # v1.32.0
+        with:
+          sarif: "true"
+
+      - name: Upload SARIF to Code Scanning
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: .
+          category: cve-lite


### PR DESCRIPTION
Bumps the CVE Lite CLI action from v1.29.0 to v1.32.0.

Your workflow has been failing on every run since adoption because of a bug where not setting `fail-on` still caused the step to exit 1 on critical findings (the CLI's internal default was applying even when the action documented `""` as "no threshold"). This was fixed in v1.31.0.

The only change here is the SHA pin:

- `fd481fff` (v1.29.0) - has the fail-on bug
- `5304b338` (v1.32.0) - fixed, also includes EPSS Priority Signal and several remediation improvements since July

No other configuration changes.
