### PR TITLE
fix(signals): re-wake tracked readers after staged commits

### DIFF
--- a/.changeset/fix-tracked-effect-staged-ref.md
+++ b/.changeset/fix-tracked-effect-staged-ref.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Re-wake tracked effects after a committed-visibility read observes a staged signal value.

--- a/packages/web/test/portal-dynamic-ref-3291.spec.tsx
+++ b/packages/web/test/portal-dynamic-ref-3291.spec.tsx
@@ -1,0 +1,53 @@
+/**
+ * @jsxImportSource @solidjs/web
+ * @vitest-environment jsdom
+ *
+ * Repro for https://github.com/solidjs/solid/issues/3291
+ * A signal written from a ref callback is never observed by an effect
+ * when the element is rendered via <Dynamic> inside a <Portal>.
+ */
+import { describe, expect, test } from "vitest";
+import { createRoot, createSignal, createTrackedEffect, flush } from "solid-js";
+import { Dynamic, Portal, render } from "@solidjs/web";
+
+describe("issue #3291: ref signal not observed through <Dynamic> in <Portal>", () => {
+  test("repro: effect should see the element written from ref", () => {
+    const [el, setEl] = createSignal<HTMLElement>();
+
+    const observations: boolean[] = [];
+    let effectRuns = 0;
+    createTrackedEffect(() => {
+      effectRuns++;
+      observations.push(!!el());
+    });
+    flush();
+
+    const Wrapper = (props: Record<string, unknown>) => <Dynamic {...props} component="div" />;
+
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+
+    const disposer = createRoot(dispose => {
+      render(
+        () => (
+          <Portal>
+            <Wrapper ref={setEl} />
+          </Portal>
+        ),
+        div
+      );
+      return dispose;
+    });
+
+    // The signal should now hold the element.
+    const element = el();
+    expect(element).toBeInstanceOf(HTMLElement);
+
+    // Regression assertion (#3291): the effect MUST be re-run after the ref
+    // write, and that run must observe a truthy element.
+    expect(observations).toContain(true);
+    expect(effectRuns).toBeGreaterThan(1);
+
+    disposer();
+  });
+});


### PR DESCRIPTION
Closes #3291

## What was broken

A signal written by a `ref` callback was not observed by a `createTrackedEffect` when the element was rendered through `<Dynamic>` inside a `<Portal>`.

The write landed in the signal, but the tracked effect ran only once and kept observing the old value.

## Root cause

The rc.6 Dynamic namespace fix made intrinsic elements lazy. In a Portal, that moves `spread()` and the ref write into the render-effect phase. The tracked effect is notified before the staged signal value is committed, but committed-visibility reads intentionally return the old value. The commit then updated the signal without waking the tracked subscriber again.

## Fix

Reuse the existing missed-wake latch when a committed-visibility reader observes a staged signal value. When the signal commits, tracked subscribers are queued again so they observe the committed value.

## Tests

- Added a regression test covering `createTrackedEffect` + `Dynamic` + `Portal` + `ref`.
- `packages/web`: `npx vitest run test/portal-dynamic-ref-3291.spec.tsx`
- Relevant signals tests: `createTrackedEffect.test.ts`, `effect-phase-writes.test.ts`, and `treeshake.test.ts`
