### PR TITLE
fix(signals): retain projection parent writes after descendant writes

### DIFF
--- a/.changeset/fix-projection-fold-order.md
+++ b/.changeset/fix-projection-fold-order.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Retain writable projection parent updates when an earlier nested update folds in the same flush.

--- a/packages/signals/src/store/next/store.ts
+++ b/packages/signals/src/store/next/store.ts
@@ -688,9 +688,21 @@ function privatizeCommitted(target: StoreNextTarget): void {
   }
 }
 
+function targetDepth(target: StoreNextTarget): number {
+  let depth = 0;
+  while (target.u !== null) {
+    target = target.u;
+    depth++;
+  }
+  return depth;
+}
+
 function drainFolds(): void {
   if (foldOlds.size === 0) return;
-  const entries = [...foldOlds];
+  // Parent drafts must fold before child drafts. A child fold path-copies its
+  // ancestors; if it runs first, a later parent fold compares against an
+  // outdated slot and its direct write is silently lost (#3271).
+  const entries = [...foldOlds].sort(([a], [b]) => targetDepth(a) - targetDepth(b));
   foldOlds.clear();
   for (const [t, old] of entries) {
     // A latest()-pull staging holds only until the fold commit: this flush

--- a/packages/signals/tests/store/projection-descendant-first-issue-3271.test.ts
+++ b/packages/signals/tests/store/projection-descendant-first-issue-3271.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "vitest";
+import { createRoot, createStore, deep, flush, snapshot, untrack } from "../../src/index.js";
+
+const expected = JSON.stringify([
+  { id: 1, selected: false, children: [{ id: 11, selected: false }] }
+]);
+
+function seed() {
+  return [{ id: 1, selected: true, children: [{ id: 11, selected: true }] }];
+}
+
+function scenario(projection: boolean, descendantFirst: boolean) {
+  return createRoot(() => {
+    const [store, setStore] = projection ? createStore(() => seed(), []) : createStore(seed());
+    untrack(() => deep(store));
+    setStore(prev => {
+      const row = prev[0];
+      const child = row.children[0];
+      if (descendantFirst) {
+        child.selected = false;
+        row.selected = false;
+      } else {
+        row.selected = false;
+        child.selected = false;
+      }
+    });
+    flush();
+    return JSON.stringify(snapshot(untrack(() => deep(store))));
+  });
+}
+
+test("projection stores retain an ancestor write after an earlier descendant write (#3271)", () => {
+  for (const projection of [false, true]) {
+    for (const descendantFirst of [false, true]) {
+      expect(scenario(projection, descendantFirst)).toBe(expected);
+    }
+  }
+});
+
+test("projection folds preserve every direct write across nested sibling orderings (#3271)", () => {
+  const operations = [
+    (row: any) => (row.children[0].selected = false),
+    (row: any) => (row.metadata.active = false),
+    (row: any) => (row.selected = false)
+  ];
+  const orders = [
+    [0, 1, 2],
+    [0, 2, 1],
+    [1, 0, 2],
+    [1, 2, 0],
+    [2, 0, 1],
+    [2, 1, 0]
+  ];
+
+  for (const order of orders) {
+    const result = createRoot(() => {
+      const [store, setStore] = createStore(
+        () => [
+          {
+            id: 1,
+            selected: true,
+            children: [{ id: 11, selected: true }],
+            metadata: { active: true }
+          }
+        ],
+        []
+      );
+      untrack(() => deep(store));
+      setStore(rows => {
+        for (const index of order) operations[index](rows[0]);
+      });
+      flush();
+      return JSON.stringify(snapshot(untrack(() => deep(store))));
+    });
+    expect(result).toBe(
+      JSON.stringify([
+        {
+          id: 1,
+          selected: false,
+          children: [{ id: 11, selected: false }],
+          metadata: { active: false }
+        }
+      ])
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- fold pending store targets from parent to child
- prevent a descendant path copy from invalidating its parent's later fold
- add regression coverage for the reported order and all six three-write orderings

## Test plan

- `pnpm --dir packages/signals exec vitest run`