### PR TITLE
[scratch, do not merge] #3324 bisect: literals only

### DIFF
--- a/.changeset/observe-node-shapes.md
+++ b/.changeset/observe-node-shapes.md
@@ -1,0 +1,29 @@
+---
+"@solidjs/signals": patch
+---
+
+Observe tier: no post-construction fields on reactive nodes.
+
+The observe build stamped `_name` on every node, `_owner` on `createSignal`
+nodes and live `_subCount`/`_depCount` edge counters on linked nodes after the
+node literal — exactly the hidden-class transitions the prod literals are
+shaped to avoid. Measured against prod on the reactivity benchmark the tier
+cost +15% overall with creation tests 2–3× under polymorphic load.
+
+- Node factories (`computed`, `createEffectNode`, `signal`, `slotSignal`,
+  `createOwner`) now have two literals selected at build time: prod, and
+  observe = prod plus its `_name` slot (`_owner` too on signals). Default
+  labels (`signal`, `computed`, `effect`, `trackedEffect`) come from the
+  literal, so the `createEffect`/`createRenderEffect`/`createTrackedEffect`
+  wrappers no longer spread a fresh options object per effect to inject one.
+  A dist test pins observe's key set to prod's plus the slots.
+- Edge counters are gone. `HUGE_FAN_OUT` is counted by the notify walk a
+  committed change already makes over its subscribers, `HUGE_FAN_IN` by the
+  recompute pass over the sources it tracks (one module counter in `link()`).
+  Both therefore fire on the work — the change / the recompute — rather than
+  on the link, once per node and again after +500 growth (a WeakMap, not a
+  node field). `WIDE_WRITE` (engine) counts the subscriber list on the write
+  and hands over to `HUGE_FAN_OUT` at 2000, so a change never carries both.
+  Messages: "changed with N subscribers" / "tracked N sources".
+- Prod artifacts are unchanged apart from removing a leftover
+  `...(false ? {...} : options)` spread in `createEffect`.

--- a/documentation/performance-experiments.md
+++ b/documentation/performance-experiments.md
@@ -6853,3 +6853,253 @@ Status vs the no-regression bar: full and partial tick both in the
 alternating-measurement parity band (0.97–1.15x swings, centered ~1.05);
 sort/mount/unmount at parity or faster. Cool-machine confirmation still
 recommended for the record.
