### PR TITLE
fix(signals): keep latest readers out of loading lanes

### DIFF
--- a/.changeset/fix-latest-loading-lane.md
+++ b/.changeset/fix-latest-loading-lane.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Keep `latest()` render readers independent from async Loading optimistic lanes so repeated refreshes are not held until unrelated async work settles.

--- a/packages/signals/src/core/lanes.ts
+++ b/packages/signals/src/core/lanes.ts
@@ -63,7 +63,6 @@ export function getOrCreateLane(signal: Signal<any>): OptimisticLane {
   // the owner's write merges the companion's subscribers into this lane and
   // their effects wait on its async instead of flushing immediately.
   adoptCompanionLane(signal._x?._pendingSignal, lane);
-  adoptCompanionLane(signal._x?._latestValueComputed, lane);
   return lane;
 }
 

--- a/packages/signals/tests/latest-async.test.ts
+++ b/packages/signals/tests/latest-async.test.ts
@@ -19,6 +19,7 @@
  */
 import {
   createMemo,
+  createLoadingBoundary,
   createRenderEffect,
   createRoot,
   createSignal,
@@ -51,6 +52,7 @@ it("latest(asyncMemo) settles to the resolved value and re-reports pending on ea
       await current.promise;
       return `AV${c}`;
     });
+
     createRenderEffect(
       () => latest(asyncValue),
       v => {
@@ -98,4 +100,50 @@ it("latest(asyncMemo) settles to the resolved value and re-reports pending on ea
   await settle();
   expect(latestLog.at(-1)).toBe("AV2");
   expect(pendingLog.at(-1)).toBe(false);
+});
+
+it("latest render readers update while unrelated Loading work is pending (#3289)", async () => {
+  const [reload, setReload] = createSignal(0);
+  const gates = [deferred<void>(), deferred<void>(), deferred<void>()];
+  const tabValues: number[] = [];
+
+  createRoot(() => {
+    const graphs = gates.map((gate, index) =>
+      createMemo(async () => {
+        latest(reload);
+        await gate.promise;
+        return index;
+      })
+    );
+
+    const boundary = createLoadingBoundary(
+      () => graphs.map(graph => [isPending(() => graph()), graph()]),
+      () => "loading"
+    );
+
+    createRenderEffect(
+      () => boundary(),
+      () => {}
+    );
+
+    createRenderEffect(
+      () => latest(reload),
+      value => {
+        tabValues.push(value);
+      }
+    );
+  });
+
+  flush();
+  expect(tabValues).toEqual([0]);
+
+  for (let value = 1; value <= 3; value++) {
+    setReload(value);
+    flush();
+    expect(tabValues.at(-1)).toBe(value);
+  }
+
+  gates.forEach(gate => gate.resolve());
+  await settle();
+  expect(tabValues.at(-1)).toBe(3);
 });


### PR DESCRIPTION
## Summary

`latest()` readers could stay on an old value while an outer `<Loading>` boundary was waiting for several async memos.

The problem was that the optimistic lane also adopted `latest()`'s `_latestValueComputed` companion. That companion is a render reader, not async work that should block the reader. The fix stops adopting it, while keeping `_pendingSignal` lane adoption unchanged.

A regression test covers three async memos, a loading boundary, and three consecutive reloads.

Fixes #3289

## How did you test?

- `pnpm build`
- `pnpm test`
- `cd packages/signals && pnpm types`
- Targeted signals and Solid integration tests
- Prettier check on changed files
- Browser reproduction harness with repeated Reload clicks

All completed successfully. The commit hook's repository-wide formatter step still fails on existing JSX fixture syntax in `packages/babel-plugin/test/*fixtures*/insertChildren`; no fixture files are part of this PR.