### PR TITLE
fix(signals): preserve parked effects when transitions merge

### DIFF
--- a/.changeset/preserve-merged-transition-effects.md
+++ b/.changeset/preserve-merged-transition-effects.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Preserve queued effects when pending actions merge into another transaction, preventing stale DOM output after signal values commit.

--- a/packages/signals/src/core/scheduler.ts
+++ b/packages/signals/src/core/scheduler.ts
@@ -222,6 +222,10 @@ function createBatch(): Transition {
 function mergeTransitionState(target: Transition, outgoing: Transition): void {
   if (__DEV__ && attrHooks !== null) attrHooks.transitionMerged(target, outgoing);
   outgoing._done = target;
+  // Requeue held effects under the surviving transition so its next flush
+  // either parks them again or runs them when the merged work completes.
+  globalQueue.restoreQueues(outgoing._queueStash);
+  outgoing._queueStash = { _queues: [[], []], _children: [] };
   target._actions.push(...outgoing._actions);
   for (const lane of activeLanes) if (lane._transition === outgoing) lane._transition = target;
   if (outgoing._optimisticNodes.length) {

--- a/packages/signals/tests/transitionMerge.test.ts
+++ b/packages/signals/tests/transitionMerge.test.ts
@@ -5,7 +5,14 @@
 // duplicating every entry.
 
 import { describe, expect, it } from "vitest";
-import { action, createOptimistic, createRoot, flush } from "../src/index.js";
+import {
+  action,
+  createRenderEffect,
+  createSignal,
+  createOptimistic,
+  createRoot,
+  flush
+} from "../src/index.js";
 import * as scheduler from "../src/core/scheduler.js";
 
 describe("transition merge", () => {
@@ -63,4 +70,48 @@ describe("transition merge", () => {
     dispose();
     flush();
   });
+});
+
+it("runs parked render effects after their transition merges into another action", async () => {
+  const rendered: number[] = [];
+  let setValue!: (value: number) => void;
+  let setOptimistic!: (value: number) => void;
+  let dispose!: () => void;
+  createRoot(d => {
+    dispose = d;
+    const [value, write] = createSignal(0);
+    setValue = write;
+    [, setOptimistic] = createOptimistic(0);
+    createRenderEffect(value, next => {
+      rendered.push(next);
+    });
+  });
+  flush();
+
+  const firstGate = Promise.withResolvers<void>();
+  const secondGate = Promise.withResolvers<void>();
+  const first = action(function* () {
+    setValue(1);
+    yield firstGate.promise;
+    setOptimistic(2); // Merge into the action that owns this optimistic write.
+  });
+  const second = action(function* () {
+    setOptimistic(1);
+    yield secondGate.promise;
+  });
+  const firstDone = first();
+  flush();
+  const secondDone = second();
+  flush();
+  firstGate.resolve();
+  await firstDone;
+  flush();
+  expect.soft(rendered).toEqual([0]);
+
+  secondGate.resolve();
+  await secondDone;
+  flush();
+  expect.soft(rendered).toEqual([0, 1]);
+  dispose();
+  flush();
 });


### PR DESCRIPTION
## Summary

Fixes lost render updates when a pending action merges into another transaction. Signal values commit correctly, but the DOM can remain stale because `mergeTransitionState` does not transfer the outgoing transaction’s parked effect queues.

The fix restores those effects into the scheduler and clears the outgoing stash. Includes a minimal regression test and a patch changeset for `@solidjs/signals`.

## How did you test this change?

Confirmed the regression test fails on current `next` (`94fe5b46`) without this fix and passes with it. Also verified a standalone reproduction using only `@solidjs/signals` and the original application’s grid-switching and clipboard-replacement failures.

Completed validation using Node 24, matching `.nvmrc`:

- `pnpm i` — passed.
- `pnpm --filter @solidjs/compiler run build` — passed; prerequisite used by upstream CI.
- `pnpm build` — all 25 tasks passed.
- `pnpm test` — all 33 tasks passed, including workspace type tests: **4,399 tests passed, 3 skipped**.
- Prettier check of all changed files — passed.