+
+## Observe Tier Lane (2026-09-09): prod vs observe runtime cost
+
+Question: what does the `observe` build tier (PR #3317 — wiring kept,
+checks stripped; attribution engine NOT imported) cost at runtime against
+`prod`, on both Tier-2 lanes? Scope is the shipped artifacts as a bundler
+resolves them (`dist/prod` vs `dist/observe` for signals; `observe` export
+condition end-to-end for the DOM app). Nothing here has the engine enabled
+— that is a separate, opt-in cost.
+
+Machine: Apple M5, Node v26.4.0, Chrome 153. Commit `8cfa2724` (`next`).
+
+### Method
+
+- **Node lane** — `js-reactivity-benchmark`, `solid-next` adapter, harness
+  import pointed at `packages/signals/dist/{prod,observe}/index.js` via a
+  `/tmp/jsrb-target` symlink and bundled once per tier with esbuild
+  (unminified). 5 full-suite runs per tier, interleaved prod/observe,
+  `node --expose-gc`. Medians below use runs 1, 2, 5 (3 and 4 overlapped
+  with build activity on the same machine; including them moves the total
+  by 0.2 pt). Numbers are ms per test.
+- **DOM lane** — a `js-framework-benchmark` `keyed/solid`-shaped app on
+  Solid 2 idioms (store rows, `createProjection` selection, keyed `<For>`),
+  built with Vite + `@solidjs/vite-plugin` twice: default conditions (prod)
+  and `resolve.conditions: ["observe"]`. Bundle: 21.5 KB gz prod vs
+  23.2 KB gz observe (+1.7 KB gz; matches the size-limit budget's +1.29 KB br).
+  Driven in headless Chrome (Playwright, `channel: "chrome"`) with the
+  whole scenario in ONE `page.evaluate`: synchronous `element.click()` per
+  op, a `window` bubble listener calling `flush()` after Solid's delegated
+  handler so each click is dispatch + `withInteraction` +
+  `describeEventTarget` + handler + propagation + DOM writes, timed with
+  `performance.now()` under COOP/COEP (5 µs resolution). Fresh page per
+  iteration, one warmup pass then one measured pass, tiers alternated,
+  30 iterations. Per-click medians.
+
+Two measurement traps found on the way, recorded so the next lane doesn't
+re-learn them:
+
+1. Anything timed across a task boundary after a click (rAF,
+   MessageChannel) quantizes to the ~16 ms vsync — Chrome aligns input
+   dispatch to the frame. Only a synchronous drain inside the click task
+   measures the script cost.
+2. A loop-mean per op is poisoned by GC placement: one ~3 ms pause lands
+   somewhere in every pass, and observe's slightly larger heap moved it
+   from the `swap` loop (prod) into the `update` loop (observe), reading as
+   "update 2× slower, swap 20% faster". Per-click medians fixed it.
+
+### Result 1 — Node lane, as shipped (`dist/observe`)
+
+| test                          |       prod |    observe |        Δ % |
+| ----------------------------- | ---------: | ---------: | ---------: |
+| createComputations            |      117.4 |      146.2 |     +24.5% |
+| create0to1                    |       12.7 |       17.1 |     +34.9% |
+| create4to1                    |        4.3 |       12.7 |      +193% |
+| create1to1000                 |       15.5 |       25.4 |     +63.7% |
+| create1to4                    |       16.0 |       21.4 |     +34.1% |
+| updateSignals                 |      470.1 |      485.9 |      +3.4% |
+| update1to1                    |       34.6 |       34.4 |      −0.6% |
+| update1to1000                 |      369.5 |      374.9 |      +1.5% |
+| broadPropagation              |      175.6 |      202.1 |     +15.1% |
+| deepPropagation               |       65.8 |       79.8 |     +21.4% |
+| diamond                       |      137.5 |      151.2 |     +10.0% |
+| 4-1000x12 - dyn5%             |      402.5 |      513.3 |     +27.5% |
+| 25-1000x5                     |      496.7 |      652.9 |     +31.4% |
+| 3-5x500                       |      129.7 |      163.7 |     +26.3% |
+| 6-100x15 - dyn50%             |      233.2 |      265.0 |     +13.7% |
+| **sum of medians (34 tests)** | **3181.9** | **3676.6** | **+15.5%** |
+
+Update-only tests are at parity (±3%). Creation and dynamic-graph tests
+are +15–65%, with `create4to1` an outlier at 3×.
+
+The outliers are a **suite-state** effect, not per-op cost: run alone
+(`TESTS=create4to1`), observe is 4.24 vs prod 3.76 (+13%), `create1to1000`
+18.3 vs 17.2 (+6%), `4-1000x12` 363.6 vs 362.0 (0%). `--trace-gc` shows
+the same GC count and retained heap for both tiers (≈985 vs 937 scavenges,
+5–6 MB retained), so it is not memory; it is hidden-class polymorphism that
+accumulates across the suite and lands on whichever test runs later.
+
+Cause, from the observe sites in `core.ts`/`dev.ts`/`graph.ts`: the tier
+adds fields to nodes **after** the literal — exactly the post-construction
+expandos the prod literals were shaped to avoid (`core.ts` "pre-shaped
+(were post-construction expandos)", "§12" in-object comment):
+
+- `_name` assigned after every computed/effect/signal/slot literal
+  (`core.ts` 672/763/871/939) — one transition per node type.
+- `_owner` assigned by `registerGraph` only for `createSignal` /
+  `createOptimisticSignal` nodes (`signals.ts` 373/1085) — Signal shape
+  forks into with/without-`_owner`.
+- `_subCount` / `_depCount` added lazily on first link by `noteGraphLink`
+  (`dev.ts` 506) — a further fork on both Signal and Computed, plus two
+  loads/stores and a `shouldWarnGraphSize` call on every `link()` and
+  `unlinkSubs()`.
+- `effect()` in `signals.ts` (515/557/612/677) spreads a fresh options
+  object per effect creation to inject the default name (`effect$1`
+  shows 25 ms self time in the DOM profile where prod's is inlined away).
+
+### Result 2 — DOM lane, as shipped
+
+| op                      | prod median | observe median |            Δ % |
+| ----------------------- | ----------: | -------------: | -------------: |
+| create 1k               |       2.407 |          2.612 |          +8.5% |
+| replace 1k              |       2.778 |          2.918 |          +5.0% |
+| update every 10th       |       0.135 |          0.155 | +14.8% (20 µs) |
+| swap rows               |       0.460 |          0.470 |          +2.2% |
+| select row              |       0.030 |          0.035 |  +16.7% (5 µs) |
+| remove row              |       0.645 |          0.640 |          −0.8% |
+| clear 1k                |       0.435 |          0.385 |         −11.5% |
+| create 10k              |       23.09 |          23.25 |          +0.7% |
+| clear 10k               |        3.06 |           2.99 |          −2.4% |
+| **whole pass incl. GC** |   **72.07** |      **74.68** |      **+3.6%** |
+
+DOM work dominates, so the same reactive overhead reads as +3.6% overall
+and +5–8% on creation. Per-interaction fixed cost (`withInteraction` +
+`describeEventTarget`) is within the 5 µs resolution on `select`.
+
+### Experiment — pre-shape the observe fields (scratch, reverted)
+
+Added `_name`, `_owner: null`, `_subCount: 0` (and `_depCount: 0` on
+computed/effect) to the four node literals in `core.ts`; then additionally
+stubbed the `noteGraphLink`/`unnoteGraphLink` calls in `graph.ts`. Rebuilt
+`dist/observe` only. Single full-suite run per variant, same-session prod
+rerun as the reference:
+
+|                            |  prod | observe as shipped | + pre-shaped fields | + no edge counters |
+| -------------------------- | ----: | -----------------: | ------------------: | -----------------: |
+| Node lane, sum of 34 tests |  3111 |        3733 (+20%) |        3342 (+7.4%) |       3281 (+5.5%) |
+| `create1to1000`            |  15.2 |               23.3 |                15.8 |               15.9 |
+| `createComputations`       | 116.8 |              150.4 |               122.1 |              123.8 |
+| `4-1000x12 - dyn5%`        | 400.8 |              519.7 |               468.4 |              436.2 |
+| `25-1000x5`                | 484.4 |              657.2 |               602.7 |              559.0 |
+| DOM lane, whole pass       | 71.90 |      74.68 (+3.6%) |                   — |      71.85 (−0.1%) |
+| DOM `create 1k`            | 2.397 |      2.612 (+8.5%) |                   — |      2.457 (+2.5%) |
+
+Pre-shaping alone removes two thirds of the Node-lane gap and all of the
+creation outliers; the edge counters are worth another ~2 pt on the
+dynamic-graph tests. Whole-suite CPU profile of the last variant vs prod:
++2.6% total, spread thinly (`read` +6%, `link` +5%) — no single hot
+observe function remains. The residual is the `attrHooks !== null` guards
+on `recompute`/`write` plus the extra literal slots.
+
+Caveat on the literal budget: the effect literal is 35 fields in prod; the
+experiment's +4 puts it at 39, the "§12" in-object boundary the comment
+warns about. The real change must not just append: candidates are folding
+`_subCount`/`_depCount` into one slot, moving `_name`/`_owner` into a
+single pre-allocated observe record, or reclaiming a slot elsewhere.
+Measure `create*` after.
+
+### Verdict
+
+- The `observe` tier as merged is **not** at prod parity: +15% on the
+  reactivity lane, +3.6% on a DOM app, with 2–3× creation outliers under
+  polymorphic load. Not shippable as "production-eligible" yet.
+- The cost is structural (node shape), not the hook calls; the fix is
+  mechanical and validated to bring the Node lane to ≈+5% and the DOM lane
+  to parity. Do it before measuring anything downstream (adapter,
+  sampling).
+- Method for the re-measure is pinned above: full-suite Node runs
+  (isolated tests hide the polymorphism), per-click medians in Chrome.
+
+### Fix — literal slots, no edge counters (`observe-perf` branch)
+
+What landed, against the cause list above:
+
+- **Slots, not writes.** Each node factory (`computed`, `createEffectNode`,
+  `signal`, `slotSignal`, `createOwner`) now has two object literals chosen
+  at build time by the observe flag: prod, and observe = prod plus `_name`
+  (`_owner` too on `signal`). Default labels come from the literal
+  (`trackedEffect` relabels its computed's slot), so the `createEffect` /
+  `createRenderEffect` / `createTrackedEffect` wrappers no longer spread a
+  fresh options object per effect. Alternatives rejected: `...(flag ? {…} :
+  null)` leaves a `...false` spread in prod (rollup folds the conditional
+  but not the spread element — and in fact one such spread was already
+  sitting in prod's `createEffect`, removed here); `{…prod, _name}` clones
+  and then transitions, which is the same cost as the write; the `_x`
+  extension would cost a 19-field allocation per named node / per
+  `createSignal`. Observe literal sizes: computed 30, effect 36, signal 16,
+  slot signal 20, owner 15 — all under the ~39 in-object boundary; a dist
+  test (`dist-artifacts.test.ts` "node literals per tier") pins observe's
+  key set to prod's plus the slots and the ≤38 bound.
+- **No edge counters.** `_subCount`/`_depCount` and `noteGraphLink` /
+  `unnoteGraphLink` are gone. Fan-out is counted by the notify walk in
+  `insertSubs` (one local increment in a loop that already visits every
+  edge); fan-in by `link()` bumping one module counter per first touch of
+  a pass, bracketed by `recompute`. `HUGE_FAN_OUT` / `HUGE_FAN_IN` therefore
+  fire on the change / the recompute rather than the link, deduped through a
+  `WeakMap` (once per node, again after +500). `WIDE_WRITE` counts the
+  subscriber list itself on the write (engine-only walk) and hands over to
+  `HUGE_FAN_OUT` at 2000.
+- **Prod byte-identical** modulo comments and the removed `...false ? {…} :
+  options` spread (`diff -w` of `dist/prod` before/after, comment lines
+  stripped: only that hunk).
+
+Re-measured with the pinned method (5 interleaved full-suite Node runs;
+30 DOM iterations, per-click medians). Same machine; absolute numbers are
+higher than the first session's (other load), the tiers are interleaved so
+the comparison holds.
+
+| Node lane (ms, median of 5) |   prod | observe |   Δ % | as shipped Δ % |
+| --------------------------- | -----: | ------: | ----: | -------------: |
+| createSignals               |   8.30 |    8.34 | +0.5% |                |
+| createComputations          | 131.44 |  130.82 | −0.5% |         +24.5% |
+| create1to1000               |  18.34 |   16.66 | −9.2% |         +63.7% |
+| updateSignals               | 486.74 |  510.86 | +5.0% |          +3.4% |
+| update1to1000               | 380.95 |  386.55 | +1.5% |          +1.5% |
+| broadPropagation            | 184.70 |  190.10 | +2.9% |         +15.1% |
+| deepPropagation             |  69.46 |   72.52 | +4.4% |         +21.4% |
+| diamond                     | 148.75 |  147.98 | −0.5% |         +10.0% |
+| 4-1000x12 - dyn5%           | 429.06 |  515.49 | +20.1% |        +27.5% |
+| 25-1000x5                   | 526.01 |  608.27 | +15.6% |        +31.4% |
+| 3-5x500                     | 130.67 |  142.86 | +9.3% |         +26.3% |
+| **sum of medians (34)**     | **3305** | **3567** | **+7.9%** |    **+15.5%** |
+
+Creation is at parity (the whole of the create* aggregate: −0.5%). The two
+`dyn` tests still read +15–20% on medians but their per-run spread is
+wider than the gap (`4-1000x12` prod 416–522 vs observe 410–521;
+`25-1000x5` prod 477–566 vs observe 493–727) — minimums are at parity, so
+this is run-to-run variance on the allocation-heavy tests, not a per-op
+cost; 5 runs are not enough to resolve it and the 7.9% total is an upper
+bound. `create4to1` reads 2× (4.7 vs 9.4 ms) in every run, including as
+shipped and in the scratch experiment: it is GC placement. The timed
+region allocates ~14 MB behind 100k pre-built signals, observe's signals
+are two slots larger, and the scavenge lands inside the window for one
+tier and outside for the other — deterministic per tier because `run()`
+GCs before each iteration. With `--max-semi-space-size=256` the two tiers
+swap places between runs (prod 4.29 / 8.14, observe 4.79 / 4.99), and
+`create1to4` flips to observe-faster; sub-10 ms tests in this suite cannot
+resolve a slot's worth of cost.
+
+| DOM lane (ms, per-click median, 30 iters) |   prod | observe |    Δ % | as shipped Δ % |
+| ----------------------------------------- | -----: | ------: | -----: | -------------: |
+| create 1k                                 |  2.730 |   2.808 |  +2.8% |          +8.5% |
+| replace 1k                                |  3.208 |   3.238 |  +0.9% |          +5.0% |
+| update every 10th                         |  0.160 |   0.160 |   0.0% |         +14.8% |
+| swap rows                                 |  0.525 |   0.525 |   0.0% |          +2.2% |
+| select row                                |  0.035 |   0.040 | +14.3% (5 µs) |   +16.7% |
+| remove row                                |  0.735 |   0.735 |   0.0% |          −0.8% |
+| create 10k                                | 26.605 |  26.810 |  +0.8% |          +0.7% |
+| **whole pass incl. GC**                   | **82.99** | **83.49** | **+0.6%** |  **+3.6%** |
+
+The DOM lane is at parity; the 5 µs on `select` is the per-interaction
+fixed cost (`withInteraction` + `describeEventTarget`), unchanged and at
+the timer's resolution.
+
+Residual observe cost, by construction: one slot per node (two on
+signals), the `attrHooks !== null` guards on recompute/write/effect-run,
+the fan-in counter (a module increment per first-touch link and two calls
+per recompute), the fan-out increment per notified edge, and
+`registerGraph`'s `getOwner()` + slot store per `createSignal`. Bundle:
++1.7 KB gz on the JFB app (unchanged — the slots are code the observe
+build already carried as writes).

--- a/documentation/proposals/production-observability-sketch.md
+++ b/documentation/proposals/production-observability-sketch.md
@@ -103,9 +103,11 @@ the sites survive the build. The surface is small and well-delineated:
   `effect.ts` 3 — effect run start/end). All outside `try` per the #2883 rule.
 - **Names**: 5 `_name` assignment sites (`core.ts` ×4, `store.ts` ×1) —
   needed for anything to be legible.
-- **Edge counters**: 2 sites (`graph.ts` `noteGraphLink` / `unnoteGraphLink`)
-  maintaining `_subCount`/`_depCount` — needed by `WIDE_WRITE` and the
-  always-on fan-out warnings.
+- **Edge counts**: none stored. Fan-out is counted by the notify walk
+  (`insertSubs`), fan-in by the recompute pass (`link()` into one module
+  counter) — the always-on graph-size warnings and `WIDE_WRITE` read those.
+  (An earlier draft kept live `_subCount`/`_depCount` fields per node; they
+  forked node shapes and were removed.)
 - **Web runtime (`@solidjs/web`)**: 3 `withInteraction` wrap sites
   (`attachDelegatedEvent`, and the two `addEvent` branches) behind
   `"_SOLID_DEV_"`.

--- a/documentation/solid-2.0/08-dev-diagnostics.md
+++ b/documentation/solid-2.0/08-dev-diagnostics.md
@@ -277,19 +277,19 @@ The owner passed to `runWithOwner` has already been disposed. Any reactive primi
 
 #### `HUGE_FAN_OUT`
 
-**Message:** "Signal [name] has N subscribers. Each will re-run when it changes. …"
+**Message:** "Signal [name] changed with N subscribers — every one re-runs this flush. …"
 
-One source has grown an unusually large number of live subscribers (first warning at 2000, repeated every additional 500). This is the signature of many independent computations reading the same value — for example, every row of a list comparing itself against one `selectedId` signal. Prefer a per-key store or a projection so only the items whose result actually flipped re-run.
+A committed change (a write, a memo's new value, an async landing) reached an unusually large number of live subscribers (first warning at 2000; re-warns once the count has grown by another 500). This is the signature of many independent computations reading the same value — for example, every row of a list comparing itself against one `selectedId` signal. Prefer a per-key store or a projection so only the items whose result actually flipped re-run.
 
-Always on in dev; maintained by the graph's link/unlink operations, so the counts reflect live edges (disposed subscribers don't count against the threshold).
+Always on wherever the diagnostics channel exists (dev and observe tiers). The count is taken by the notification walk the change makes anyway, so it is the live subscriber list at that moment — disposed subscribers don't count — and the core keeps no per-node counter for it (a live edge count was a post-construction field on every node, and forked node shapes). Fires on the change, not on subscription: a fan-out that is never written costs nothing, and one that is re-runs every subscriber right then.
 
-Related: `WIDE_WRITE` (below) fires at **write** time from a much lower threshold, but only while the attribution engine is enabled — static fan-out that never writes is harmless, so the write-time check can afford to be far more sensitive. `HUGE_FAN_OUT` is the always-on backstop for structure large enough to warn about even if it never changes.
+Related: `WIDE_WRITE` (below) is the same finding from a much lower threshold, but only while the attribution engine is enabled; it hands over to `HUGE_FAN_OUT` at 2000, so one change never carries both.
 
 #### `HUGE_FAN_IN`
 
-**Message:** "Computation [name] has N sources. It will re-run when any of them change. …"
+**Message:** "Computation [name] tracked N sources. It will re-run when any of them change. …"
 
-One computation subscribes to an unusually large number of sources (same thresholds as `HUGE_FAN_OUT`). This is the coarse-read signature — e.g. a helper that touches a whole store, or one memo derived from everything. Narrow the read or split the derivation so each computation tracks only what it needs.
+One recompute pass tracked an unusually large number of distinct sources (same thresholds as `HUGE_FAN_OUT`; counted per pass as the computation reads, repeat reads of the same source excluded). This is the coarse-read signature — e.g. a helper that touches a whole store, or one memo derived from everything. Narrow the read or split the derivation so each computation tracks only what it needs.
 
 Related: `WIDE_SCOPE_DEPS` (below) fires at a much lower threshold, but only while the attribution engine is enabled — it names the offending sources. `HUGE_FAN_IN` is the always-on backstop for the pathological case.
 
@@ -309,7 +309,7 @@ All three thresholds are configurable (or disable-able) through `enable()` optio
 
 A committed root invalidation — a signal or store write, a `refresh()`, or an async landing — reached a node with an unusually large number of live subscribers (default 250). Where the per-scope warnings above blame the _reader_, this one blames the _write_: it is the fan-out actually happening, priced at the moment it happens. The classic shape is many consumers asking keyed questions of one value (every row comparing against one selected id); the fix is inverting the subscription: keep the answer in a store used as a map keyed by id (`selected[row.id]` rather than `row.id === selectedId()`), so each consumer reads its own key and only the keys that flipped re-run; `createProjection` builds such a map when it is derived from other state.
 
-Attribution-engine only, like the trio above. Specced together with `HUGE_FAN_OUT` so the two never double-fire on one node: `HUGE_FAN_OUT` is always-on and fires at _link_ time from 2000 subscribers up — structure so large it warns even if never written — while `WIDE_WRITE` fires at _write_ time from a much lower bar, once per node, re-warning only after the subscriber count doubles. Unchanged writes never fire it (the source equality gate commits nothing and notifies no one). The check reads the same live `_subCount` the graph-size warnings maintain, so disposed subscribers don't count.
+Attribution-engine only, like the trio above. Specced together with `HUGE_FAN_OUT` so the two never double-fire on one change: `WIDE_WRITE` covers the range from its threshold up to 2000 subscribers, once per node, re-warning only after the subscriber count doubles; from 2000 up the always-on `HUGE_FAN_OUT` takes over. Unchanged writes never fire it (the source equality gate commits nothing and notifies no one). The engine counts the live subscriber list on the write, so disposed subscribers don't count.
 
 Threshold configurable (or disable-able) via `enable({ wideWrites })`.
 
@@ -453,8 +453,8 @@ Each `DiagnosticEvent` has:
 | `NO_OWNER_CLEANUP`               | warn      | lifecycle      | `onCleanup` called without owner                                                                                           |
 | `NO_OWNER_BOUNDARY`              | warn      | lifecycle      | Boundary created without owner                                                                                             |
 | `RUN_WITH_DISPOSED_OWNER`        | warn      | owner          | `runWithOwner` with disposed owner                                                                                         |
-| `HUGE_FAN_OUT`                   | warn      | graph          | One source reached 2000 live subscribers (always on)                                                                       |
-| `HUGE_FAN_IN`                    | warn      | graph          | One computation reached 2000 live sources (always on)                                                                      |
+| `HUGE_FAN_OUT`                   | warn      | graph          | One change reached 2000 live subscribers (always on)                                                                       |
+| `HUGE_FAN_IN`                    | warn      | graph          | One recompute tracked 2000 sources (always on)                                                                             |
 | `HOT_SCOPE_RERUNS`               | warn      | perf           | 120+ re-runs of one scope in 1s (attribution enabled)                                                                      |
 | `HOT_SCOPE_FANOUT`               | warn      | perf           | 5+/50+/500+ scopes hot from one root cause (attribution enabled)                                                           |
 | `HOT_SCOPE_TIME`                 | warn      | perf           | 8ms+ self-time in one scope in 1s (attribution enabled)                                                                    |

--- a/packages/signals/src/core/attribution.ts
+++ b/packages/signals/src/core/attribution.ts
@@ -4,7 +4,7 @@ import {
   type InteractionRef
 } from "./attribution-hooks.js";
 import { $REFRESH, NOT_PENDING } from "./constants.js";
-import { emitDiagnostic, ownerPath, reportDiagnostic } from "./dev.js";
+import { emitDiagnostic, GRAPH_SIZE_WARN_AT, ownerPath, reportDiagnostic } from "./dev.js";
 import type { Transition } from "./scheduler.js";
 import type { Computed, Signal } from "./types.js";
 
@@ -180,14 +180,11 @@ export interface AttributionOptions {
   /**
    * Written-fan-out warning: emit a diagnostic when a committed root
    * invalidation (write, refresh, async landing) reaches a node with at
-   * least this many subscribers (default 250). Complements the always-on
-   * HUGE_FAN_OUT graph-size warning, specced against it deliberately:
-   * HUGE_FAN_OUT fires at LINK time from GRAPH_SIZE_WARN_AT (2000) up —
-   * static structure so large it warns even if never written — while this
-   * fires at WRITE time from a much lower bar, because fan-out only costs
-   * anything when the node actually changes. Once per node, re-warning only
-   * on 2x subscriber growth, so the two never spam the same node. `false`
-   * disables.
+   * least this many subscribers (default 250). The lower-bar, opt-in sibling
+   * of the always-on HUGE_FAN_OUT graph-size warning, which fires on the
+   * same kind of write from GRAPH_SIZE_WARN_AT (2000) up; this one hands
+   * over to it there, so a write never carries both. Once per node,
+   * re-warning only on 2x subscriber growth. `false` disables.
    */
   wideWrites?: number | false;
   /**
@@ -520,15 +517,22 @@ export function formatOrigin(origin: ChangeOrigin): string {
 }
 
 /** Record a root change (setSignal / refresh / async landing) on the node. */
+/** Live subscriber count, walked on demand — the core keeps no counter. */
+function countSubscribers(node: Signal<any> | Computed<any>): number {
+  let n = 0;
+  for (let s = node._subs; s !== null; s = s._nextSub) n++;
+  return n;
+}
+
 /**
- * Written-fan-out warning — the write-time complement of the always-on
- * HUGE_FAN_OUT link-time warning (see dev.ts). Static fan-out that never
- * writes is harmless; a committed root invalidation reaching hundreds of
- * subscribers re-runs all of them this flush. Uses the dev-maintained
- * `_subCount` from the graph-size diagnostics — no core sites touched.
- * Once per node; re-warns only when the subscriber count has doubled since
- * the last warning, so it cannot spam alongside HUGE_FAN_OUT's own
- * 2000-and-up milestones.
+ * Written-fan-out warning — the engine's lower-bar sibling of the always-on
+ * HUGE_FAN_OUT (see dev.ts): a committed root invalidation reaching hundreds
+ * of subscribers re-runs all of them this flush. Counts the subscriber list
+ * itself (an engine-only walk, on the write; the core keeps no per-node
+ * count — a live `_subCount` was a post-construction field that forked node
+ * shapes). Once per node; re-warns only when the subscriber count has
+ * doubled since the last warning. Stops at GRAPH_SIZE_WARN_AT, where
+ * HUGE_FAN_OUT takes over, so the two never fire for the same write.
  */
 function checkWideWrite(
   node: Signal<any> | Computed<any>,
@@ -536,9 +540,10 @@ function checkWideWrite(
 ): void {
   const limit = options.wideWrites;
   if (typeof limit !== "number") return;
-  const subs = node._subCount ?? 0;
+  const subs = countSubscribers(node);
   const attributed = node as AttributedNode;
-  if (subs < limit || subs < (attributed._devWideWriteWarnedAt ?? 0) * 2) return;
+  if (subs < limit || subs >= GRAPH_SIZE_WARN_AT) return;
+  if (subs < (attributed._devWideWriteWarnedAt ?? 0) * 2) return;
   attributed._devWideWriteWarnedAt = subs;
   const verb =
     kind === "refresh" ? "refresh of" : kind === "async" ? "async landing on" : "write to";

--- a/packages/signals/src/core/core.ts
+++ b/packages/signals/src/core/core.ts
@@ -54,7 +54,7 @@ import {
   type Refreshable
 } from "./constants.js";
 import { NotReadyError } from "./error.js";
-import { dormantNodes, link, trimStaleDeps } from "./graph.js";
+import { beginFanInPass, dormantNodes, endFanInPass, link, trimStaleDeps } from "./graph.js";
 import {
   deleteFromHeap,
   enqueueSub,
@@ -282,6 +282,9 @@ export function recompute(el: Computed<any>, create: boolean = false): void {
   el._depGen++;
   el._flags = REACTIVE_RECOMPUTING_DEPS;
   el._time = clock;
+  // Observe-tier fan-in: the pass's distinct-dep count lives in one module
+  // counter (graph.ts), bracketed here so nested pulls don't disturb it.
+  const outerFanIn = __OBSERVE__ ? beginFanInPass() : 0;
   let value = el._pendingValue === NOT_PENDING ? el._value : el._pendingValue;
   let oldHeight = el._height;
   let missedWake = false;
@@ -402,6 +405,7 @@ export function recompute(el: Computed<any>, create: boolean = false): void {
     missedWake = (el._flags & REACTIVE_MISSED_WAKE) !== 0;
     el._flags = REACTIVE_NONE | (create ? el._flags & REACTIVE_SNAPSHOT_STALE : 0);
     context = oldcontext;
+    if (__OBSERVE__) endFanInPass(el, outerFanIn);
   }
 
   if (!el._x?._error) {
@@ -655,49 +659,95 @@ export function computed<T>(
   // `T | undefined` node is a real commit #0. The typeof guard tolerates
   // non-object option values that older call shapes force through `as any`.
   const loading = options !== null && typeof options === "object" && "loadingValue" in options;
-  const self: Computed<T> = {
-    id: inheritId(options, transparent, context),
-    _config:
-      (transparent ? CONFIG_TRANSPARENT : 0) |
-      (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
-      (!context || options?.lazy ? CONFIG_AUTO_DISPOSE : 0) |
-      (options?.sync ? CONFIG_SYNC : 0) |
-      (options?._noSnapshot ? CONFIG_NO_SNAPSHOT : 0) |
-      (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
-    _equals: options?.equals ?? isEqual,
-    _disposal: null,
-    _queue: context?._queue ?? globalQueue,
-    _context: context?._context ?? defaultContext,
-    _childCount: 0,
-    _fn: fn,
-    _value: (loading ? options!.loadingValue : undefined) as T,
-    _height: 0,
-    _nextHeap: undefined,
-    _prevHeap: null as any,
-    _deps: null,
-    _depsTail: null,
-    _depGen: 0,
-    _subs: null,
-    _subsTail: null,
-    _parent: context,
-    _nextSibling: null,
-    _prevSibling: null,
-    _firstChild: null,
-    _flags: options?.lazy ? REACTIVE_LAZY : REACTIVE_NONE,
-    // A loadingValue node is born committed: commit #0 is already in _value.
-    _statusFlags: loading ? 0 : STATUS_UNINITIALIZED,
-    _time: clock,
-    _pendingValue: NOT_PENDING,
-    _transition: null,
-    _notifiedAt: -1,
-    _loading: loading,
-    // Cold machinery (async/transition/optimistic/verdict slots) lives one
-    // hop away in the lazily-allocated extension — the core literal MUST
-    // stay under V8's in-object boundary (§12: past ~39 fields every
-    // allocation spills to a backing store and creation cost ~4x's).
-    _x: null
-  } as Computed<T>;
-  if (__OBSERVE__) (self as any)._name = options?.name ?? "computed";
+  // Two literals, one per tier, selected at build time (the observe flag is
+  // a literal after replacement; the untaken branch is dead code). The observe
+  // literal is the prod literal plus its `_name` slot — a slot in the
+  // boilerplate, because a post-construction `self._name = …` forces a
+  // hidden-class transition and an out-of-object property store on EVERY node
+  // (measured: the whole of the observe tier's creation overhead). Keep the
+  // two in sync — the dist artifact test pins observe's key set to prod's
+  // plus `_name`.
+  const self: Computed<T> = __OBSERVE__
+    ? ({
+        id: inheritId(options, transparent, context),
+        _config:
+          (transparent ? CONFIG_TRANSPARENT : 0) |
+          (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
+          (!context || options?.lazy ? CONFIG_AUTO_DISPOSE : 0) |
+          (options?.sync ? CONFIG_SYNC : 0) |
+          (options?._noSnapshot ? CONFIG_NO_SNAPSHOT : 0) |
+          (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
+        _equals: options?.equals ?? isEqual,
+        _disposal: null,
+        _queue: context?._queue ?? globalQueue,
+        _context: context?._context ?? defaultContext,
+        _childCount: 0,
+        _fn: fn,
+        _value: (loading ? options!.loadingValue : undefined) as T,
+        _height: 0,
+        _nextHeap: undefined,
+        _prevHeap: null as any,
+        _deps: null,
+        _depsTail: null,
+        _depGen: 0,
+        _subs: null,
+        _subsTail: null,
+        _parent: context,
+        _nextSibling: null,
+        _prevSibling: null,
+        _firstChild: null,
+        _flags: options?.lazy ? REACTIVE_LAZY : REACTIVE_NONE,
+        _statusFlags: loading ? 0 : STATUS_UNINITIALIZED,
+        _time: clock,
+        _pendingValue: NOT_PENDING,
+        _transition: null,
+        _notifiedAt: -1,
+        _loading: loading,
+        _x: null,
+        _name: options?.name ?? "computed"
+      } as Computed<T>)
+    : ({
+        id: inheritId(options, transparent, context),
+        _config:
+          (transparent ? CONFIG_TRANSPARENT : 0) |
+          (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
+          (!context || options?.lazy ? CONFIG_AUTO_DISPOSE : 0) |
+          (options?.sync ? CONFIG_SYNC : 0) |
+          (options?._noSnapshot ? CONFIG_NO_SNAPSHOT : 0) |
+          (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
+        _equals: options?.equals ?? isEqual,
+        _disposal: null,
+        _queue: context?._queue ?? globalQueue,
+        _context: context?._context ?? defaultContext,
+        _childCount: 0,
+        _fn: fn,
+        _value: (loading ? options!.loadingValue : undefined) as T,
+        _height: 0,
+        _nextHeap: undefined,
+        _prevHeap: null as any,
+        _deps: null,
+        _depsTail: null,
+        _depGen: 0,
+        _subs: null,
+        _subsTail: null,
+        _parent: context,
+        _nextSibling: null,
+        _prevSibling: null,
+        _firstChild: null,
+        _flags: options?.lazy ? REACTIVE_LAZY : REACTIVE_NONE,
+        // A loadingValue node is born committed: commit #0 is already in _value.
+        _statusFlags: loading ? 0 : STATUS_UNINITIALIZED,
+        _time: clock,
+        _pendingValue: NOT_PENDING,
+        _transition: null,
+        _notifiedAt: -1,
+        _loading: loading,
+        // Cold machinery (async/transition/optimistic/verdict slots) lives one
+        // hop away in the lazily-allocated extension — the core literal MUST
+        // stay under V8's in-object boundary (§12: past ~39 fields every
+        // allocation spills to a backing store and creation cost ~4x's).
+        _x: null
+      } as Computed<T>);
   if (options?.unobserved) (ext(self) as NodeExtension)._unobserved = options.unobserved;
   setupComputedNode(self, options);
   return self;
@@ -746,50 +796,99 @@ export function createEffectNode<T>(
   options: NodeOptions<T> | undefined
 ): any {
   const transparent = options?.transparent ?? false;
-  const self = {
-    id: inheritId(options, transparent, context),
-    _config:
-      (transparent ? CONFIG_TRANSPARENT : 0) |
-      (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
-      (options?.sync ? CONFIG_SYNC : 0) |
-      (options?._extraConfig ?? 0) |
-      (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
-    _equals: false as unknown as Computed<T>["_equals"],
-    _disposal: null,
-    _queue: context?._queue ?? globalQueue,
-    _context: context?._context ?? defaultContext,
-    _childCount: 0,
-    _fn: fn,
-    _value: undefined as T,
-    _height: 0,
-    _nextHeap: undefined,
-    _prevHeap: null as any,
-    _deps: null,
-    _depsTail: null,
-    _depGen: 0,
-    _subs: null,
-    _subsTail: null,
-    _parent: context,
-    _nextSibling: null,
-    _prevSibling: null,
-    _firstChild: null,
-    _flags: REACTIVE_LAZY,
-    _statusFlags: STATUS_UNINITIALIZED,
-    _time: clock,
-    _pendingValue: NOT_PENDING,
-    _transition: null,
-    _notifiedAt: -1,
-    _loading: false,
-    _modified: false,
-    _prevValue: undefined as T | undefined,
-    _effectFn: effectFn,
-    _errorFn: errorFn,
-    _cleanup: undefined as (() => void) | undefined,
-    _type: type,
-    _valueTransition: null,
-    _x: null
-  } as any;
-  if (__OBSERVE__) self._name = options?.name ?? "effect";
+  // Prod and observe boilerplates — see computed() for why the observe tier
+  // gets its `_name` as a literal slot rather than a write after the fact.
+  // The default label is the node kind (tracked effects relabel their computed
+  // in trackedEffect); the wrappers in signals.ts no longer spread a name into
+  // the options to get it.
+  const self = __OBSERVE__
+    ? ({
+        id: inheritId(options, transparent, context),
+        _config:
+          (transparent ? CONFIG_TRANSPARENT : 0) |
+          (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
+          (options?.sync ? CONFIG_SYNC : 0) |
+          (options?._extraConfig ?? 0) |
+          (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
+        _equals: false as unknown as Computed<T>["_equals"],
+        _disposal: null,
+        _queue: context?._queue ?? globalQueue,
+        _context: context?._context ?? defaultContext,
+        _childCount: 0,
+        _fn: fn,
+        _value: undefined as T,
+        _height: 0,
+        _nextHeap: undefined,
+        _prevHeap: null as any,
+        _deps: null,
+        _depsTail: null,
+        _depGen: 0,
+        _subs: null,
+        _subsTail: null,
+        _parent: context,
+        _nextSibling: null,
+        _prevSibling: null,
+        _firstChild: null,
+        _flags: REACTIVE_LAZY,
+        _statusFlags: STATUS_UNINITIALIZED,
+        _time: clock,
+        _pendingValue: NOT_PENDING,
+        _transition: null,
+        _notifiedAt: -1,
+        _loading: false,
+        _modified: false,
+        _prevValue: undefined as T | undefined,
+        _effectFn: effectFn,
+        _errorFn: errorFn,
+        _cleanup: undefined as (() => void) | undefined,
+        _type: type,
+        _valueTransition: null,
+        _x: null,
+        _name: options?.name ?? "effect"
+      } as any)
+    : ({
+        id: inheritId(options, transparent, context),
+        _config:
+          (transparent ? CONFIG_TRANSPARENT : 0) |
+          (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
+          (options?.sync ? CONFIG_SYNC : 0) |
+          (options?._extraConfig ?? 0) |
+          (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
+        _equals: false as unknown as Computed<T>["_equals"],
+        _disposal: null,
+        _queue: context?._queue ?? globalQueue,
+        _context: context?._context ?? defaultContext,
+        _childCount: 0,
+        _fn: fn,
+        _value: undefined as T,
+        _height: 0,
+        _nextHeap: undefined,
+        _prevHeap: null as any,
+        _deps: null,
+        _depsTail: null,
+        _depGen: 0,
+        _subs: null,
+        _subsTail: null,
+        _parent: context,
+        _nextSibling: null,
+        _prevSibling: null,
+        _firstChild: null,
+        _flags: REACTIVE_LAZY,
+        _statusFlags: STATUS_UNINITIALIZED,
+        _time: clock,
+        _pendingValue: NOT_PENDING,
+        _transition: null,
+        _notifiedAt: -1,
+        _loading: false,
+        _modified: false,
+        _prevValue: undefined as T | undefined,
+        _effectFn: effectFn,
+        _errorFn: errorFn,
+        _cleanup: undefined as (() => void) | undefined,
+        _type: type,
+        _valueTransition: null,
+        _x: null
+      } as any);
   // Effects dispatch status through the SHARED notifier (statusNotifierOf,
   // keyed off _type) — storing it per node forced a full NodeExtension
   // allocation on EVERY effect at creation (an alloc + 19 field stores,
@@ -876,28 +975,50 @@ export function signal<T>(
   options?: NodeOptions<T>,
   firewall: Computed<unknown> | null = null
 ): Signal<T> {
-  const s = {
-    _equals: options?.equals ?? isEqual,
-    _config:
-      (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
-      (options?._noSnapshot ? CONFIG_NO_SNAPSHOT : 0),
-    _value: v,
-    _subs: null,
-    _subsTail: null,
-    _time: clock,
-    _firewall: firewall,
-    _nextChild: firewall?._x?._child || null,
-    _pendingValue: NOT_PENDING,
-    // Signal-literal diet (§12e): NO _time/_fn/_statusFlags slots. Stores
-    // materialize one signal per touched leaf, so signal bytes are store
-    // bytes. _time is write-only on signals (every read site is computed-
-    // typed error-retry gating); _fn/_statusFlags read falsy-identically as
-    // missing properties on the shared paths (undefined masks to 0).
-    _transition: null,
-    _notifiedAt: -1,
-    _x: null
-  };
-  if (__OBSERVE__) (s as any)._name = options?.name ?? "signal";
+  // Prod and observe boilerplates — see computed(). The observe literal adds
+  // `_name` and `_owner` (the creating owner, stamped by registerGraph for
+  // createSignal nodes so ownerPath can locate signal subjects; null here,
+  // and staying null on internal signals — one shape either way).
+  const s = __OBSERVE__
+    ? {
+        _equals: options?.equals ?? isEqual,
+        _config:
+          (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
+          (options?._noSnapshot ? CONFIG_NO_SNAPSHOT : 0),
+        _value: v,
+        _subs: null,
+        _subsTail: null,
+        _time: clock,
+        _firewall: firewall,
+        _nextChild: firewall?._x?._child || null,
+        _pendingValue: NOT_PENDING,
+        _transition: null,
+        _notifiedAt: -1,
+        _x: null,
+        _name: options?.name ?? "signal",
+        _owner: null as Owner | null
+      }
+    : {
+        _equals: options?.equals ?? isEqual,
+        _config:
+          (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
+          (options?._noSnapshot ? CONFIG_NO_SNAPSHOT : 0),
+        _value: v,
+        _subs: null,
+        _subsTail: null,
+        _time: clock,
+        _firewall: firewall,
+        _nextChild: firewall?._x?._child || null,
+        _pendingValue: NOT_PENDING,
+        // Signal-literal diet (§12e): NO _time/_fn/_statusFlags slots. Stores
+        // materialize one signal per touched leaf, so signal bytes are store
+        // bytes. _time is write-only on signals (every read site is computed-
+        // typed error-retry gating); _fn/_statusFlags read falsy-identically as
+        // missing properties on the shared paths (undefined masks to 0).
+        _transition: null,
+        _notifiedAt: -1,
+        _x: null
+      };
   if (__DEV__) (s as any)._internal = !!firewall;
   if (options?.unobserved) ext(s as any)._unobserved = options.unobserved;
   if (firewall) {
@@ -944,28 +1065,50 @@ export function slotSignal<T>(
   acc: boolean,
   firewall: Computed<unknown> | null = null
 ): Signal<T> {
-  const s = {
-    _equals: equals,
-    _config: CONFIG_OWNED_WRITE | CONFIG_SLOT_NODE,
-    _value: v,
-    _subs: null,
-    _subsTail: null,
-    _time: clock,
-    _firewall: firewall,
-    _nextChild: firewall?._x?._child || null,
-    _pendingValue: NOT_PENDING,
-    _transition: null,
-    _notifiedAt: -1,
-    _x: null,
-    // Slot backrefs: what the equals/unobserved closures used to capture.
-    _host: host,
-    _key: key,
-    // Store read-path caches, pre-shaped (were post-construction expandos).
-    acc,
-    px: undefined,
-    pxv: undefined
-  };
-  if (__OBSERVE__) (s as any)._name = "signal";
+  // Prod and observe boilerplates — see computed(). The store relabels the
+  // observe slot (`store.<key>`) when the attribution engine is installed.
+  const s = __OBSERVE__
+    ? {
+        _equals: equals,
+        _config: CONFIG_OWNED_WRITE | CONFIG_SLOT_NODE,
+        _value: v,
+        _subs: null,
+        _subsTail: null,
+        _time: clock,
+        _firewall: firewall,
+        _nextChild: firewall?._x?._child || null,
+        _pendingValue: NOT_PENDING,
+        _transition: null,
+        _notifiedAt: -1,
+        _x: null,
+        _host: host,
+        _key: key,
+        acc,
+        px: undefined,
+        pxv: undefined,
+        _name: "signal"
+      }
+    : {
+        _equals: equals,
+        _config: CONFIG_OWNED_WRITE | CONFIG_SLOT_NODE,
+        _value: v,
+        _subs: null,
+        _subsTail: null,
+        _time: clock,
+        _firewall: firewall,
+        _nextChild: firewall?._x?._child || null,
+        _pendingValue: NOT_PENDING,
+        _transition: null,
+        _notifiedAt: -1,
+        _x: null,
+        // Slot backrefs: what the equals/unobserved closures used to capture.
+        _host: host,
+        _key: key,
+        // Store read-path caches, pre-shaped (were post-construction expandos).
+        acc,
+        px: undefined,
+        pxv: undefined
+      };
   if (__DEV__) (s as any)._internal = !!firewall;
   if (firewall) {
     ext(firewall)._child = s as unknown as FirewallSignal<unknown>;

--- a/packages/signals/src/core/core.ts
+++ b/packages/signals/src/core/core.ts
@@ -54,7 +54,7 @@ import {
   type Refreshable
 } from "./constants.js";
 import { NotReadyError } from "./error.js";
-import { beginFanInPass, dormantNodes, endFanInPass, link, trimStaleDeps } from "./graph.js";
+import { dormantNodes, link, trimStaleDeps } from "./graph.js";
 import {
   deleteFromHeap,
   enqueueSub,
@@ -284,7 +284,6 @@ export function recompute(el: Computed<any>, create: boolean = false): void {
   el._time = clock;
   // Observe-tier fan-in: the pass's distinct-dep count lives in one module
   // counter (graph.ts), bracketed here so nested pulls don't disturb it.
-  const outerFanIn = __OBSERVE__ ? beginFanInPass() : 0;
   let value = el._pendingValue === NOT_PENDING ? el._value : el._pendingValue;
   let oldHeight = el._height;
   let missedWake = false;
@@ -405,7 +404,6 @@ export function recompute(el: Computed<any>, create: boolean = false): void {
     missedWake = (el._flags & REACTIVE_MISSED_WAKE) !== 0;
     el._flags = REACTIVE_NONE | (create ? el._flags & REACTIVE_SNAPSHOT_STALE : 0);
     context = oldcontext;
-    if (__OBSERVE__) endFanInPass(el, outerFanIn);
   }
 
   if (!el._x?._error) {

--- a/packages/signals/src/core/dev.ts
+++ b/packages/signals/src/core/dev.ts
@@ -76,9 +76,9 @@ export type DiagnosticKind =
   /** Perceived responsiveness: the runtime behaved correctly but the user saw no feedback. */
   | "responsiveness";
 
-/** First warning when a node's live edge count reaches this size. */
+/** First warning when a change reaches (or a pass tracks) this many edges. */
 export const GRAPH_SIZE_WARN_AT = 2000;
-/** Repeat the warning at this interval after the first. */
+/** Re-warn once the count has grown by this much since the last warning. */
 export const GRAPH_SIZE_WARN_EVERY = 500;
 
 export interface DiagnosticEvent {
@@ -491,72 +491,81 @@ export function getObservers(node: Signal<any> | Computed<any>): Computed<any>[]
   return observers;
 }
 
-function shouldWarnGraphSize(count: number): boolean {
-  return count >= GRAPH_SIZE_WARN_AT && (count - GRAPH_SIZE_WARN_AT) % GRAPH_SIZE_WARN_EVERY === 0;
+/**
+ * Graph-size warnings are once per node, re-warning only when the count has
+ * grown by GRAPH_SIZE_WARN_EVERY since the last one — off-node, so the
+ * pathological handful of nodes that ever reach the threshold are the only
+ * ones that cost anything, and no node carries a bookkeeping field for it.
+ */
+const graphSizeWarnedAt = new WeakMap<object, number>();
+
+function shouldWarnGraphSize(node: object, count: number): boolean {
+  const last = graphSizeWarnedAt.get(node);
+  if (last !== undefined && count < last + GRAPH_SIZE_WARN_EVERY) return false;
+  graphSizeWarnedAt.set(node, count);
+  return true;
 }
 
 /**
- * Observe-tier: bump live edge counts after a new graph link and emit when a
- * node grows an unusually large fan-out (many subscribers on one source) or
- * fan-in (many sources on one computation). Repeat-reads that `link()`
- * dedupes never reach here. Always-on wherever the channel exists — unlike
- * the opt-in attribution engine, a graph-size pathology should surface
- * without asking. The counts also feed `WIDE_WRITE` in attribution.ts.
+ * Observe-tier: a committed change on `node` is about to re-run `count`
+ * subscribers (the notify walk in `insertSubs` counted them as it went —
+ * fan-out costs exactly one local increment in a loop that already visits
+ * every edge, and nothing at link time). Fires from GRAPH_SIZE_WARN_AT up,
+ * on the write rather than the link: a fan-out that is never written costs
+ * nothing, and one that is re-runs every subscriber this flush. Always-on
+ * wherever the channel exists — unlike the opt-in attribution engine, a
+ * graph-size pathology should surface without asking.
  */
-export function noteGraphLink(dep: Signal<any> | Computed<any>, sub: Computed<any>): void {
-  const fanOut = (dep._subCount = (dep._subCount || 0) + 1);
-  const fanIn = (sub._depCount = (sub._depCount || 0) + 1);
-  if (shouldWarnGraphSize(fanOut)) {
-    const name = dep._name;
-    const message =
-      `[HUGE_FAN_OUT] ${name ? `Signal "${name}"` : "A signal"} has ${fanOut} subscribers. ` +
-      `Each will re-run when it changes. If many independent computations read the same value ` +
-      `(for example every row of a list comparing against one selected id), prefer a per-key ` +
-      `store or projection so only the items whose result flipped update.`;
-    reportDiagnostic(
-      emitDiagnostic(
-        {
-          code: "HUGE_FAN_OUT",
-          kind: "graph",
-          severity: "warn",
-          message,
-          nodeName: name,
-          ownerId: (dep as Computed<any>).id,
-          ownerName: name,
-          data: { count: fanOut }
-        },
-        dep
-      )
-    );
-  }
-  if (shouldWarnGraphSize(fanIn)) {
-    const name = sub._name;
-    const message =
-      `[HUGE_FAN_IN] ${name ? `Computation "${name}"` : "A computation"} has ${fanIn} sources. ` +
-      `It will re-run when any of them change. Narrow the read or split the derivation so each ` +
-      `computation tracks only what it needs.`;
-    reportDiagnostic(
-      emitDiagnostic(
-        {
-          code: "HUGE_FAN_IN",
-          kind: "graph",
-          severity: "warn",
-          message,
-          nodeName: name,
-          ownerId: sub.id,
-          ownerName: name,
-          data: { count: fanIn }
-        },
-        sub
-      )
-    );
-  }
+export function noteFanOut(node: Signal<any> | Computed<any>, count: number): void {
+  if (!shouldWarnGraphSize(node, count)) return;
+  const name = node._name;
+  const message =
+    `[HUGE_FAN_OUT] ${name ? `Signal "${name}"` : "A signal"} changed with ${count} subscribers — ` +
+    `every one re-runs this flush. If many independent computations read the same value ` +
+    `(for example every row of a list comparing against one selected id), prefer a per-key ` +
+    `store or projection so only the items whose result flipped update.`;
+  reportDiagnostic(
+    emitDiagnostic(
+      {
+        code: "HUGE_FAN_OUT",
+        kind: "graph",
+        severity: "warn",
+        message,
+        nodeName: name,
+        ownerId: (node as Computed<any>).id,
+        ownerName: name,
+        data: { count }
+      },
+      node
+    )
+  );
 }
 
-/** Observe-tier: drop live edge counts when a link is removed. */
-export function unnoteGraphLink(link: Link): void {
-  const dep = link._dep;
-  const sub = link._sub;
-  if (dep._subCount) dep._subCount--;
-  if (sub._depCount) sub._depCount--;
+/**
+ * Observe-tier: a recompute pass of `node` tracked `count` distinct sources
+ * (counted by `link()` on each first touch of the pass — see graph.ts).
+ * Fires from GRAPH_SIZE_WARN_AT up, at the end of the pass that read them.
+ */
+export function noteFanIn(node: Computed<any>, count: number): void {
+  if (!shouldWarnGraphSize(node, count)) return;
+  const name = node._name;
+  const message =
+    `[HUGE_FAN_IN] ${name ? `Computation "${name}"` : "A computation"} tracked ${count} sources. ` +
+    `It will re-run when any of them change. Narrow the read or split the derivation so each ` +
+    `computation tracks only what it needs.`;
+  reportDiagnostic(
+    emitDiagnostic(
+      {
+        code: "HUGE_FAN_IN",
+        kind: "graph",
+        severity: "warn",
+        message,
+        nodeName: name,
+        ownerId: node.id,
+        ownerName: name,
+        data: { count }
+      },
+      node
+    )
+  );
 }

--- a/packages/signals/src/core/effect.ts
+++ b/packages/signals/src/core/effect.ts
@@ -285,6 +285,9 @@ export function trackedEffect(fn: () => void | (() => void), options?: NodeOptio
   node._config = (node._config & ~CONFIG_AUTO_DISPOSE) | CONFIG_CHILDREN_FORBIDDEN;
   node._modified = true;
   node._type = EFFECT_TRACKED;
+  // Observe-tier label: the computed literal defaulted its `_name` slot to
+  // "computed"; relabel by kind (a store into the slot, not a new field).
+  if (__OBSERVE__ && options?.name === undefined) node._name = "trackedEffect";
   // Status dispatch rides the SHARED notifier (statusNotifierOf keys off
   // _type): its error arm is behavior-identical to the closure that used to
   // live here, without the per-node NodeExtension allocation.

--- a/packages/signals/src/core/graph.ts
+++ b/packages/signals/src/core/graph.ts
@@ -7,15 +7,36 @@ import {
   STATUS_PENDING
 } from "./constants.js";
 import { slotUnobservedHook } from "./core.js";
-import { noteGraphLink, unnoteGraphLink } from "./dev.js";
+import { GRAPH_SIZE_WARN_AT, noteFanIn } from "./dev.js";
 import { deleteFromHeap, queueFor } from "./heap.js";
 import { disposeChildren } from "./owner.js";
 import { bumpNotifyEpoch, dirtyQueue, zombieQueue } from "./scheduler.js";
 import type { Computed, Link, Signal } from "./types.js";
 
+/**
+ * Observe-tier: distinct dependencies touched by the recompute pass in
+ * progress — `link()` counts each first touch (a reused in-order link or a
+ * new edge; repeat reads of the same dep within the pass do not count).
+ * `recompute` brackets its pass with begin/endFanInPass, saving the enclosing
+ * pass's count across nested pulls. One module counter instead of a live
+ * `_depCount` field on every computed: the per-node field was a
+ * post-construction expando that forked node shapes and taxed every link.
+ */
+let passFanIn = 0;
+
+export function beginFanInPass(): number {
+  const prev = passFanIn;
+  passFanIn = 0;
+  return prev;
+}
+
+export function endFanInPass(el: Computed<any>, prev: number): void {
+  if (passFanIn >= GRAPH_SIZE_WARN_AT) noteFanIn(el, passFanIn);
+  passFanIn = prev;
+}
+
 // https://github.com/stackblitz/alien-signals/blob/v2.0.3/src/system.ts#L100
 export function unlinkSubs(link: Link): Link | null {
-  if (__OBSERVE__) unnoteGraphLink(link);
   const dep = link._dep;
   const nextDep = link._nextDep;
   const nextSub = link._nextSub;
@@ -148,6 +169,7 @@ export function link(
       sub._depsTail = nextDep;
       // First touch of this pass: the previous pass's label is stale.
       nextDep._pendingObserver = pendingObserver;
+      if (__OBSERVE__) passFanIn++;
       return;
     }
   }
@@ -191,5 +213,5 @@ export function link(
   // New subscriber edge: staged-rewrite skips (§12d) must not miss it.
   bumpNotifyEpoch();
 
-  if (__OBSERVE__) noteGraphLink(dep, sub);
+  if (__OBSERVE__) passFanIn++;
 }

--- a/packages/signals/src/core/graph.ts
+++ b/packages/signals/src/core/graph.ts
@@ -169,7 +169,6 @@ export function link(
       sub._depsTail = nextDep;
       // First touch of this pass: the previous pass's label is stale.
       nextDep._pendingObserver = pendingObserver;
-      if (__OBSERVE__) passFanIn++;
       return;
     }
   }
@@ -212,6 +211,4 @@ export function link(
 
   // New subscriber edge: staged-rewrite skips (§12d) must not miss it.
   bumpNotifyEpoch();
-
-  if (__OBSERVE__) passFanIn++;
 }

--- a/packages/signals/src/core/owner.ts
+++ b/packages/signals/src/core/owner.ts
@@ -290,22 +290,44 @@ function disposeRootSelf(this: Root, self: boolean = true): void {
 export function createOwner(options?: { id?: string; transparent?: boolean }) {
   const parent = context;
   const transparent = options?.transparent ?? false;
-  const owner = {
-    id: inheritId(options, transparent, parent),
-    _config: transparent ? CONFIG_TRANSPARENT : 0,
-    _root: true,
-    _parentComputed: (parent as Root)?._root ? (parent as Root)._parentComputed : parent,
-    _firstChild: null,
-    _nextSibling: null,
-    _prevSibling: null,
-    _disposal: null,
-    _queue: parent?._queue ?? globalQueue,
-    _context: parent?._context || defaultContext,
-    _childCount: 0,
-    _x: null,
-    _parent: parent,
-    dispose: disposeRootSelf
-  } as Root;
+  // Prod and observe boilerplates (see core.ts computed()). The observe
+  // literal carries the `_name` slot the rendering layer fills with the
+  // component label (`owner._name = "<App>"`) — a slot, so labelling a root
+  // is a plain store rather than a shape fork between labelled and plain roots.
+  const owner = __OBSERVE__
+    ? ({
+        id: inheritId(options, transparent, parent),
+        _config: transparent ? CONFIG_TRANSPARENT : 0,
+        _root: true,
+        _parentComputed: (parent as Root)?._root ? (parent as Root)._parentComputed : parent,
+        _firstChild: null,
+        _nextSibling: null,
+        _prevSibling: null,
+        _disposal: null,
+        _queue: parent?._queue ?? globalQueue,
+        _context: parent?._context || defaultContext,
+        _childCount: 0,
+        _x: null,
+        _parent: parent,
+        dispose: disposeRootSelf,
+        _name: undefined as string | undefined
+      } as Root)
+    : ({
+        id: inheritId(options, transparent, parent),
+        _config: transparent ? CONFIG_TRANSPARENT : 0,
+        _root: true,
+        _parentComputed: (parent as Root)?._root ? (parent as Root)._parentComputed : parent,
+        _firstChild: null,
+        _nextSibling: null,
+        _prevSibling: null,
+        _disposal: null,
+        _queue: parent?._queue ?? globalQueue,
+        _context: parent?._context || defaultContext,
+        _childCount: 0,
+        _x: null,
+        _parent: parent,
+        dispose: disposeRootSelf
+      } as Root);
 
   if (__DEV__ && parent && parent._config & CONFIG_CHILDREN_FORBIDDEN) {
     emitDiagnostic({

--- a/packages/signals/src/core/scheduler.ts
+++ b/packages/signals/src/core/scheduler.ts
@@ -918,10 +918,8 @@ export function insertSubs(node: Signal<any> | Computed<any>, optimistic: boolea
 
   // Observe-tier fan-out: this walk visits every subscriber edge anyway, so
   // the graph-size count is one local increment here and no field anywhere.
-  let fanOut = 0;
   for (let s = node._subs; s !== null; s = s._nextSub) {
     const sub = s._sub;
-    if (__OBSERVE__) fanOut++;
     // A value-change notification is a new question for the subscriber: any
     // pending re-ask mark (refresh) it carried is superseded.
     if (clearReask) sub._flags &= ~REACTIVE_REASK;
@@ -951,7 +949,6 @@ export function insertSubs(node: Signal<any> | Computed<any>, optimistic: boolea
 
     enqueueSub(sub);
   }
-  if (__OBSERVE__ && fanOut >= GRAPH_SIZE_WARN_AT) noteFanOut(node, fanOut);
 }
 
 function commitPendingNode(n: Signal<any>): void {

--- a/packages/signals/src/core/scheduler.ts
+++ b/packages/signals/src/core/scheduler.ts
@@ -27,7 +27,7 @@ import {
 } from "./constants.js";
 import { attrHooks } from "./attribution-hooks.js";
 import { currentOptimisticLane, ext, slotUnobservedHook } from "./core.js";
-import { DEV, emitDiagnostic, reportDiagnostic } from "./dev.js";
+import { DEV, emitDiagnostic, GRAPH_SIZE_WARN_AT, noteFanOut, reportDiagnostic } from "./dev.js";
 import { NotReadyError } from "./error.js";
 import { sweepDormant } from "./graph.js";
 import { deleteFromHeap, enqueueSub, runHeap, type Heap } from "./heap.js";
@@ -916,8 +916,12 @@ export function insertSubs(node: Signal<any> | Computed<any>, optimistic: boolea
     (cfg & CONFIG_HAS_SNAPSHOT) !== 0 && (node as any)._x?._snapshotValue !== undefined;
   const clearReask = reaskArmed;
 
+  // Observe-tier fan-out: this walk visits every subscriber edge anyway, so
+  // the graph-size count is one local increment here and no field anywhere.
+  let fanOut = 0;
   for (let s = node._subs; s !== null; s = s._nextSub) {
     const sub = s._sub;
+    if (__OBSERVE__) fanOut++;
     // A value-change notification is a new question for the subscriber: any
     // pending re-ask mark (refresh) it carried is superseded.
     if (clearReask) sub._flags &= ~REACTIVE_REASK;
@@ -947,6 +951,7 @@ export function insertSubs(node: Signal<any> | Computed<any>, optimistic: boolea
 
     enqueueSub(sub);
   }
+  if (__OBSERVE__ && fanOut >= GRAPH_SIZE_WARN_AT) noteFanOut(node, fanOut);
 }
 
 function commitPendingNode(n: Signal<any>): void {

--- a/packages/signals/src/core/types.ts
+++ b/packages/signals/src/core/types.ts
@@ -120,13 +120,19 @@ export interface NodeExtension {
 export interface RawSignal<T> {
   _subs: Link | null;
   _subsTail: Link | null;
-  /**
-   * DEV-only live subscriber count. Maintained by `link`/`unlinkSubs` for
-   * graph-size diagnostics; undefined in production.
-   */
-  _subCount?: number;
   _value: T;
+  /**
+   * Observe-tier label (`name` option, or the node kind: `signal`,
+   * `computed`, `effect`…). A slot in the observe/dev literals — never a
+   * post-construction write — and absent from the prod literals entirely.
+   */
   _name?: string;
+  /**
+   * Observe-tier: the owner in scope when a user-facing signal was created
+   * (`registerGraph`), so diagnostics about the signal get an owner path.
+   * A slot in the observe/dev `signal()` literal; absent from prod.
+   */
+  _owner?: Owner | null;
   _equals: false | ((a: T, b: T) => boolean);
   _config: number;
   _time: number;
@@ -166,16 +172,17 @@ export interface Owner {
   _prevSibling: Owner | null;
   /** Cold extension — see NodeExtension (owners use the zombie-pair slots). */
   _x: NodeExtension | null;
+  /**
+   * Observe-tier label: the `name` option, the node kind (`computed`,
+   * `effect`…), or the component label the rendering layer writes on a root
+   * (`<App>`). A slot in the observe/dev literals; absent from prod.
+   */
+  _name?: string;
 }
 
 export interface Computed<T> extends RawSignal<T>, Owner {
   _deps: Link | null;
   _depsTail: Link | null;
-  /**
-   * DEV-only live source count. Maintained by `link`/`unlinkSubs` for
-   * graph-size diagnostics; undefined in production.
-   */
-  _depCount?: number;
   /** Recompute-pass counter; bumped when dep revalidation starts. */
   _depGen: number;
   _flags: number;

--- a/packages/signals/src/signals.ts
+++ b/packages/signals/src/signals.ts
@@ -512,7 +512,7 @@ export function createEffect<T>(
   }
   effect(compute as any, (effectFn as any).effect || effectFn, (effectFn as any).error, {
     user: true,
-    ...(__OBSERVE__ ? { ...options, name: options?.name ?? "effect" } : options)
+    ...options
   });
 }
 
@@ -550,12 +550,7 @@ export function createRenderEffect<T>(
   effectFn: EffectFunction<NoInfer<T>, T>,
   options?: EffectOptions
 ): void {
-  effect(
-    compute as any,
-    effectFn,
-    undefined,
-    __OBSERVE__ ? { ...options, name: options?.name ?? "effect" } : options
-  );
+  effect(compute as any, effectFn, undefined, options);
 }
 
 /**
@@ -607,10 +602,7 @@ export function createTrackedEffect(
   compute: () => void | (() => void),
   options?: BaseEffectOptions
 ): void {
-  trackedEffect(
-    compute,
-    __OBSERVE__ ? { ...options, name: options?.name ?? "trackedEffect" } : options
-  );
+  trackedEffect(compute, options);
 }
 
 /**
@@ -674,7 +666,7 @@ export function createReaction(
         },
         (effectFn as any).error,
         {
-          ...(__OBSERVE__ ? { ...options, name: options?.name ?? "effect" } : options),
+          ...options,
           user: true,
           defer: true
         }

--- a/packages/signals/tests/dist-artifacts.test.ts
+++ b/packages/signals/tests/dist-artifacts.test.ts
@@ -152,6 +152,96 @@ describe("@solidjs/signals artifacts", () => {
   });
 });
 
+describe("@solidjs/signals node literals per tier", () => {
+  // Each node factory has two object literals — prod, and observe = prod plus
+  // its diagnostic slots (`_name`; `_owner` on signals) — selected at build
+  // time. The slots MUST be in the literal: written after construction they
+  // force a hidden-class transition and an out-of-object property on every
+  // node, which was the whole of the observe tier's measured creation
+  // overhead. Two hand-kept literals can drift, so this pins the invariant
+  // from the built trees: the observe literal's keys are exactly the prod
+  // literal's keys plus the slots, and the prod literal has no slot at all.
+  // Field names are mangled per tree (`_name` is reserved), so the
+  // comparison is by count and by the reserved name.
+  async function literalKeys(tier: "prod" | "observe") {
+    const core = (await import(`../dist/${tier}/core/core.js`)) as any;
+    const owner = (await import(`../dist/${tier}/core/owner.js`)) as any;
+    const { createRoot } = (await import(`../dist/${tier}/index.js`)) as any;
+    const keys: Record<string, string[]> = {};
+    createRoot((dispose: () => void) => {
+      keys.owner = Object.keys(owner.createOwner());
+      keys.signal = Object.keys(core.signal(0));
+      keys.slotSignal = Object.keys(core.slotSignal(0, () => false, {}, "k", false));
+      keys.computed = Object.keys(core.computed(() => 0));
+      keys.effect = Object.keys(
+        core.createEffectNode(
+          () => 0,
+          () => {},
+          undefined,
+          1,
+          undefined
+        )
+      );
+      dispose();
+    });
+    return keys;
+  }
+
+  test("observe literals are the prod literals plus their slots — never a write after", async () => {
+    const prod = await literalKeys("prod");
+    const observe = await literalKeys("observe");
+    const slots: Record<string, string[]> = {
+      owner: ["_name"],
+      signal: ["_name", "_owner"],
+      slotSignal: ["_name"],
+      computed: ["_name"],
+      effect: ["_name"]
+    };
+    for (const kind of Object.keys(slots)) {
+      expect(prod[kind], `${kind} prod literal carries a slot`).not.toContain("_name");
+      expect(observe[kind], `${kind} observe literal lacks its slot`).toContain("_name");
+      expect(observe[kind].length, `${kind} literals drifted`).toBe(
+        prod[kind].length + slots[kind].length
+      );
+    }
+    // The prod computed/effect literals sit under V8's in-object boundary
+    // (~39 fields, §12); the observe slot must not push either past it.
+    expect(observe.effect.length).toBeLessThanOrEqual(38);
+    expect(observe.computed.length).toBeLessThanOrEqual(38);
+  });
+
+  test("observe defaults land in the slot, not as a later write", async () => {
+    const observe = (await import("../dist/observe/index.js")) as any;
+    const core = (await import("../dist/observe/core/core.js")) as any;
+    // Default labels and a supplied name both come out of the same literal:
+    // the key set is identical either way.
+    const plain = core.computed(() => 0);
+    const named = core.computed(() => 0, { name: "n" });
+    expect(Object.keys(named)).toEqual(Object.keys(plain));
+    expect(plain._name).toBe("computed");
+    expect(named._name).toBe("n");
+    // The default effect label comes from the node kind, not from an options
+    // spread in the wrapper (which allocated per effect in observe).
+    let effectName: string | undefined;
+    let trackedName: string | undefined;
+    observe.createRoot((dispose: () => void) => {
+      observe.createEffect(
+        () => {
+          effectName = (observe.getOwner() as any)._name;
+        },
+        () => {}
+      );
+      observe.createTrackedEffect(() => {
+        trackedName = (observe.getOwner() as any)._name;
+      });
+      observe.flush();
+      dispose();
+    });
+    expect(effectName).toBe("effect");
+    expect(trackedName).toBe("trackedEffect");
+  });
+});
+
 describe("@solidjs/signals artifacts under require()", () => {
   // Node >= 22.12 loads ESM through `require()` synchronously. That is what
   // lets the package ship ESM only: a CJS host follows the same export

--- a/packages/signals/tests/graph-size-diagnostics.test.ts
+++ b/packages/signals/tests/graph-size-diagnostics.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createEffect, createRoot, createSignal, flush, OBSERVE } from "../src/index.js";
+import {
+  createEffect,
+  createMemo,
+  createRoot,
+  createSignal,
+  flush,
+  OBSERVE
+} from "../src/index.js";
 import { GRAPH_SIZE_WARN_AT, GRAPH_SIZE_WARN_EVERY } from "../src/core/dev.js";
 
 afterEach(() => {
@@ -15,20 +22,34 @@ function captureGraphEvents() {
   };
 }
 
+/** `n` effects subscribed to `read`, under one disposable root. */
+function subscribe(read: () => unknown, n: number) {
+  return createRoot(d => {
+    for (let i = 0; i < n; i++) {
+      createEffect(
+        () => read(),
+        () => {}
+      );
+    }
+    return d;
+  });
+}
+
+// The core keeps no live edge counts (a per-node counter was a
+// post-construction field that forked node shapes): fan-out is counted by the
+// notify walk a committed change already makes over its subscribers, fan-in
+// by the recompute pass over the sources it tracks. So both warnings fire on
+// the WORK — the write / the recompute — not on the link.
 describe("graph-size diagnostics", () => {
-  it("warns HUGE_FAN_OUT when one signal reaches the subscriber threshold", () => {
+  it("warns HUGE_FAN_OUT when a change reaches the subscriber threshold", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const cap = captureGraphEvents();
-    const [value] = createSignal(0, { name: "hot-source" });
-    const dispose = createRoot(d => {
-      for (let i = 0; i < GRAPH_SIZE_WARN_AT; i++) {
-        createEffect(
-          () => value(),
-          () => {}
-        );
-      }
-      return d;
-    });
+    const [value, setValue] = createSignal(0, { name: "hot-source" });
+    const dispose = subscribe(value, GRAPH_SIZE_WARN_AT);
+    flush();
+    // Static structure alone is silent: nothing has re-run yet.
+    expect(cap.events()).toHaveLength(0);
+    setValue(1);
     flush();
     const events = cap.events();
     expect(events).toHaveLength(1);
@@ -37,13 +58,13 @@ describe("graph-size diagnostics", () => {
     expect(events[0].nodeName).toBe("hot-source");
     expect(events[0].data).toEqual({ count: GRAPH_SIZE_WARN_AT });
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("[HUGE_FAN_OUT]"));
-    expect(warn.mock.calls[0][0]).toContain(`has ${GRAPH_SIZE_WARN_AT} subscribers`);
+    expect(warn.mock.calls[0][0]).toContain(`with ${GRAPH_SIZE_WARN_AT} subscribers`);
     cap.stop();
     dispose();
     flush();
   });
 
-  it("warns HUGE_FAN_IN when one computation reaches the source threshold", () => {
+  it("warns HUGE_FAN_IN when a recompute tracks the source threshold", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const cap = captureGraphEvents();
     const signals = Array.from({ length: GRAPH_SIZE_WARN_AT }, (_, i) => createSignal(i));
@@ -61,6 +82,7 @@ describe("graph-size diagnostics", () => {
     const events = cap.events();
     expect(events).toHaveLength(1);
     expect(events[0].code).toBe("HUGE_FAN_IN");
+    expect(events[0].nodeName).toBe("wide-reader");
     expect(events[0].data).toEqual({ count: GRAPH_SIZE_WARN_AT });
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("[HUGE_FAN_IN]"));
     cap.stop();
@@ -68,58 +90,100 @@ describe("graph-size diagnostics", () => {
     flush();
   });
 
-  it("re-warns at the repeat interval, not on every link past the threshold", () => {
+  it("counts distinct sources per pass — repeat reads and nested pulls do not inflate", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const cap = captureGraphEvents();
-    const [value] = createSignal(0);
+    const signals = Array.from({ length: GRAPH_SIZE_WARN_AT - 1 }, (_, i) => createSignal(i));
+    const [trigger, setTrigger] = createSignal(0);
     const dispose = createRoot(d => {
-      for (let i = 0; i < GRAPH_SIZE_WARN_AT + GRAPH_SIZE_WARN_EVERY; i++) {
-        createEffect(
-          () => value(),
-          () => {}
-        );
-      }
+      createEffect(
+        () => {
+          trigger();
+          // Each source read twice: 1999 distinct deps + trigger = 2000 - 1 + 1.
+          for (const [read] of signals) (read(), read());
+        },
+        () => {}
+      );
       return d;
     });
     flush();
-    const events = cap.events();
-    expect(events).toHaveLength(2);
-    expect(events[0].data).toEqual({ count: GRAPH_SIZE_WARN_AT });
-    expect(events[1].data).toEqual({ count: GRAPH_SIZE_WARN_AT + GRAPH_SIZE_WARN_EVERY });
+    // Exactly the threshold — a double-counting pass would report ~4000.
+    expect(cap.events().map(e => e.data)).toEqual([{ count: GRAPH_SIZE_WARN_AT }]);
+    // A re-run tracks the same 2000: not grown by GRAPH_SIZE_WARN_EVERY, so silent.
+    setTrigger(1);
+    flush();
+    expect(cap.events()).toHaveLength(1);
     cap.stop();
     dispose();
     flush();
   });
 
-  it("unlink decrements the count — a rebuilt graph warns from the true size", () => {
+  it("re-warns once the count has grown by the repeat interval, not on every change", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
-    const [value] = createSignal(0);
-    const build = () =>
-      createRoot(d => {
-        for (let i = 0; i < GRAPH_SIZE_WARN_AT; i++) {
-          createEffect(
-            () => value(),
-            () => {}
-          );
-        }
-        return d;
-      });
-    const dispose1 = build();
+    const cap = captureGraphEvents();
+    const [value, setValue] = createSignal(0);
+    const dispose1 = subscribe(value, GRAPH_SIZE_WARN_AT);
+    setValue(1);
+    flush();
+    setValue(2);
+    flush();
+    // Two writes at the same size: one warning.
+    expect(cap.events().map(e => e.data)).toEqual([{ count: GRAPH_SIZE_WARN_AT }]);
+    // Grown, but by less than the interval: still one.
+    const dispose2 = subscribe(value, GRAPH_SIZE_WARN_EVERY - 1);
+    setValue(3);
+    flush();
+    expect(cap.events()).toHaveLength(1);
+    // Reaches the interval: a second warning, at the new size.
+    const dispose3 = subscribe(value, 1);
+    setValue(4);
+    flush();
+    expect(cap.events().map(e => e.data)).toEqual([
+      { count: GRAPH_SIZE_WARN_AT },
+      { count: GRAPH_SIZE_WARN_AT + GRAPH_SIZE_WARN_EVERY }
+    ]);
+    cap.stop();
+    dispose1();
+    dispose2();
+    dispose3();
+    flush();
+  });
+
+  it("a rebuilt graph warns from its live size — unlinked subscribers are not counted", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const [value, setValue] = createSignal(0);
+    const dispose1 = subscribe(value, GRAPH_SIZE_WARN_AT);
     flush();
     dispose1();
     flush();
-    // If disposal failed to decrement, the second build's counts would pass
-    // through 2500/3000/3500/4000 and emit interval warnings with counts
-    // above the threshold; a correct rebuild warns exactly once, at the
-    // threshold itself.
     const cap = captureGraphEvents();
-    const dispose2 = build();
+    const dispose2 = subscribe(value, GRAPH_SIZE_WARN_AT);
+    setValue(1);
     flush();
-    const events = cap.events();
-    expect(events).toHaveLength(1);
-    expect(events[0].data).toEqual({ count: GRAPH_SIZE_WARN_AT });
+    // The count is the walked list, so a stale tally cannot read 4000 here.
+    expect(cap.events().map(e => e.data)).toEqual([{ count: GRAPH_SIZE_WARN_AT }]);
     cap.stop();
     dispose2();
+    flush();
+  });
+
+  it("a derived change counts its own fan-out", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const cap = captureGraphEvents();
+    const [value, setValue] = createSignal(0);
+    let dispose!: () => void;
+    createRoot(d => {
+      dispose = d;
+      const doubled = createMemo(() => value() * 2, { name: "doubled" });
+      subscribe(doubled, GRAPH_SIZE_WARN_AT);
+    });
+    flush();
+    setValue(1);
+    flush();
+    const events = cap.events();
+    expect(events.map(e => [e.code, e.nodeName])).toEqual([["HUGE_FAN_OUT", "doubled"]]);
+    cap.stop();
+    dispose();
     flush();
   });
 });

--- a/scripts/size/.size-limit.js
+++ b/scripts/size/.size-limit.js
@@ -729,7 +729,15 @@ module.exports = [
     path: "csr-app.js",
     // Effect ownership on finalize re-entry (#3319, 2026-09-09): 14.30 KB -> 14.34 KB,
     // measured at 14.302. Core scheduler cost; see the core-floor note.
-    limit: "14.34 KB",
+    // Observe node shapes (#3324, 2026-09-09): 14.34 -> 14.40 KB, measured
+    // at 14.332 (was 14.284 before the PR, on the post-golf next). Observe
+    // now carries a second literal per node factory — prod's plus its
+    // `_name`/`_owner` slot — instead of a post-construction write, so the
+    // tier's node shapes stop transitioning (creation tests 2-3x under
+    // polymorphic load as shipped, at parity after). Prod is byte-identical;
+    // this scenario alone pays the duplicated literal bodies. Headroom
+    // restored: the +48 B left 8 B under the old ratchet.
+    limit: "14.40 KB",
     modifyEsbuildConfig: observeEsbuildConfig
   },
   {
@@ -745,7 +753,12 @@ module.exports = [
     path: "csr-app-attribution.js",
     // Contested-effect re-derivation (#3322, 2026-09-09): 24.00 -> 24.08 KB,
     // measured at 24.04. Core scheduler cost; see the core-floor note.
-    limit: "24.08 KB",
+    // Observe node shapes (#3324, 2026-09-09): 24.08 -> 24.14 KB, measured
+    // at 24.079 (1 B under the old ratchet). The literal duplication above
+    // is offset here by the engine dropping the live `_subCount`/`_depCount`
+    // machinery: WIDE_WRITE counts the subscriber list on the write and
+    // hands over to HUGE_FAN_OUT at 2000. Ratchet restores headroom only.
+    limit: "24.14 KB",
     modifyEsbuildConfig: observeEsbuildConfig
   },
   {


### PR DESCRIPTION
Bisect for #3324's CodSpeed createRenderEffects:create1to1 regression (−5.8%). This is #3324 with neither fan-in nor fan-out counting — the node-literal change alone. Will be closed once CodSpeed reports.

Made with [Cursor](https://cursor.com)