### PR TITLE
fix(signals): suspend uninitialized async across lanes

### DIFF
--- a/.changeset/fix-latest-conditional-async-gate.md
+++ b/.changeset/fix-latest-conditional-async-gate.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Suspend uninitialized async values across optimistic lanes so `latest()`-conditioned branches wait for their first value instead of rendering `undefined`.

--- a/packages/signals/src/core/core.ts
+++ b/packages/signals/src/core/core.ts
@@ -1204,9 +1204,16 @@ export function read<T>(el: Signal<T> | Computed<T>): T {
         console.warn(message);
       }
       // Per-lane suspension lives with the engine (a non-null lane implies it
-      // is installed): under a lane, only same-lane pending async without an
-      // active override throws.
-      if (currentOptimisticLane === null || GlobalQueue._laneSuspends!(owner)) {
+      // is installed): under a lane, same-lane pending async without an active
+      // override throws; uninitialized async sources always suspend.
+      // A lane mismatch can preserve an already committed stale value, but an
+      // uninitialized async source has no such value. Never let that path
+      // surface `undefined` while a conditional branch is being updated.
+      if (
+        currentOptimisticLane === null ||
+        owner._statusFlags & STATUS_UNINITIALIZED ||
+        GlobalQueue._laneSuspends!(owner)
+      ) {
         if (!tracking && el !== c) link(el, c as Computed<any>);
         throw owner._x?._error;
       }

--- a/packages/web/test/latest-conditional-async-issue-3276.spec.tsx
+++ b/packages/web/test/latest-conditional-async-issue-3276.spec.tsx
@@ -1,0 +1,82 @@
+/**
+ * @jsxImportSource @solidjs/web
+ * @vitest-environment jsdom
+ */
+
+import { expect, test } from "vitest";
+import { createSignal, flush, latest } from "solid-js";
+import { render } from "../src/index.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(r => (resolve = r));
+  return { promise, resolve };
+}
+
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+  flush();
+}
+
+test("latest() condition does not reveal an unready async branch (#3276)", async () => {
+  const div = document.createElement("div");
+  const answer = deferred<string>();
+  const trace: Array<Record<string, unknown>> = [];
+  const log = (event: string, details: Record<string, unknown> = {}) => {
+    trace.push({ event, ...details });
+  };
+  let toggle!: () => void;
+
+  const dispose = render(() => {
+    const [entangle, setEntangle] = createSignal(false);
+    const [asyncValue] = createSignal(async () => {
+      log("async.compute.start");
+      const value = await answer.promise;
+      log("async.compute.resolve", { value });
+      return value;
+    });
+    const a = () => {
+      const condition = latest(entangle);
+      log("branch.a", { condition, value: condition ? asyncValue() : "BAD" });
+      return condition ? asyncValue() : "BAD";
+    };
+    const b = () => {
+      const condition = entangle();
+      log("branch.b", { condition, value: condition ? asyncValue() : "OK" });
+      return condition ? asyncValue() : "OK";
+    };
+    toggle = () => {
+      log("toggle.before", { entangle: entangle() });
+      setEntangle(value => !value);
+      log("toggle.after", { entangle: entangle(), latest: latest(entangle) });
+    };
+
+    return (
+      <main>
+        <button onClick={toggle}>toggle</button>
+        <p id="a">{a()}</p>
+        <p id="b">{b()}</p>
+      </main>
+    );
+  }, div);
+
+  expect(div.querySelector("#a")!.textContent).toBe("BAD");
+  expect(div.querySelector("#b")!.textContent).toBe("OK");
+
+  toggle();
+  flush();
+  if (process.env.SOLID_ISSUE_3276_TRACE)
+    process.stderr.write(`ISSUE-3276 TRACE ${JSON.stringify(trace)}\n`);
+
+  // A must obey the same async gate as B: neither branch may expose an
+  // uninitialized value before the async computation resolves.
+  expect(div.querySelector("#a")!.textContent).toBe("BAD");
+  expect(div.querySelector("#b")!.textContent).toBe("OK");
+
+  answer.resolve("ready");
+  await settle();
+  expect(div.querySelector("#a")!.textContent).toBe("ready");
+  expect(div.querySelector("#b")!.textContent).toBe("ready");
+  dispose();
+});


### PR DESCRIPTION
Fixes #3276.

An uninitialized async source has no committed stale value to show. Suspend it even when the reader is running under a different optimistic lane, so a `latest()`-conditioned branch keeps its existing DOM until the source resolves.

Adds a DOM regression test covering `latest(entangle) ? asyncValue() : ...`.

Tests:
- `pnpm exec vitest run test/latest-conditional-async-issue-3276.spec.tsx test/latest-async.spec.tsx test/latest-banner-landing-gap.spec.tsx test/latest-ispending-issue-3041.spec.tsx test/ispending-gated-landing.spec.tsx test/loading.spec.tsx test/dev-warning.spec.tsx`
- `JSX_COMPILER=babel pnpm exec vitest run test/latest-conditional-async-issue-3276.spec.tsx`