### PR TITLE
ci: bump cve-lite-cli action from v1.29.0 to v1.32.0

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Scan for vulnerabilities
-        uses: OWASP/cve-lite-cli@fd481fff75f492f94de36dcaf020674af0eca9ef # v1.29.0
+        uses: OWASP/cve-lite-cli@5304b338b624e23922c723b284a1b58c0a74f7fa # v1.32.0
         with:
           sarif: "true"
 


### PR DESCRIPTION
Bumps the CVE Lite CLI action from v1.29.0 to v1.32.0.

Your workflow has been failing on every run since adoption because of a bug where not setting `fail-on` still caused the step to exit 1 on critical findings (the CLI's internal default was applying even when the action documented `""` as "no threshold"). This was fixed in v1.31.0.

The only change here is the SHA pin:

- `fd481fff` (v1.29.0) - has the fail-on bug
- `5304b338` (v1.32.0) - fixed, also includes EPSS Priority Signal and several remediation improvements since July

No other configuration changes.
