### PR TITLE
fix(web): rebuild the buffered server-function request from its parts

### DIFF
--- a/.changeset/rebuild-buffered-request-from-parts.md
+++ b/.changeset/rebuild-buffered-request-from-parts.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/web": patch
+---
+
+Rebuild the buffered server-function request from its url, method, headers and signal instead of through the `Request` copy constructor, so a host adapter's lazy request (Nitro via srvx) no longer fails every POST with 400 "Malformed server function arguments"; only a failed upload read answers 400 now, a failure to put the bytes back surfaces as its own error.

--- a/packages/web/server-functions/src/server.ts
+++ b/packages/web/server-functions/src/server.ts
@@ -1561,9 +1561,9 @@ function stripUnsafeArgumentKeys(value) {
  * against the limit before this runs, but a declaration under it is not
  * evidence of anything (#3236), so the count is taken on the bytes that
  * arrive. The original body is read, not a clone: cancellation must tear
- * down the upload source rather than one branch of a tee (#3219). On
- * success the consumed body is replaced so the ordinary decoder can still
- * read it. Returns that replacement Request, or `null` past the limit.
+ * down the upload source rather than one branch of a tee (#3219). Returns
+ * the bytes that arrived, or `null` past the limit; `withBufferedBody` puts
+ * them back in front of the ordinary decoder.
  */
 async function bufferBodyWithin(request, limit) {
   const reader = request.body.getReader();
@@ -1604,7 +1604,29 @@ async function bufferBodyWithin(request, limit) {
     body.set(chunk, offset);
     offset += chunk.byteLength;
   }
-  return new Request(request, { body });
+  return body;
+}
+
+/**
+ * The consumed request with its buffered bytes back in front of the
+ * ordinary decoder. Assembled from the request's parts rather than
+ * `new Request(request, { body })`: the copy constructor reaches into the
+ * source's internal state, and a host adapter's request need not have any.
+ * srvx (Nitro's server layer) hands out a lazy `NodeRequest` that only
+ * wears `Request.prototype` — `instanceof` says Request, the native
+ * constructor never ran — so undici threw on the private slot and every
+ * POST under Nitro came back 400 (#3311). The parts the runtime reads are
+ * url, method, headers and signal, and any adapter has to serve those to
+ * get this far; the fetch-only fields the copy also carried (mode,
+ * credentials, cache) mean nothing on an inbound request.
+ */
+function withBufferedBody(request, body) {
+  return new Request(request.url, {
+    method: request.method,
+    headers: request.headers,
+    signal: request.signal,
+    body
+  });
 }
 
 // Every tag the decode switch has a case for, derived from `BodyFormat`
@@ -3385,26 +3407,29 @@ export async function handleServerFunctionRequest(request, options = {}) {
       );
       return finalizeTransportResponse(protectsRequest ? withCSRFVary(response) : response, method);
     }
-    let bounded;
+    let buffered;
     try {
-      bounded = await bufferBodyWithin(request, bodySizeLimit);
+      buffered = await bufferBodyWithin(request, bodySizeLimit);
     } catch {
       // A failed or aborted upload is an incomplete argument encoding,
       // not a handler failure. Match the decoder's malformed-body answer
-      // instead of rejecting out of dispatch (#3217).
+      // instead of rejecting out of dispatch (#3217). Only the READ sits
+      // under this answer: putting the bytes back is the runtime's own
+      // step, and answering its failure as the caller's malformed
+      // arguments pointed every Nitro user at their payload (#3311).
       const response = new Response(DEV ? "Malformed server function arguments" : null, {
         status: 400
       });
       return finalizeTransportResponse(protectsRequest ? withCSRFVary(response) : response, method);
     }
-    if (bounded === null) {
+    if (buffered === null) {
       const response = new Response(
         DEV ? "Server function request body exceeds the configured bodySizeLimit" : null,
         { status: 413 }
       );
       return finalizeTransportResponse(protectsRequest ? withCSRFVary(response) : response, method);
     }
-    request = bounded;
+    request = withBufferedBody(request, buffered);
   }
 
   // An async createEvent is out of contract (the type is synchronous), but

--- a/packages/web/test/server/server-functions-adapter-request.spec.tsx
+++ b/packages/web/test/server/server-functions-adapter-request.spec.tsx
@@ -1,0 +1,134 @@
+/**
+ * A host adapter's request need not carry undici's internals (#3311).
+ *
+ * `bodySizeLimit` buffers a POST body through a counting read, then puts
+ * the bytes back in front of the decoder. The rebuild used the copy
+ * constructor, `new Request(request, { body })`, which reaches into the
+ * source's private state — and srvx, the server layer under Nitro, hands
+ * out a lazy `NodeRequest` that only WEARS `Request.prototype`:
+ * `instanceof Request` says yes, the native constructor never ran, and the
+ * copy threw "Cannot read private member #state". The bare catch around the
+ * buffering then answered 400 "Malformed server function arguments", so
+ * every POST server function under Nitro failed with a message pointing at
+ * the caller's payload, whatever the payload was.
+ *
+ * Two invariants: the rebuild reads the request's PARTS (url, method,
+ * headers, signal — the ones the runtime already reads to get this far), so
+ * a request that serves those dispatches; and the 400 covers the READ only.
+ * Putting the bytes back is the runtime's own step, and its failure keeps
+ * its own error instead of being relabelled as the caller's.
+ *
+ * Like the other server-function specs, these run against the built bundles
+ * (server-functions/dist/*, wired up in vite.config.server.mjs).
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  handleServerFunctionRequest,
+  registerServerFunction
+} from "@solidjs/web/server-functions/server";
+
+const RequestContext = Symbol.for("solid.RequestContext");
+const BODY_FORMAT_HEADER = "X-Server-Function-Format";
+const JSON_FORMAT = "8";
+
+beforeAll(() => {
+  (globalThis as any)[RequestContext] = new AsyncLocalStorage();
+});
+
+afterAll(() => {
+  delete (globalThis as any)[RequestContext];
+});
+
+/**
+ * srvx's `NodeRequest`, reduced to the trait that matters: a class that is
+ * not a Request — the native constructor never runs — whose prototype is
+ * spliced under `Request.prototype` so `instanceof` still says Request, and
+ * whose parts are served by getters over the host's own objects. Backed by
+ * a real Request so the parts are exactly what a conforming host produces.
+ */
+function adapterRequest(native: Request, parts: { signal?: AbortSignal } = {}): Request {
+  class LazyRequest {
+    get url() {
+      return native.url;
+    }
+    get method() {
+      return native.method;
+    }
+    get headers() {
+      return native.headers;
+    }
+    get signal() {
+      return parts.signal ?? native.signal;
+    }
+    get body() {
+      return native.body;
+    }
+  }
+  Object.setPrototypeOf(LazyRequest.prototype, Request.prototype);
+  return new LazyRequest() as unknown as Request;
+}
+
+// the reporter's curl: a scripted JSON-tagged POST, same-origin by Origin
+function post(functionId: string, args: unknown[]) {
+  return new Request(`https://app.example/_server/data/${functionId}`, {
+    method: "POST",
+    body: JSON.stringify(args),
+    headers: {
+      "Content-Type": "application/json",
+      Origin: "https://app.example",
+      [BODY_FORMAT_HEADER]: JSON_FORMAT
+    }
+  });
+}
+
+describe("server functions on an adapter's lazy request (#3311)", () => {
+  it("dispatches a capped POST whose request only wears Request.prototype", async () => {
+    const fn = vi.fn(async (...args: unknown[]) => ({ argc: args.length }));
+    registerServerFunction("adapter-request-echo", fn);
+    const native = post("adapter-request-echo", ["en", "home", []]);
+    const lazy = adapterRequest(native);
+
+    // the trait under test: the copy constructor has no state to copy from
+    expect(lazy).toBeInstanceOf(Request);
+    expect(() => new Request(lazy, { body: new Uint8Array() })).toThrow(TypeError);
+
+    let handed: Request | undefined;
+    const response = await handleServerFunctionRequest(lazy, {
+      createEvent: request => {
+        handed = request;
+        return { request, locals: {} };
+      }
+    });
+    expect(response.status).toBe(200);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn.mock.calls[0]).toEqual(["en", "home", []]);
+
+    // the request the app is handed kept every part the adapter served...
+    expect(handed!.url).toBe(native.url);
+    expect(handed!.method).toBe("POST");
+    expect(handed!.headers.get(BODY_FORMAT_HEADER)).toBe(JSON_FORMAT);
+    expect(handed!.headers.get("content-type")).toBe("application/json");
+    // ...and its body is still the app's to read: the decoder took a clone
+    expect(await handed!.text()).toBe('["en","home",[]]');
+  });
+
+  it("keeps a rebuild failure's own error instead of answering malformed arguments", async () => {
+    const fn = vi.fn(async () => "ran");
+    registerServerFunction("adapter-request-rebuild-failure", fn);
+    // A signal the counting read is content with (aborted, reason, the two
+    // listener methods) that is not an AbortSignal, so the read succeeds
+    // and only the rebuild refuses it. Whatever the runtime does with that
+    // failure, it is not the caller's malformed payload: no 400 relabel.
+    const signal = {
+      aborted: false,
+      reason: undefined,
+      addEventListener() {},
+      removeEventListener() {}
+    } as unknown as AbortSignal;
+    const lazy = adapterRequest(post("adapter-request-rebuild-failure", []), { signal });
+
+    await expect(handleServerFunctionRequest(lazy)).rejects.toBeInstanceOf(TypeError);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3311. Under Nitro, srvx hands `handleServerFunctionRequest` a lazy `NodeRequest` that only wears `Request.prototype`: `instanceof Request` is true, but the native constructor never ran. `bufferBodyWithin` put the buffered bytes back with `new Request(request, { body })`, which reaches into undici's private state and threw, and the bare `catch` around the buffering relabelled that as 400 "Malformed server function arguments". Every POST server function under Nitro failed with the default `bodySizeLimit`, whatever the arguments were.

- `bufferBodyWithin` now returns the bytes, and `withBufferedBody` rebuilds the request from its url, method, headers and signal — the parts the runtime already reads to get this far. srvx's lazy headers iterate fine through that path. (srvx's documented `request._request` fallback does not work here: its getter builds from the already-consumed stream and throws "body object should not be disturbed or locked".)
- Only the counting read stays under the 400. A failure to put the bytes back is the runtime's own step and surfaces as its own error instead of the caller's malformed arguments.
- Regression spec `server-functions-adapter-request.spec.tsx` models the srvx trait with a `setPrototypeOf` class over a real Request (and asserts the copy constructor throws on it), pins that the capped POST dispatches with the app-facing `event.request` intact and still readable, and that a rebuild failure is not relabelled as a 400.
- Patch changeset for `@solidjs/web`.

## How did you test this change?

- New spec against the unfixed bundle on `next` (91088d2c): both tests fail with the reported 400. After the fix: both pass.
- `vitest run --config vite.config.server.mjs` in `packages/web`: 765 passed, 2 skipped, 3 failed. The 3 are in `exports-server-conditions.spec.tsx` (from #3309) and fail for a reason independent of this change: they require `solid-js`/`@solidjs/signals` `*.dev.cjs` artifacts that a `packages/web`-only build does not produce ("Cannot find module .../solid-js/dist/server.dev.cjs"), plus a symlinked-path expectation.
- End to end against real srvx 1.0.4 (the version in the report): served the built `server.dev.js` through `srvx/node`'s `serve({ fetch })` and replayed the issue's curl (`X-Server-Function-Format: 8`, JSON body, `Origin`). Before: 400 "Malformed server function arguments". After: 200 with the decoded arguments. `bodySizeLimit: Infinity` returns 200 in both.
- `tsc --project tsconfig.build.json --noEmit` and Prettier on the changed files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
