### PR TITLE
feat(signals): router-agnostic navigation attribution (OBSERVE.attribution.withOrigin)

### DIFF
--- a/.changeset/attribution-navigation-origin.md
+++ b/.changeset/attribution-navigation-origin.md
@@ -1,0 +1,14 @@
+---
+"@solidjs/signals": patch
+---
+
+Router-agnostic navigation attribution: `OBSERVE.attribution.withOrigin({ kind: "navigation", name, to, from, params }, fn)`
+
+A navigation in Solid 2 is a plain write to the location; the runtime already sees everything it costs (the hold behind route data, the re-runs, the silence) but not that the writes were a navigation, or to which route. `withOrigin` is the seam where a router says so, around its write — the one router-specific line, living in the router. From it the attribution engine:
+
+- stamps the writes with a `navigation` origin (new `ChangeOrigin.kind`, with `name`/`to`/`from`/`params`), nested under the enclosing interaction — including through an action step — so cause chains read `— navigation to /users/:id (under click on a.nav "Alice")`;
+- names holds by route: `HoldEvent.origin`, `SILENT_HOLD`/`LONG_HOLD` messages that start from the navigation, and `data.navigation` on the event;
+- keeps one `NavigationEvent` per frame (`attribution.navigations()`), settled exactly once as `committed` (a plain drain took the writes), `held` (with the `HoldEvent` attached), or `superseded` (a later write replaced them before they landed);
+- folds settled navigations per route into `feedback().navigations`.
+
+One new core hook, `flushEnd`, fires once per `flush()` drain so the engine has the "committed and effects ran" instant for writes no transition held. Prod builds are unchanged (the hook site folds out; only the inert attribution twin gained the new empty queries).

--- a/.changeset/observe-node-shapes.md
+++ b/.changeset/observe-node-shapes.md
@@ -1,0 +1,29 @@
+---
+"@solidjs/signals": patch
+---
+
+Observe tier: no post-construction fields on reactive nodes.
+
+The observe build stamped `_name` on every node, `_owner` on `createSignal`
+nodes and live `_subCount`/`_depCount` edge counters on linked nodes after the
+node literal — exactly the hidden-class transitions the prod literals are
+shaped to avoid. Measured against prod on the reactivity benchmark the tier
+cost +15% overall with creation tests 2–3× under polymorphic load.
+
+- Node factories (`computed`, `createEffectNode`, `signal`, `slotSignal`,
+  `createOwner`) now have two literals selected at build time: prod, and
+  observe = prod plus its `_name` slot (`_owner` too on signals). Default
+  labels (`signal`, `computed`, `effect`, `trackedEffect`) come from the
+  literal, so the `createEffect`/`createRenderEffect`/`createTrackedEffect`
+  wrappers no longer spread a fresh options object per effect to inject one.
+  A dist test pins observe's key set to prod's plus the slots.
+- Edge counters are gone. `HUGE_FAN_OUT` is counted by the notify walk a
+  committed change already makes over its subscribers, `HUGE_FAN_IN` by the
+  recompute pass over the sources it tracks (one module counter in `link()`).
+  Both therefore fire on the work — the change / the recompute — rather than
+  on the link, once per node and again after +500 growth (a WeakMap, not a
+  node field). `WIDE_WRITE` (engine) counts the subscriber list on the write
+  and hands over to `HUGE_FAN_OUT` at 2000, so a change never carries both.
+  Messages: "changed with N subscribers" / "tracked N sources".
+- Prod artifacts are unchanged apart from removing a leftover
+  `...(false ? {...} : options)` spread in `createEffect`.

--- a/documentation/performance-experiments.md
+++ b/documentation/performance-experiments.md
@@ -6853,3 +6853,253 @@ Status vs the no-regression bar: full and partial tick both in the
 alternating-measurement parity band (0.97–1.15x swings, centered ~1.05);
 sort/mount/unmount at parity or faster. Cool-machine confirmation still
 recommended for the record.
+
+## Observe Tier Lane (2026-09-09): prod vs observe runtime cost
+
+Question: what does the `observe` build tier (PR #3317 — wiring kept,
+checks stripped; attribution engine NOT imported) cost at runtime against
+`prod`, on both Tier-2 lanes? Scope is the shipped artifacts as a bundler
+resolves them (`dist/prod` vs `dist/observe` for signals; `observe` export
+condition end-to-end for the DOM app). Nothing here has the engine enabled
+— that is a separate, opt-in cost.
+
+Machine: Apple M5, Node v26.4.0, Chrome 153. Commit `8cfa2724` (`next`).
+
+### Method
+
+- **Node lane** — `js-reactivity-benchmark`, `solid-next` adapter, harness
+  import pointed at `packages/signals/dist/{prod,observe}/index.js` via a
+  `/tmp/jsrb-target` symlink and bundled once per tier with esbuild
+  (unminified). 5 full-suite runs per tier, interleaved prod/observe,
+  `node --expose-gc`. Medians below use runs 1, 2, 5 (3 and 4 overlapped
+  with build activity on the same machine; including them moves the total
+  by 0.2 pt). Numbers are ms per test.
+- **DOM lane** — a `js-framework-benchmark` `keyed/solid`-shaped app on
+  Solid 2 idioms (store rows, `createProjection` selection, keyed `<For>`),
+  built with Vite + `@solidjs/vite-plugin` twice: default conditions (prod)
+  and `resolve.conditions: ["observe"]`. Bundle: 21.5 KB gz prod vs
+  23.2 KB gz observe (+1.7 KB gz; matches the size-limit budget's +1.29 KB br).
+  Driven in headless Chrome (Playwright, `channel: "chrome"`) with the
+  whole scenario in ONE `page.evaluate`: synchronous `element.click()` per
+  op, a `window` bubble listener calling `flush()` after Solid's delegated
+  handler so each click is dispatch + `withInteraction` +
+  `describeEventTarget` + handler + propagation + DOM writes, timed with
+  `performance.now()` under COOP/COEP (5 µs resolution). Fresh page per
+  iteration, one warmup pass then one measured pass, tiers alternated,
+  30 iterations. Per-click medians.
+
+Two measurement traps found on the way, recorded so the next lane doesn't
+re-learn them:
+
+1. Anything timed across a task boundary after a click (rAF,
+   MessageChannel) quantizes to the ~16 ms vsync — Chrome aligns input
+   dispatch to the frame. Only a synchronous drain inside the click task
+   measures the script cost.
+2. A loop-mean per op is poisoned by GC placement: one ~3 ms pause lands
+   somewhere in every pass, and observe's slightly larger heap moved it
+   from the `swap` loop (prod) into the `update` loop (observe), reading as
+   "update 2× slower, swap 20% faster". Per-click medians fixed it.
+
+### Result 1 — Node lane, as shipped (`dist/observe`)
+
+| test                          |       prod |    observe |        Δ % |
+| ----------------------------- | ---------: | ---------: | ---------: |
+| createComputations            |      117.4 |      146.2 |     +24.5% |
+| create0to1                    |       12.7 |       17.1 |     +34.9% |
+| create4to1                    |        4.3 |       12.7 |      +193% |
+| create1to1000                 |       15.5 |       25.4 |     +63.7% |
+| create1to4                    |       16.0 |       21.4 |     +34.1% |
+| updateSignals                 |      470.1 |      485.9 |      +3.4% |
+| update1to1                    |       34.6 |       34.4 |      −0.6% |
+| update1to1000                 |      369.5 |      374.9 |      +1.5% |
+| broadPropagation              |      175.6 |      202.1 |     +15.1% |
+| deepPropagation               |       65.8 |       79.8 |     +21.4% |
+| diamond                       |      137.5 |      151.2 |     +10.0% |
+| 4-1000x12 - dyn5%             |      402.5 |      513.3 |     +27.5% |
+| 25-1000x5                     |      496.7 |      652.9 |     +31.4% |
+| 3-5x500                       |      129.7 |      163.7 |     +26.3% |
+| 6-100x15 - dyn50%             |      233.2 |      265.0 |     +13.7% |
+| **sum of medians (34 tests)** | **3181.9** | **3676.6** | **+15.5%** |
+
+Update-only tests are at parity (±3%). Creation and dynamic-graph tests
+are +15–65%, with `create4to1` an outlier at 3×.
+
+The outliers are a **suite-state** effect, not per-op cost: run alone
+(`TESTS=create4to1`), observe is 4.24 vs prod 3.76 (+13%), `create1to1000`
+18.3 vs 17.2 (+6%), `4-1000x12` 363.6 vs 362.0 (0%). `--trace-gc` shows
+the same GC count and retained heap for both tiers (≈985 vs 937 scavenges,
+5–6 MB retained), so it is not memory; it is hidden-class polymorphism that
+accumulates across the suite and lands on whichever test runs later.
+
+Cause, from the observe sites in `core.ts`/`dev.ts`/`graph.ts`: the tier
+adds fields to nodes **after** the literal — exactly the post-construction
+expandos the prod literals were shaped to avoid (`core.ts` "pre-shaped
+(were post-construction expandos)", "§12" in-object comment):
+
+- `_name` assigned after every computed/effect/signal/slot literal
+  (`core.ts` 672/763/871/939) — one transition per node type.
+- `_owner` assigned by `registerGraph` only for `createSignal` /
+  `createOptimisticSignal` nodes (`signals.ts` 373/1085) — Signal shape
+  forks into with/without-`_owner`.
+- `_subCount` / `_depCount` added lazily on first link by `noteGraphLink`
+  (`dev.ts` 506) — a further fork on both Signal and Computed, plus two
+  loads/stores and a `shouldWarnGraphSize` call on every `link()` and
+  `unlinkSubs()`.
+- `effect()` in `signals.ts` (515/557/612/677) spreads a fresh options
+  object per effect creation to inject the default name (`effect$1`
+  shows 25 ms self time in the DOM profile where prod's is inlined away).
+
+### Result 2 — DOM lane, as shipped
+
+| op                      | prod median | observe median |            Δ % |
+| ----------------------- | ----------: | -------------: | -------------: |
+| create 1k               |       2.407 |          2.612 |          +8.5% |
+| replace 1k              |       2.778 |          2.918 |          +5.0% |
+| update every 10th       |       0.135 |          0.155 | +14.8% (20 µs) |
+| swap rows               |       0.460 |          0.470 |          +2.2% |
+| select row              |       0.030 |          0.035 |  +16.7% (5 µs) |
+| remove row              |       0.645 |          0.640 |          −0.8% |
+| clear 1k                |       0.435 |          0.385 |         −11.5% |
+| create 10k              |       23.09 |          23.25 |          +0.7% |
+| clear 10k               |        3.06 |           2.99 |          −2.4% |
+| **whole pass incl. GC** |   **72.07** |      **74.68** |      **+3.6%** |
+
+DOM work dominates, so the same reactive overhead reads as +3.6% overall
+and +5–8% on creation. Per-interaction fixed cost (`withInteraction` +
+`describeEventTarget`) is within the 5 µs resolution on `select`.
+
+### Experiment — pre-shape the observe fields (scratch, reverted)
+
+Added `_name`, `_owner: null`, `_subCount: 0` (and `_depCount: 0` on
+computed/effect) to the four node literals in `core.ts`; then additionally
+stubbed the `noteGraphLink`/`unnoteGraphLink` calls in `graph.ts`. Rebuilt
+`dist/observe` only. Single full-suite run per variant, same-session prod
+rerun as the reference:
+
+|                            |  prod | observe as shipped | + pre-shaped fields | + no edge counters |
+| -------------------------- | ----: | -----------------: | ------------------: | -----------------: |
+| Node lane, sum of 34 tests |  3111 |        3733 (+20%) |        3342 (+7.4%) |       3281 (+5.5%) |
+| `create1to1000`            |  15.2 |               23.3 |                15.8 |               15.9 |
+| `createComputations`       | 116.8 |              150.4 |               122.1 |              123.8 |
+| `4-1000x12 - dyn5%`        | 400.8 |              519.7 |               468.4 |              436.2 |
+| `25-1000x5`                | 484.4 |              657.2 |               602.7 |              559.0 |
+| DOM lane, whole pass       | 71.90 |      74.68 (+3.6%) |                   — |      71.85 (−0.1%) |
+| DOM `create 1k`            | 2.397 |      2.612 (+8.5%) |                   — |      2.457 (+2.5%) |
+
+Pre-shaping alone removes two thirds of the Node-lane gap and all of the
+creation outliers; the edge counters are worth another ~2 pt on the
+dynamic-graph tests. Whole-suite CPU profile of the last variant vs prod:
++2.6% total, spread thinly (`read` +6%, `link` +5%) — no single hot
+observe function remains. The residual is the `attrHooks !== null` guards
+on `recompute`/`write` plus the extra literal slots.
+
+Caveat on the literal budget: the effect literal is 35 fields in prod; the
+experiment's +4 puts it at 39, the "§12" in-object boundary the comment
+warns about. The real change must not just append: candidates are folding
+`_subCount`/`_depCount` into one slot, moving `_name`/`_owner` into a
+single pre-allocated observe record, or reclaiming a slot elsewhere.
+Measure `create*` after.
+
+### Verdict
+
+- The `observe` tier as merged is **not** at prod parity: +15% on the
+  reactivity lane, +3.6% on a DOM app, with 2–3× creation outliers under
+  polymorphic load. Not shippable as "production-eligible" yet.
+- The cost is structural (node shape), not the hook calls; the fix is
+  mechanical and validated to bring the Node lane to ≈+5% and the DOM lane
+  to parity. Do it before measuring anything downstream (adapter,
+  sampling).
+- Method for the re-measure is pinned above: full-suite Node runs
+  (isolated tests hide the polymorphism), per-click medians in Chrome.
+
+### Fix — literal slots, no edge counters (`observe-perf` branch)
+
+What landed, against the cause list above:
+
+- **Slots, not writes.** Each node factory (`computed`, `createEffectNode`,
+  `signal`, `slotSignal`, `createOwner`) now has two object literals chosen
+  at build time by the observe flag: prod, and observe = prod plus `_name`
+  (`_owner` too on `signal`). Default labels come from the literal
+  (`trackedEffect` relabels its computed's slot), so the `createEffect` /
+  `createRenderEffect` / `createTrackedEffect` wrappers no longer spread a
+  fresh options object per effect. Alternatives rejected: `...(flag ? {…} :
+  null)` leaves a `...false` spread in prod (rollup folds the conditional
+  but not the spread element — and in fact one such spread was already
+  sitting in prod's `createEffect`, removed here); `{…prod, _name}` clones
+  and then transitions, which is the same cost as the write; the `_x`
+  extension would cost a 19-field allocation per named node / per
+  `createSignal`. Observe literal sizes: computed 30, effect 36, signal 16,
+  slot signal 20, owner 15 — all under the ~39 in-object boundary; a dist
+  test (`dist-artifacts.test.ts` "node literals per tier") pins observe's
+  key set to prod's plus the slots and the ≤38 bound.
+- **No edge counters.** `_subCount`/`_depCount` and `noteGraphLink` /
+  `unnoteGraphLink` are gone. Fan-out is counted by the notify walk in
+  `insertSubs` (one local increment in a loop that already visits every
+  edge); fan-in by `link()` bumping one module counter per first touch of
+  a pass, bracketed by `recompute`. `HUGE_FAN_OUT` / `HUGE_FAN_IN` therefore
+  fire on the change / the recompute rather than the link, deduped through a
+  `WeakMap` (once per node, again after +500). `WIDE_WRITE` counts the
+  subscriber list itself on the write (engine-only walk) and hands over to
+  `HUGE_FAN_OUT` at 2000.
+- **Prod byte-identical** modulo comments and the removed `...false ? {…} :
+  options` spread (`diff -w` of `dist/prod` before/after, comment lines
+  stripped: only that hunk).
+
+Re-measured with the pinned method (5 interleaved full-suite Node runs;
+30 DOM iterations, per-click medians). Same machine; absolute numbers are
+higher than the first session's (other load), the tiers are interleaved so
+the comparison holds.
+
+| Node lane (ms, median of 5) |   prod | observe |   Δ % | as shipped Δ % |
+| --------------------------- | -----: | ------: | ----: | -------------: |
+| createSignals               |   8.30 |    8.34 | +0.5% |                |
+| createComputations          | 131.44 |  130.82 | −0.5% |         +24.5% |
+| create1to1000               |  18.34 |   16.66 | −9.2% |         +63.7% |
+| updateSignals               | 486.74 |  510.86 | +5.0% |          +3.4% |
+| update1to1000               | 380.95 |  386.55 | +1.5% |          +1.5% |
+| broadPropagation            | 184.70 |  190.10 | +2.9% |         +15.1% |
+| deepPropagation             |  69.46 |   72.52 | +4.4% |         +21.4% |
+| diamond                     | 148.75 |  147.98 | −0.5% |         +10.0% |
+| 4-1000x12 - dyn5%           | 429.06 |  515.49 | +20.1% |        +27.5% |
+| 25-1000x5                   | 526.01 |  608.27 | +15.6% |        +31.4% |
+| 3-5x500                     | 130.67 |  142.86 | +9.3% |         +26.3% |
+| **sum of medians (34)**     | **3305** | **3567** | **+7.9%** |    **+15.5%** |
+
+Creation is at parity (the whole of the create* aggregate: −0.5%). The two
+`dyn` tests still read +15–20% on medians but their per-run spread is
+wider than the gap (`4-1000x12` prod 416–522 vs observe 410–521;
+`25-1000x5` prod 477–566 vs observe 493–727) — minimums are at parity, so
+this is run-to-run variance on the allocation-heavy tests, not a per-op
+cost; 5 runs are not enough to resolve it and the 7.9% total is an upper
+bound. `create4to1` reads 2× (4.7 vs 9.4 ms) in every run, including as
+shipped and in the scratch experiment: it is GC placement. The timed
+region allocates ~14 MB behind 100k pre-built signals, observe's signals
+are two slots larger, and the scavenge lands inside the window for one
+tier and outside for the other — deterministic per tier because `run()`
+GCs before each iteration. With `--max-semi-space-size=256` the two tiers
+swap places between runs (prod 4.29 / 8.14, observe 4.79 / 4.99), and
+`create1to4` flips to observe-faster; sub-10 ms tests in this suite cannot
+resolve a slot's worth of cost.
+
+| DOM lane (ms, per-click median, 30 iters) |   prod | observe |    Δ % | as shipped Δ % |
+| ----------------------------------------- | -----: | ------: | -----: | -------------: |
+| create 1k                                 |  2.730 |   2.808 |  +2.8% |          +8.5% |
+| replace 1k                                |  3.208 |   3.238 |  +0.9% |          +5.0% |
+| update every 10th                         |  0.160 |   0.160 |   0.0% |         +14.8% |
+| swap rows                                 |  0.525 |   0.525 |   0.0% |          +2.2% |
+| select row                                |  0.035 |   0.040 | +14.3% (5 µs) |   +16.7% |
+| remove row                                |  0.735 |   0.735 |   0.0% |          −0.8% |
+| create 10k                                | 26.605 |  26.810 |  +0.8% |          +0.7% |
+| **whole pass incl. GC**                   | **82.99** | **83.49** | **+0.6%** |  **+3.6%** |
+
+The DOM lane is at parity; the 5 µs on `select` is the per-interaction
+fixed cost (`withInteraction` + `describeEventTarget`), unchanged and at
+the timer's resolution.
+
+Residual observe cost, by construction: one slot per node (two on
+signals), the `attrHooks !== null` guards on recompute/write/effect-run,
+the fan-in counter (a module increment per first-touch link and two calls
+per recompute), the fan-out increment per notified edge, and
+`registerGraph`'s `getOwner()` + slot store per `createSignal`. Bundle:
++1.7 KB gz on the JFB app (unchanged — the slots are code the observe
+build already carried as writes).

--- a/documentation/proposals/production-observability-sketch.md
+++ b/documentation/proposals/production-observability-sketch.md
@@ -103,9 +103,11 @@ the sites survive the build. The surface is small and well-delineated:
   `effect.ts` 3 — effect run start/end). All outside `try` per the #2883 rule.
 - **Names**: 5 `_name` assignment sites (`core.ts` ×4, `store.ts` ×1) —
   needed for anything to be legible.
-- **Edge counters**: 2 sites (`graph.ts` `noteGraphLink` / `unnoteGraphLink`)
-  maintaining `_subCount`/`_depCount` — needed by `WIDE_WRITE` and the
-  always-on fan-out warnings.
+- **Edge counts**: none stored. Fan-out is counted by the notify walk
+  (`insertSubs`), fan-in by the recompute pass (`link()` into one module
+  counter) — the always-on graph-size warnings and `WIDE_WRITE` read those.
+  (An earlier draft kept live `_subCount`/`_depCount` fields per node; they
+  forked node shapes and were removed.)
 - **Web runtime (`@solidjs/web`)**: 3 `withInteraction` wrap sites
   (`attachDelegatedEvent`, and the two `addEvent` branches) behind
   `"_SOLID_DEV_"`.

--- a/documentation/solid-2.0/08-dev-diagnostics.md
+++ b/documentation/solid-2.0/08-dev-diagnostics.md
@@ -383,7 +383,7 @@ Thresholds sit at the strict end of the published bands on purpose. The engine m
 
 A signal/store write (or an action's writes) was held because a downstream async source went pending, and for the whole hold no acknowledgement was observed: no subscribed `isPending()` or `latest()` companion on the held graph, no optimistic overlay, no `affects()` declaration, and no lane effect painted while the hold was open. (Mainline effects are stashed while a hold is open, so the only effects that _can_ paint are readers of optimistic values and companions — the screen changing in response to the hold. An unrelated effect cannot clear the verdict; it waits with everything else. A `Loading` boundary that has not revealed yet is a different answer — the read never holds, the fallback shows.) Holds shorter than `holds.infoMs` (default 100ms — RAIL's "feels instant" ceiling) are recorded silently; from `infoMs` the hold emits `info`; from `holds.warnMs` (default 200ms — the INP "good" ceiling) it warns. When the silent hold is also long (below) the message carries the boundary repair and `data.long` is `true`; one hold is one report.
 
-The hold is attributed to its opening interaction when the web runtime can stamp it (`click`, `keydown`, `input` on the element hit), to the effect or action that made the write otherwise. `holdMs` runs from the interaction's dispatch or the first parked flush, whichever is earlier. Every hold — reported or not — is queryable via `attribution.holds()`.
+The hold is attributed to its opening interaction when the web runtime can stamp it (`click`, `keydown`, `input` on the element hit), to the effect or action that made the write otherwise. When the held write was a router's navigation declared via `withOrigin`, the hold also carries that `origin` and the message names the route — "[click on a.nav (navigation to /users/:id)] wrote [location] …" — with `data.navigation` giving the pattern, paths and params. `holdMs` runs from the interaction's dispatch or the first parked flush, whichever is earlier. Every hold — reported or not — is queryable via `attribution.holds()`.
 
 #### `LONG_HOLD`
 
@@ -479,7 +479,7 @@ Beyond the always-on diagnostics above, dev and observe builds ship an opt-in **
     ← signal "notifications" write (#5) 2 → 3
 ```
 
-The engine is its own entry, `solid-js/attribution` (re-exporting `@solidjs/signals/attribution`), so a build that never imports it never ships it: the runtime carries only the hook slot the engine installs into (`OBSERVE.attribution.install`) and the interaction frame the web runtime opens around event dispatch (`OBSERVE.attribution.withInteraction`). The import is legal in every tier — the prod tier resolves an inert engine with the same surface, so app code needs no per-tier guard.
+The engine is its own entry, `solid-js/attribution` (re-exporting `@solidjs/signals/attribution`), so a build that never imports it never ships it: the runtime carries only the hook slot the engine installs into (`OBSERVE.attribution.install`) and the two declared frames — the interaction frame the web runtime opens around event dispatch (`OBSERVE.attribution.withInteraction`) and the origin frame a router opens around its navigation write (`OBSERVE.attribution.withOrigin`). The import is legal in every tier — the prod tier resolves an inert engine with the same surface, so app code needs no per-tier guard.
 
 ### API (`solid-js/attribution`)
 
@@ -506,6 +506,7 @@ attribution.subscriptions(fn);  // current dep names of one scope
 attribution.costs();            // { scopes, writes } ranked cost tables
 attribution.waterfalls();       // graph-provable sequential flight chains
 attribution.holds();            // every hold, acknowledged or not
+attribution.navigations();      // every declared navigation, settled or not (below)
 attribution.feedback();         // responsiveness tables (below)
 attribution.subscribe(fn);      // live RerunEvent feed
 attribution.disable();
@@ -521,6 +522,15 @@ attribution.markFlight(promise, startedAt?);
 // harnesses call it themselves. `fn()` when no engine is enabled.
 import { OBSERVE } from "solid-js";
 OBSERVE.attribution.withInteraction({ type: "click", target: 'button#next "Next →"' }, fn);
+// A router declares a navigation around its location write — match eagerly,
+// describe by the parametrized route, then write. This is the only
+// router-specific line anywhere; the engine knows no router.
+OBSERVE
+  ? OBSERVE.attribution.withOrigin(
+      { kind: "navigation", name: "/users/:id", to, from, params: match.params },
+      () => setLocation(to)
+    )
+  : setLocation(to);
 // An external engine (devtools) installs into the same slot the built-in
 // one uses: OBSERVE.attribution.install(hooks) / .installed.
 ```
@@ -537,9 +547,21 @@ Every root `ChangeRecord` carries an `origin` describing the imperative frame th
 | `effect`      | An effect callback (`name`, and the `run` of the compute run it belongs to)                      |
 | `action`      | An `action()` body (`name`); an `interaction` field carries the event that invoked it            |
 | `async`       | An async landing — the value arrived from a promise or iterable                                  |
+| `navigation`  | A router's navigation declared via `withOrigin` (`name` = route pattern, `to`, `from`, `params`) |
 | `external`    | Nothing enclosing was known (module scope, a timer, a foreign callback)                          |
 
 Effect- and action-origin writes resolve through the record of the run they belong to, so `RerunEvent.interaction` names the user interaction a re-run ultimately traces to, however many effects relayed it. Writes made after an `await` inside an action's body have left the action's synchronous frame; they are stamped `async`, which is what makes their escape from the transaction visible.
+
+### Navigations (`navigations()`)
+
+A navigation in Solid 2 is a plain write to the location — reads pull the route's async and the runtime holds the write until the data is ready — so the engine already sees everything a navigation costs. What it cannot see is that the writes _were_ a navigation, and to which route. `OBSERVE.attribution.withOrigin({ kind: "navigation", … }, fn)` is where a router says so, around its write; every router (or hand-rolled one) adds that one call, and nothing else anywhere is router-specific. From it the engine keeps one `NavigationEvent` per frame:
+
+- `name`, `to`, `from`, `params`, `at` — what the router described; `interaction` — the link click (or other event) it ran under, when known, including through an action step (`navigate()` after a `yield`).
+- `writes` — root writes the frame performed.
+- `settledMs` and `outcome`, once its writes are through: `committed` (a plain drain took them — settle is the end of that drain, the instant the screen had them), `held` (they waited in a transition — settle is its commit, and `hold` carries the `HoldEvent` when hold tracking recorded one), or `superseded` (a later write to the same node replaced them before they landed — the user navigated again).
+- `origin` — the frame object the writes were stamped with, the same object as `ChangeRecord.origin` on each write and `HoldEvent.origin` on the hold, so records join by identity.
+
+A navigation that changed nothing (no write survived the equality gate) settles at once with `writes: 0`. `formatOrigin` renders the kind as `navigation to /users/:id (/users/42)`, and cause chains under a click read `— navigation to /users/:id (under click on a.nav "Alice")`. `feedback().navigations` folds settled events per route.
 
 Known gap: handlers bound through the runtime (delegated events, and non-literal `on*` expressions that route through `addEvent`) are stamped; a _literal_ function handler compiles to a bare `addEventListener` and is not, so its writes read as `external` until the compiler wraps them too.
 
@@ -549,6 +571,7 @@ Known gap: handlers bound through the runtime (delegated events, and non-literal
 
 - `sources`: per set of async sources waited on, `holds`, `heldMs`/`worstMs`, the `silent` subset (no acknowledgement at any duration) with its `silentMs`, `latestOnly` (the only acknowledgement was a `latest()` shadow — the input showed, nothing said "loading"), `long`/`longMs` (holds whose tail reached `longHolds.infoMs`, acknowledged or not — the `LONG_HOLD` shape; `longMs` sums the tails), `acknowledgedBy` ranked by affordance (`isPending:`, `latest:`, `optimistic:`, `affects:` prefixed with the node), the `interactions` and root `writes` that were held, and how many holds an `action` opened or joined.
 - `interactions`: per opening interaction (`click on button#next "Next →"`), `dispatches` folded together, the re-`runs` traced back to it with summed `selfMs` and `worstDispatchMs` (the long-flush hazard) beside `holds`, `heldMs`, `silentMs`, and `worstHoldMs` (the silent-hold hazard) — the two INP failure modes as columns of one row.
+- `navigations`: per route pattern (`/users/:id`), `navigations` settled, summed `settledMs` and `worstMs`, the `held` subset with its `heldMs` and how many of those were `silent`, and `superseded` — navigations the user moved on from before they landed. The route-level view a router integration used to build itself, from the runtime's own facts.
 - `flights`: per async source, flights started, `landed` (with `landedMs`/`worstMs`) and `abandoned` — superseded before landing. A high abandon count is the request-per-keystroke signature.
 - `fallbacks`: per `Loading` boundary, `shows`, total `shownMs`, `worstMs`, and `flashes` — fallbacks shown under 150ms, the loading-flash shape.
 

--- a/documentation/solid-2.0/08-dev-diagnostics.md
+++ b/documentation/solid-2.0/08-dev-diagnostics.md
@@ -277,19 +277,19 @@ The owner passed to `runWithOwner` has already been disposed. Any reactive primi
 
 #### `HUGE_FAN_OUT`
 
-**Message:** "Signal [name] has N subscribers. Each will re-run when it changes. …"
+**Message:** "Signal [name] changed with N subscribers — every one re-runs this flush. …"
 
-One source has grown an unusually large number of live subscribers (first warning at 2000, repeated every additional 500). This is the signature of many independent computations reading the same value — for example, every row of a list comparing itself against one `selectedId` signal. Prefer a per-key store or a projection so only the items whose result actually flipped re-run.
+A committed change (a write, a memo's new value, an async landing) reached an unusually large number of live subscribers (first warning at 2000; re-warns once the count has grown by another 500). This is the signature of many independent computations reading the same value — for example, every row of a list comparing itself against one `selectedId` signal. Prefer a per-key store or a projection so only the items whose result actually flipped re-run.
 
-Always on in dev; maintained by the graph's link/unlink operations, so the counts reflect live edges (disposed subscribers don't count against the threshold).
+Always on wherever the diagnostics channel exists (dev and observe tiers). The count is taken by the notification walk the change makes anyway, so it is the live subscriber list at that moment — disposed subscribers don't count — and the core keeps no per-node counter for it (a live edge count was a post-construction field on every node, and forked node shapes). Fires on the change, not on subscription: a fan-out that is never written costs nothing, and one that is re-runs every subscriber right then.
 
-Related: `WIDE_WRITE` (below) fires at **write** time from a much lower threshold, but only while the attribution engine is enabled — static fan-out that never writes is harmless, so the write-time check can afford to be far more sensitive. `HUGE_FAN_OUT` is the always-on backstop for structure large enough to warn about even if it never changes.
+Related: `WIDE_WRITE` (below) is the same finding from a much lower threshold, but only while the attribution engine is enabled; it hands over to `HUGE_FAN_OUT` at 2000, so one change never carries both.
 
 #### `HUGE_FAN_IN`
 
-**Message:** "Computation [name] has N sources. It will re-run when any of them change. …"
+**Message:** "Computation [name] tracked N sources. It will re-run when any of them change. …"
 
-One computation subscribes to an unusually large number of sources (same thresholds as `HUGE_FAN_OUT`). This is the coarse-read signature — e.g. a helper that touches a whole store, or one memo derived from everything. Narrow the read or split the derivation so each computation tracks only what it needs.
+One recompute pass tracked an unusually large number of distinct sources (same thresholds as `HUGE_FAN_OUT`; counted per pass as the computation reads, repeat reads of the same source excluded). This is the coarse-read signature — e.g. a helper that touches a whole store, or one memo derived from everything. Narrow the read or split the derivation so each computation tracks only what it needs.
 
 Related: `WIDE_SCOPE_DEPS` (below) fires at a much lower threshold, but only while the attribution engine is enabled — it names the offending sources. `HUGE_FAN_IN` is the always-on backstop for the pathological case.
 
@@ -309,7 +309,7 @@ All three thresholds are configurable (or disable-able) through `enable()` optio
 
 A committed root invalidation — a signal or store write, a `refresh()`, or an async landing — reached a node with an unusually large number of live subscribers (default 250). Where the per-scope warnings above blame the _reader_, this one blames the _write_: it is the fan-out actually happening, priced at the moment it happens. The classic shape is many consumers asking keyed questions of one value (every row comparing against one selected id); the fix is inverting the subscription: keep the answer in a store used as a map keyed by id (`selected[row.id]` rather than `row.id === selectedId()`), so each consumer reads its own key and only the keys that flipped re-run; `createProjection` builds such a map when it is derived from other state.
 
-Attribution-engine only, like the trio above. Specced together with `HUGE_FAN_OUT` so the two never double-fire on one node: `HUGE_FAN_OUT` is always-on and fires at _link_ time from 2000 subscribers up — structure so large it warns even if never written — while `WIDE_WRITE` fires at _write_ time from a much lower bar, once per node, re-warning only after the subscriber count doubles. Unchanged writes never fire it (the source equality gate commits nothing and notifies no one). The check reads the same live `_subCount` the graph-size warnings maintain, so disposed subscribers don't count.
+Attribution-engine only, like the trio above. Specced together with `HUGE_FAN_OUT` so the two never double-fire on one change: `WIDE_WRITE` covers the range from its threshold up to 2000 subscribers, once per node, re-warning only after the subscriber count doubles; from 2000 up the always-on `HUGE_FAN_OUT` takes over. Unchanged writes never fire it (the source equality gate commits nothing and notifies no one). The engine counts the live subscriber list on the write, so disposed subscribers don't count.
 
 Threshold configurable (or disable-able) via `enable({ wideWrites })`.
 
@@ -453,8 +453,8 @@ Each `DiagnosticEvent` has:
 | `NO_OWNER_CLEANUP`               | warn      | lifecycle      | `onCleanup` called without owner                                                                                           |
 | `NO_OWNER_BOUNDARY`              | warn      | lifecycle      | Boundary created without owner                                                                                             |
 | `RUN_WITH_DISPOSED_OWNER`        | warn      | owner          | `runWithOwner` with disposed owner                                                                                         |
-| `HUGE_FAN_OUT`                   | warn      | graph          | One source reached 2000 live subscribers (always on)                                                                       |
-| `HUGE_FAN_IN`                    | warn      | graph          | One computation reached 2000 live sources (always on)                                                                      |
+| `HUGE_FAN_OUT`                   | warn      | graph          | One change reached 2000 live subscribers (always on)                                                                       |
+| `HUGE_FAN_IN`                    | warn      | graph          | One recompute tracked 2000 sources (always on)                                                                             |
 | `HOT_SCOPE_RERUNS`               | warn      | perf           | 120+ re-runs of one scope in 1s (attribution enabled)                                                                      |
 | `HOT_SCOPE_FANOUT`               | warn      | perf           | 5+/50+/500+ scopes hot from one root cause (attribution enabled)                                                           |
 | `HOT_SCOPE_TIME`                 | warn      | perf           | 8ms+ self-time in one scope in 1s (attribution enabled)                                                                    |

--- a/packages/diagnostics/skills/agent-loops/SKILL.md
+++ b/packages/diagnostics/skills/agent-loops/SKILL.md
@@ -125,10 +125,14 @@ fix through Loop 3) beside the time its writes spent held (`worstHoldMs`,
 `silentMs` — fix here). In browser captures the interaction is stamped by the
 web runtime; in-process, wrap the write in
 `OBSERVE.attribution.withInteraction({ type, target }, () => …)` so holds are
-measured from the event and keyed by it.
+measured from the event and keyed by it. A router that wraps its location
+write in `OBSERVE.attribution.withOrigin({ kind: "navigation", name, to, from, params }, () => …)`
+names holds by route as well — `SILENT_HOLD` then reads "click on a.nav
+(navigation to /users/:id) wrote …", and `feedback.navigations` /
+`attribution.navigations()` give the per-route view.
 
-Two more fact tables in `feedback` have no verdict of their own; read them
-when a scenario is slow without being silent:
+The remaining fact tables in `feedback` have no verdict of their own; read
+them when a scenario is slow without being silent:
 
 - `flights` — per async source, `flights`/`landed`/`abandoned`. A source that
   abandons most of its flights re-asks on every input change (search as you

--- a/packages/signals/src/attribution.prod.ts
+++ b/packages/signals/src/attribution.prod.ts
@@ -22,7 +22,8 @@ export const attribution: Attribution = {
   costs: () => ({ scopes: [], writes: [] }),
   waterfalls: () => EMPTY,
   holds: () => EMPTY,
-  feedback: () => ({ sources: [], interactions: [], flights: [], fallbacks: [] }),
+  navigations: () => EMPTY,
+  feedback: () => ({ sources: [], interactions: [], navigations: [], flights: [], fallbacks: [] }),
   markFlight: noop,
   format: () => "",
   formatOrigin: () => ""
@@ -37,14 +38,16 @@ export type {
   ChangeRecord,
   FallbackStats,
   FeedbackInteraction,
+  FeedbackNavigation,
   FeedbackSource,
   FlightLink,
   FlightStats,
   HeldWrite,
   HoldEvent,
+  NavigationEvent,
   RerunEvent,
   ScopeCost,
   WaterfallRecord,
   WriteCost
 } from "./core/attribution.js";
-export type { InteractionRef } from "./core/attribution-hooks.js";
+export type { InteractionRef, NavigationRef, OriginRef } from "./core/attribution-hooks.js";

--- a/packages/signals/src/attribution.ts
+++ b/packages/signals/src/attribution.ts
@@ -20,14 +20,16 @@ export type {
   ChangeRecord,
   FallbackStats,
   FeedbackInteraction,
+  FeedbackNavigation,
   FeedbackSource,
   FlightLink,
   FlightStats,
   HeldWrite,
   HoldEvent,
+  NavigationEvent,
   RerunEvent,
   ScopeCost,
   WaterfallRecord,
   WriteCost
 } from "./core/attribution.js";
-export type { InteractionRef } from "./core/attribution-hooks.js";
+export type { InteractionRef, NavigationRef, OriginRef } from "./core/attribution-hooks.js";

--- a/packages/signals/src/core/attribution-hooks.ts
+++ b/packages/signals/src/core/attribution-hooks.ts
@@ -27,6 +27,23 @@ export interface AttributionHooks {
   interactionStart(ref: InteractionRef): void;
   interactionEnd(): void;
   /**
+   * `withOrigin` opened a declared-origin frame: root writes until the
+   * matching `originEnd` are the unit of work `ref` describes (a router's
+   * navigation). Nests inside an interaction frame — a link click that
+   * navigates — or stands alone (a redirect from an action, a programmatic
+   * `navigate()`). Frames nest strictly, so the engine keeps a stack.
+   */
+  originStart(ref: OriginRef): void;
+  originEnd(): void;
+  /**
+   * A `flush()` drain finished: every batch it processed either committed
+   * (its effects have run) or was parked in a held transition (`holdStart`
+   * fired for it). Fires once per drain, after the loop — not per batch, and
+   * not for a `flush()` call that found nothing to do. Gives the engine the
+   * "committed, screen updated" instant for writes no transition ever held.
+   */
+  flushEnd(): void;
+  /**
    * A recompute is starting; `el._deps` still holds the previous run's links.
    * Always paired with `recomputeEnd` (recompute has no early returns).
    */
@@ -162,6 +179,35 @@ export interface InteractionRef {
   at?: number;
 }
 
+/**
+ * A navigation, as a router describes it to `withOrigin` around the location
+ * write it is about to perform. Match eagerly and describe before writing:
+ * the engine keys the work the write causes — the hold behind route data,
+ * the re-runs, the verdicts — to this record, and names it by the
+ * parametrized route so occurrences fold together.
+ */
+export interface NavigationRef {
+  kind: "navigation";
+  /** The matched route pattern — `/users/:id`. The name every consumer groups by. */
+  name?: string;
+  /** Concrete destination path. */
+  to?: string;
+  /** Concrete path being left. */
+  from?: string;
+  /** Route params the pattern bound — `{ id: "42" }`. */
+  params?: Readonly<Record<string, string>>;
+  /** When the navigation was requested on the `performance.now()` clock; defaults to now. */
+  at?: number;
+}
+
+/**
+ * What `withOrigin` accepts: a declared unit of work whose writes the engine
+ * should attribute as a whole. A discriminated union so kinds can be added
+ * (a form submission, a tab switch) without the seam changing shape; the
+ * engine knows `navigation` today.
+ */
+export type OriginRef = NavigationRef;
+
 export let attrHooks: AttributionHooks | null = null;
 
 export function setAttributionHooks(hooks: AttributionHooks | null): void {
@@ -191,5 +237,34 @@ export function withInteraction<T>(ref: InteractionRef, fn: () => T): T {
     return fn();
   } finally {
     hooks.interactionEnd();
+  }
+}
+
+/**
+ * Run `fn` as a declared unit of work — a router's navigation: every root
+ * write it performs is attributed to `ref` (and, through it, to the enclosing
+ * interaction when there is one), so the hold those writes wait in, the
+ * re-runs they cause and the verdicts on them all carry the route's name
+ * instead of a bare signal's. Same contract as `withInteraction`: the wiring,
+ * not the engine; `fn()` with no engine installed. Reachable as
+ * `OBSERVE.attribution.withOrigin`.
+ *
+ * ```ts
+ * OBSERVE
+ *   ? OBSERVE.attribution.withOrigin(
+ *       { kind: "navigation", name: match.pattern, to, from, params: match.params },
+ *       () => setLocation(to)
+ *     )
+ *   : setLocation(to);
+ * ```
+ */
+export function withOrigin<T>(ref: OriginRef, fn: () => T): T {
+  const hooks = attrHooks;
+  if (hooks === null) return fn();
+  hooks.originStart(ref);
+  try {
+    return fn();
+  } finally {
+    hooks.originEnd();
   }
 }

--- a/packages/signals/src/core/attribution.ts
+++ b/packages/signals/src/core/attribution.ts
@@ -4,7 +4,7 @@ import {
   type InteractionRef
 } from "./attribution-hooks.js";
 import { $REFRESH, NOT_PENDING } from "./constants.js";
-import { emitDiagnostic, ownerPath, reportDiagnostic } from "./dev.js";
+import { emitDiagnostic, GRAPH_SIZE_WARN_AT, ownerPath, reportDiagnostic } from "./dev.js";
 import type { Transition } from "./scheduler.js";
 import type { Computed, Signal } from "./types.js";
 
@@ -180,14 +180,11 @@ export interface AttributionOptions {
   /**
    * Written-fan-out warning: emit a diagnostic when a committed root
    * invalidation (write, refresh, async landing) reaches a node with at
-   * least this many subscribers (default 250). Complements the always-on
-   * HUGE_FAN_OUT graph-size warning, specced against it deliberately:
-   * HUGE_FAN_OUT fires at LINK time from GRAPH_SIZE_WARN_AT (2000) up —
-   * static structure so large it warns even if never written — while this
-   * fires at WRITE time from a much lower bar, because fan-out only costs
-   * anything when the node actually changes. Once per node, re-warning only
-   * on 2x subscriber growth, so the two never spam the same node. `false`
-   * disables.
+   * least this many subscribers (default 250). The lower-bar, opt-in sibling
+   * of the always-on HUGE_FAN_OUT graph-size warning, which fires on the
+   * same kind of write from GRAPH_SIZE_WARN_AT (2000) up; this one hands
+   * over to it there, so a write never carries both. Once per node,
+   * re-warning only on 2x subscriber growth. `false` disables.
    */
   wideWrites?: number | false;
   /**
@@ -520,15 +517,22 @@ export function formatOrigin(origin: ChangeOrigin): string {
 }
 
 /** Record a root change (setSignal / refresh / async landing) on the node. */
+/** Live subscriber count, walked on demand — the core keeps no counter. */
+function countSubscribers(node: Signal<any> | Computed<any>): number {
+  let n = 0;
+  for (let s = node._subs; s !== null; s = s._nextSub) n++;
+  return n;
+}
+
 /**
- * Written-fan-out warning — the write-time complement of the always-on
- * HUGE_FAN_OUT link-time warning (see dev.ts). Static fan-out that never
- * writes is harmless; a committed root invalidation reaching hundreds of
- * subscribers re-runs all of them this flush. Uses the dev-maintained
- * `_subCount` from the graph-size diagnostics — no core sites touched.
- * Once per node; re-warns only when the subscriber count has doubled since
- * the last warning, so it cannot spam alongside HUGE_FAN_OUT's own
- * 2000-and-up milestones.
+ * Written-fan-out warning — the engine's lower-bar sibling of the always-on
+ * HUGE_FAN_OUT (see dev.ts): a committed root invalidation reaching hundreds
+ * of subscribers re-runs all of them this flush. Counts the subscriber list
+ * itself (an engine-only walk, on the write; the core keeps no per-node
+ * count — a live `_subCount` was a post-construction field that forked node
+ * shapes). Once per node; re-warns only when the subscriber count has
+ * doubled since the last warning. Stops at GRAPH_SIZE_WARN_AT, where
+ * HUGE_FAN_OUT takes over, so the two never fire for the same write.
  */
 function checkWideWrite(
   node: Signal<any> | Computed<any>,
@@ -536,9 +540,10 @@ function checkWideWrite(
 ): void {
   const limit = options.wideWrites;
   if (typeof limit !== "number") return;
-  const subs = node._subCount ?? 0;
+  const subs = countSubscribers(node);
   const attributed = node as AttributedNode;
-  if (subs < limit || subs < (attributed._devWideWriteWarnedAt ?? 0) * 2) return;
+  if (subs < limit || subs >= GRAPH_SIZE_WARN_AT) return;
+  if (subs < (attributed._devWideWriteWarnedAt ?? 0) * 2) return;
   attributed._devWideWriteWarnedAt = subs;
   const verb =
     kind === "refresh" ? "refresh of" : kind === "async" ? "async landing on" : "write to";

--- a/packages/signals/src/core/attribution.ts
+++ b/packages/signals/src/core/attribution.ts
@@ -1,7 +1,8 @@
 import {
   setAttributionHooks,
   type AttributionHooks,
-  type InteractionRef
+  type InteractionRef,
+  type OriginRef
 } from "./attribution-hooks.js";
 import { $REFRESH, NOT_PENDING } from "./constants.js";
 import { emitDiagnostic, GRAPH_SIZE_WARN_AT, ownerPath, reportDiagnostic } from "./dev.js";
@@ -50,21 +51,32 @@ export type ChangeKind = "write" | "derived" | "async" | "refresh";
  *   name, when it has one). Writes after an `await` (not a `yield`) run in a
  *   bare microtask and stamp `external` — the documented escape.
  * - `async` — an async landing (`name` = the node whose flight landed).
+ * - `navigation` — a router's navigation, declared via `withOrigin` around
+ *   the location write (`name` = the matched route pattern `/users/:id`;
+ *   `to`/`from` the concrete paths; `params` what the pattern bound; `at`
+ *   when it was requested). The router-agnostic seam: any router that wraps
+ *   its write gets navigations named by route in every hold, re-run and
+ *   verdict, with no per-router knowledge anywhere in the engine.
  * - `external` — none of the above: timers, sockets, promise callbacks, setup.
  *
  * `interaction` on a non-interaction frame is the user event the frame runs
  * under — an action started by a click, an effect whose run was caused by a
- * click's write, a landing whose flight a click started. It is what lets
- * every downstream cost be keyed by the interaction that paid for it.
+ * click's write, a landing whose flight a click started, a navigation a link
+ * click performed. It is what lets every downstream cost be keyed by the
+ * interaction that paid for it.
  */
 export interface ChangeOrigin {
-  kind: "interaction" | "effect" | "action" | "async" | "external";
+  kind: "interaction" | "effect" | "action" | "async" | "navigation" | "external";
   name?: string;
   target?: string;
   at?: number;
   interaction?: ChangeOrigin;
   /** `effect` only: the `RerunEvent.run` of the compute run this callback belongs to. */
   run?: number;
+  /** `navigation` only: concrete destination and departure paths, and the bound params. */
+  to?: string;
+  from?: string;
+  params?: Readonly<Record<string, string>>;
 }
 
 export interface ChangeRecord {
@@ -475,6 +487,12 @@ interface EffectFrameInfo {
 }
 const effectFrames = new WeakMap<ChangeOrigin, EffectFrameInfo>();
 
+/** The interaction the innermost open frame runs under, else the ambient one. */
+function enclosingInteraction(): ChangeOrigin | undefined {
+  const top = originFrames[originFrames.length - 1];
+  return (top !== undefined ? interactionOf(top) : undefined) ?? currentInteraction ?? undefined;
+}
+
 function pushFrame(
   kind: "effect" | "action",
   name: string | undefined,
@@ -493,14 +511,41 @@ function pushFrame(
   originFrames.push(frame);
 }
 
-function popFrame(kind: "effect" | "action") {
+function popFrame(kind: "effect" | "action" | "navigation") {
   // Frames are strictly nested; a mismatch means enable() landed mid-frame
   // (the opener never pushed) — leave the stack alone rather than pop a stranger.
   const top = originFrames[originFrames.length - 1];
   if (top !== undefined && top.kind === kind) originFrames.pop();
 }
 
-/** `click on button#next "Next →"`, `effect "syncTitle"`, `action "save"`, … */
+/**
+ * `withOrigin` opened a declared frame. The frame object IS the origin every
+ * write inside stamps, and the key the navigation record hangs off (see
+ * "Navigations" below), so a hold or re-run that later resolves a write's
+ * origin lands on the same record. It runs under the interaction of the frame
+ * it opened inside — a `navigate()` from an action step, whose ambient
+ * interaction is long gone but whose frame remembers it — else the ambient
+ * one (a link click's handler).
+ */
+function originStart(ref: OriginRef): void {
+  const frame: ChangeOrigin = { kind: ref.kind, at: ref.at ?? now() };
+  if (ref.name !== undefined) frame.name = ref.name;
+  if (ref.to !== undefined) frame.to = ref.to;
+  if (ref.from !== undefined) frame.from = ref.from;
+  if (ref.params !== undefined) frame.params = ref.params;
+  const under = enclosingInteraction();
+  if (under !== undefined) frame.interaction = under;
+  originFrames.push(frame);
+  openNavigation(frame);
+}
+
+function originEnd(): void {
+  const top = originFrames[originFrames.length - 1];
+  popFrame("navigation");
+  if (top !== undefined && top.kind === "navigation") closeNavigation(top);
+}
+
+/** `click on button#next "Next →"`, `effect "syncTitle"`, `action "save"`, `navigation to /users/:id`, … */
 export function formatOrigin(origin: ChangeOrigin): string {
   switch (origin.kind) {
     case "interaction":
@@ -511,6 +556,14 @@ export function formatOrigin(origin: ChangeOrigin): string {
       return `action${origin.name ? ` "${origin.name}"` : ""}`;
     case "async":
       return `async landing${origin.name ? ` on "${origin.name}"` : ""}`;
+    case "navigation": {
+      // The route pattern is the name consumers group by; the concrete path
+      // follows when it adds information.
+      const name = origin.name ?? origin.to;
+      if (name === undefined) return "navigation";
+      const concrete = origin.to !== undefined && origin.to !== name ? ` (${origin.to})` : "";
+      return `navigation to ${name}${concrete}`;
+    }
     default:
       return "outside the reactive system";
   }
@@ -581,7 +634,9 @@ function stampWrite(
   record.origin = kind === "async" ? asyncOrigin(node as Computed<any>) : currentOrigin();
   record.at = now();
   record.stack = captureStack();
+  const prior = (node as AttributedNode)._devChange;
   (node as AttributedNode)._devChange = record;
+  noteNavigationWrite(prior, record);
   if (kind === "write") trackEffectWrite(node, record, value);
   // stampWrite is the single funnel for committed root invalidations (sync
   // writes, refresh(), async landings), which makes it the one place the
@@ -955,16 +1010,28 @@ export interface Attribution {
    */
   holds(): readonly HoldEvent[];
   /**
+   * Every navigation a router declared via `withOrigin` since enable()
+   * (ring-buffered like history()), settled or not: what route, under which
+   * interaction, how many writes, and — once its writes are through — how
+   * long that took and how (`committed` in a plain drain, `held` behind
+   * route data with the HoldEvent attached, or `superseded` by a later
+   * navigation before it landed). Facts for any consumer that wants
+   * navigation spans named by route: no router integration needed.
+   */
+  navigations(): readonly NavigationEvent[];
+  /**
    * What the user waited on, folded from holds() and the interaction on each
    * re-run: `sources` ranks async sources by the silent time writes spent
    * held behind them (with which affordances answered, how often, and which
    * interactions were held); `interactions` ranks user events by the total
    * time they cost — re-run work caused (long-flush hazard) beside time held
    * (silent-hold hazard). Facts at every duration; SILENT_HOLD is the
-   * thresholded verdict. Two more tables round out the picture: `flights`
-   * counts each async source's flights and how many were abandoned before
-   * landing (the re-ask storm), and `fallbacks` measures how long each
-   * loading boundary showed its fallback and how often that was a flash.
+   * thresholded verdict. Three more tables round out the picture:
+   * `navigations` ranks routes by the time spent held navigating to them
+   * (folded from navigations()), `flights` counts each async source's
+   * flights and how many were abandoned before landing (the re-ask storm),
+   * and `fallbacks` measures how long each loading boundary showed its
+   * fallback and how often that was a flash.
    */
   feedback(): AttributionFeedbackTables;
   /**
@@ -1811,6 +1878,13 @@ export interface HoldEvent {
   tailMs: number;
   /** The user interaction whose writes were held, when the stamp is known. */
   interaction?: ChangeOrigin;
+  /**
+   * The declared unit of work the held writes belong to — the `navigation`
+   * a router described via `withOrigin` — when one is known. What names the
+   * hold by route (`navigation to /users/:id`) rather than by signal; the
+   * same object as `navigations()[].origin`, so the two join by identity.
+   */
+  origin?: ChangeOrigin;
   /** Flushes that ended with the hold still open. */
   flushes: number;
   /** Root signal writes staged behind the hold (the user's unanswered input). */
@@ -1903,6 +1977,9 @@ function holdState(t: Transition): HoldState {
 }
 
 function trackHoldStart(t: Transition): void {
+  // Navigations learn they are held regardless of hold tracking: their
+  // settle must wait for the transition either way (see flushEnd).
+  markNavigationsHeld(t);
   if (options.holds === false) return;
   const state = holdState(t);
   state.flushes++;
@@ -1928,13 +2005,19 @@ function trackHoldMerge(target: Transition, outgoing: Transition): void {
 
 function trackHoldSettled(t: Transition): void {
   const state = holdStates.get(t);
-  if (state === undefined) return;
+  if (state === undefined) {
+    // No hold was recorded (the transition completed in its first flush, or
+    // hold tracking is off): navigations staged in it still settle here.
+    settleNavigations(t, undefined);
+    return;
+  }
   holdStates.delete(t);
   // Root writes only: a memo in _pendingNodes is a derived hold, and the
   // question is whether the USER's input went unanswered.
   const heldWrites: HeldWrite[] = [];
   let subject: Signal<any> | null = null;
   let interaction: ChangeOrigin | undefined;
+  let origin: ChangeOrigin | undefined;
   let lastJoinAt = -Infinity;
   for (const node of t._pendingNodes) {
     if (typeof (node as Computed<any>)._fn === "function" || isCompanion(node)) continue;
@@ -1949,11 +2032,21 @@ function trackHoldSettled(t: Transition): void {
     const under = interactionOf(change.origin);
     if (under !== undefined && (interaction === undefined || under.at! < interaction.at!))
       interaction = under;
+    // The declared frame the writes belong to — earliest navigation, by the
+    // same reasoning.
+    if (
+      change.origin?.kind === "navigation" &&
+      (origin === undefined || change.origin.at! < origin.at!)
+    )
+      origin = change.origin;
     // Latest write: a signal written twice while held carries the later
     // stamp, so this is the user's final input, not their first.
     if (change.at !== undefined && change.at > lastJoinAt) lastJoinAt = change.at;
   }
-  if (heldWrites.length === 0) return;
+  if (heldWrites.length === 0) {
+    settleNavigations(t, undefined);
+    return;
+  }
   censusRegistrations(t, state);
   censusCompanions([...t._pendingNodes, ...state.blockers], state.acknowledgedBy);
   const end = now();
@@ -1974,8 +2067,10 @@ function trackHoldSettled(t: Transition): void {
     action: state.action
   };
   if (interaction !== undefined) event.interaction = interaction;
+  if (origin !== undefined) event.origin = origin;
   holdLog.push(event);
   if (holdLog.length > options.historyLimit) holdLog.shift();
+  settleNavigations(t, event);
   recordFeedbackHold(event);
   if (isSilentHold(event)) checkSilentHold(event, subject!);
   else checkLongHold(event, subject!);
@@ -2027,7 +2122,21 @@ function holdData(event: HoldEvent): Record<string, unknown> {
   };
   if (event.interaction !== undefined)
     data.interaction = { type: event.interaction.name, target: event.interaction.target };
+  if (event.origin?.kind === "navigation") data.navigation = navigationData(event.origin);
   return data;
+}
+
+/**
+ * Who the verdict sentence starts from: the interaction, with the navigation
+ * it performed in parentheses — `click on a.nav (navigation to /users/:id)`;
+ * the navigation alone when nothing user-dispatched is known (a redirect);
+ * empty when neither is.
+ */
+function holdActor(event: HoldEvent): string {
+  const via = event.origin !== undefined ? formatOrigin(event.origin) : "";
+  if (event.interaction !== undefined)
+    return `${formatOrigin(event.interaction)}${via ? ` (${via})` : ""}`;
+  return via;
 }
 
 function checkSilentHold(event: HoldEvent, subject: Signal<any>): void {
@@ -2037,9 +2146,10 @@ function checkSilentHold(event: HoldEvent, subject: Signal<any>): void {
   const ms = event.holdMs.toFixed(0);
   const writes = describeHeldWrites(event);
   const waitedOn = describeBlockers(event, "waiting on");
-  // With the interaction stamped the sentence starts from what the user did;
-  // without it, from the writes.
-  const who = event.interaction !== undefined ? `${formatOrigin(event.interaction)} ` : "";
+  // With the interaction (or navigation) stamped the sentence starts from
+  // what the user did; without it, from the writes.
+  const actor = holdActor(event);
+  const who = actor ? `${actor} ` : "";
   let message = event.action
     ? `[SILENT_HOLD] ${who}${who ? "started an action that" : "an action"} held ${writes} for ` +
       `${ms}ms${waitedOn} and the screen showed nothing for the whole round-trip: no optimistic ` +
@@ -2081,7 +2191,8 @@ function checkLongHold(event: HoldEvent, subject: Signal<any>): void {
   const tail = event.tailMs.toFixed(0);
   const writes = describeHeldWrites(event);
   const waitedOn = describeBlockers(event, "waiting on");
-  const who = event.interaction !== undefined ? `${formatOrigin(event.interaction)} ` : "";
+  const actor = holdActor(event);
+  const who = actor ? `${actor} ` : "";
   const answered =
     event.acknowledgedBy.length > 0
       ? `${event.acknowledgedBy.map(a => `"${a}"`).join(", ")} said it was pending`
@@ -2109,6 +2220,170 @@ function checkLongHold(event: HoldEvent, subject: Signal<any>): void {
     subject
   );
   if (severity === "warn") reportDiagnostic(entry);
+}
+
+// --- Navigations ------------------------------------------------------------------
+//
+// A navigation in Solid 2 is not a primitive: it is a plain write to the
+// location (reads pull the route's async, and the runtime holds the write
+// until the data is ready), so the engine already sees everything a
+// navigation costs — the hold, the re-runs, the blockers, the silence — with
+// one thing missing: that those writes WERE a navigation, and to which route.
+// `withOrigin({ kind: "navigation", … })` is where a router says so, around
+// its write; this section keeps one record per such frame and settles it
+// when the work it caused is done. Nothing here knows any router; the seam
+// is the frame, and the record is keyed by the frame object the writes
+// stamped, so a hold or a cause chain resolves back to it by identity.
+//
+// A record settles once, one of three ways: `committed` — its writes went
+// through in a drain no transition held (flushEnd is the instant the screen
+// had them); `held` — they waited in a transition, whose commit is the
+// instant (with the HoldEvent attached when hold tracking recorded one);
+// `superseded` — a later write to the same node replaced its record before
+// it landed (the user navigated again; the first never showed).
+
+export interface NavigationEvent {
+  /** The matched route pattern the router gave — `/users/:id`. */
+  name?: string;
+  to?: string;
+  from?: string;
+  params?: Readonly<Record<string, string>>;
+  /** When the navigation was requested (`performance.now()` clock). */
+  at: number;
+  /** The user interaction it ran under, when known — a link click. */
+  interaction?: ChangeOrigin;
+  /** Root writes the frame performed. */
+  writes: number;
+  /**
+   * Wall time from the request to settle: the end of the drain that committed
+   * its writes, or the commit of the hold they waited in. `undefined` while
+   * unsettled.
+   */
+  settledMs?: number;
+  outcome?: "committed" | "held" | "superseded";
+  /** The hold its writes waited in, when hold tracking recorded one. */
+  hold?: HoldEvent;
+  /**
+   * The frame object its writes were stamped with — `ChangeRecord.origin` on
+   * each, `HoldEvent.origin` on the hold. Join key, by identity.
+   */
+  origin: ChangeOrigin;
+}
+
+interface NavState {
+  event: NavigationEvent;
+  /** `originEnd` has fired. */
+  closed: boolean;
+  /** A flush parked its writes in a transition (`holdStart`). */
+  held: boolean;
+  /** `drainSeq` at its last write — a later drain committed it. */
+  writeDrain: number;
+}
+const navStates = new WeakMap<ChangeOrigin, NavState>();
+/** Opened, not yet settled. */
+const openNavs = new Set<NavState>();
+let navigationLog: NavigationEvent[] = [];
+/** Drains completed since enable() — the clock `writeDrain` reads. */
+let drainSeq = 0;
+
+function openNavigation(frame: ChangeOrigin): void {
+  const event: NavigationEvent = { at: frame.at!, writes: 0, origin: frame };
+  if (frame.name !== undefined) event.name = frame.name;
+  if (frame.to !== undefined) event.to = frame.to;
+  if (frame.from !== undefined) event.from = frame.from;
+  if (frame.params !== undefined) event.params = frame.params;
+  if (frame.interaction !== undefined) event.interaction = frame.interaction;
+  const state: NavState = { event, closed: false, held: false, writeDrain: drainSeq };
+  navStates.set(frame, state);
+  openNavs.add(state);
+  navigationLog.push(event);
+  if (navigationLog.length > options.historyLimit) navigationLog.shift();
+}
+
+function closeNavigation(frame: ChangeOrigin): void {
+  const state = navStates.get(frame);
+  if (state === undefined) return;
+  state.closed = true;
+  // Nothing to wait for: no write survived the equality gate (navigating to
+  // where we already are), or a drain inside the frame already committed
+  // them (`flush(() => setLocation(…))`) with no hold.
+  if (state.event.writes === 0 || (!state.held && drainSeq > state.writeDrain))
+    settleNavigation(state, "committed");
+}
+
+/** stampWrite: the record replacing `prior` on a node was just stamped. */
+function noteNavigationWrite(prior: ChangeRecord | undefined, record: ChangeRecord): void {
+  const origin = record.origin!;
+  if (origin.kind === "navigation") {
+    const state = navStates.get(origin);
+    if (state !== undefined) {
+      state.event.writes++;
+      state.writeDrain = drainSeq;
+    }
+  }
+  // The node now carries a different frame's record: whatever `prior`'s
+  // navigation was waiting to show on it will never land as that navigation.
+  const before = prior?.origin;
+  if (before !== undefined && before !== origin && before.kind === "navigation") {
+    const state = navStates.get(before);
+    if (state !== undefined && openNavs.has(state)) settleNavigation(state, "superseded");
+  }
+}
+
+/** holdStart: `t`'s staged writes are parked — their navigations settle with `t`. */
+function markNavigationsHeld(t: Transition): void {
+  if (openNavs.size === 0) return;
+  for (const node of t._pendingNodes) {
+    const origin = (node as AttributedNode)._devChange?.origin;
+    if (origin?.kind !== "navigation") continue;
+    const state = navStates.get(origin);
+    if (state !== undefined) state.held = true;
+  }
+}
+
+/** transitionSettled: `t` commits — the navigations whose writes it staged are done. */
+function settleNavigations(t: Transition, hold: HoldEvent | undefined): void {
+  if (openNavs.size === 0) return;
+  for (const node of t._pendingNodes) {
+    const origin = (node as AttributedNode)._devChange?.origin;
+    if (origin?.kind !== "navigation") continue;
+    const state = navStates.get(origin);
+    if (state === undefined || !openNavs.has(state)) continue;
+    // A navigation whose frame is still open when its transition commits
+    // (`until()` inside the frame) settles here too: its writes are through.
+    settleNavigation(state, state.held ? "held" : "committed", hold);
+  }
+}
+
+/** flushEnd: every open, closed, unheld navigation's writes just committed. */
+function trackFlushEnd(): void {
+  drainSeq++;
+  if (openNavs.size === 0) return;
+  for (const state of openNavs)
+    if (state.closed && !state.held) settleNavigation(state, "committed");
+}
+
+function settleNavigation(
+  state: NavState,
+  outcome: NonNullable<NavigationEvent["outcome"]>,
+  hold?: HoldEvent
+): void {
+  if (!openNavs.delete(state)) return;
+  const event = state.event;
+  event.settledMs = now() - event.at;
+  event.outcome = outcome;
+  if (hold !== undefined) event.hold = hold;
+  recordFeedbackNavigation(event);
+}
+
+/** The serializable face of a navigation origin for diagnostic `data`. */
+function navigationData(origin: ChangeOrigin): Record<string, unknown> {
+  const data: Record<string, unknown> = {};
+  if (origin.name !== undefined) data.name = origin.name;
+  if (origin.to !== undefined) data.to = origin.to;
+  if (origin.from !== undefined) data.from = origin.from;
+  if (origin.params !== undefined) data.params = origin.params;
+  return data;
 }
 
 // --- Feedback tables ----------------------------------------------------------
@@ -2209,6 +2484,27 @@ export interface FallbackStats {
   flashes: number;
 }
 
+/**
+ * Per route: what navigating to it cost, folded from settled
+ * `NavigationEvent`s — the route-level view a router integration used to
+ * have to build itself, from the runtime's own facts.
+ */
+export interface FeedbackNavigation {
+  /** The route pattern (`/users/:id`), or the concrete `to` when the router gave no pattern. */
+  name: string;
+  navigations: number;
+  /** Summed and worst request-to-settle time (ms) across settled navigations. */
+  settledMs: number;
+  worstMs: number;
+  /** Navigations whose writes waited in a hold, and the time they waited. */
+  held: number;
+  heldMs: number;
+  /** Held navigations the screen acknowledged nothing for — the SILENT_HOLD signature. */
+  silent: number;
+  /** Navigations overwritten by a later one before they landed. */
+  superseded: number;
+}
+
 interface SourceBucket {
   row: FeedbackSource;
   acks: Map<string, number>;
@@ -2222,6 +2518,7 @@ interface InteractionBucket {
 }
 const feedbackSources = new Map<string, SourceBucket>();
 const feedbackInteractions = new Map<string, InteractionBucket>();
+const feedbackNavigations = new Map<string, FeedbackNavigation>();
 const flightStats = new Map<Computed<any>, FlightStats>();
 interface FallbackBucket {
   row: FallbackStats;
@@ -2371,6 +2668,38 @@ function recordFeedbackHold(event: HoldEvent): void {
   }
 }
 
+function recordFeedbackNavigation(event: NavigationEvent): void {
+  const name = event.name ?? event.to;
+  if (name === undefined) return;
+  let row = feedbackNavigations.get(name);
+  if (row === undefined) {
+    row = {
+      name,
+      navigations: 0,
+      settledMs: 0,
+      worstMs: 0,
+      held: 0,
+      heldMs: 0,
+      silent: 0,
+      superseded: 0
+    };
+    feedbackNavigations.set(name, row);
+  }
+  row.navigations++;
+  if (event.outcome === "superseded") {
+    row.superseded++;
+    return;
+  }
+  const ms = event.settledMs!;
+  row.settledMs += ms;
+  if (ms > row.worstMs) row.worstMs = ms;
+  if (event.outcome === "held") {
+    row.held++;
+    row.heldMs += event.hold?.holdMs ?? ms;
+    if (event.hold !== undefined && isSilentHold(event.hold)) row.silent++;
+  }
+}
+
 function rankedCounts<K extends string>(
   counts: Map<string, number>,
   key: K
@@ -2383,6 +2712,8 @@ function rankedCounts<K extends string>(
 export interface AttributionFeedbackTables {
   sources: FeedbackSource[];
   interactions: FeedbackInteraction[];
+  /** Routes ranked by the time spent held navigating to them, then by total settle time. */
+  navigations: FeedbackNavigation[];
   /** Async sources ranked by abandoned flights, then by flights. */
   flights: FlightStats[];
   /** Loading boundaries ranked by flashes, then by time shown. */
@@ -2390,6 +2721,9 @@ export interface AttributionFeedbackTables {
 }
 
 function feedbackTables(): AttributionFeedbackTables {
+  const navigations = [...feedbackNavigations.values()]
+    .map(row => ({ ...row }))
+    .sort((a, b) => b.heldMs - a.heldMs || b.settledMs - a.settledMs);
   const flights = [...flightStats.values()]
     .map(row => ({ ...row }))
     .sort((a, b) => b.abandoned - a.abandoned || b.flights - a.flights);
@@ -2408,7 +2742,7 @@ function feedbackTables(): AttributionFeedbackTables {
   const interactions = [...feedbackInteractions.values()]
     .map(bucket => ({ ...bucket.row }))
     .sort((a, b) => b.heldMs + b.selfMs - (a.heldMs + a.selfMs));
-  return { sources, interactions, flights, fallbacks };
+  return { sources, interactions, navigations, flights, fallbacks };
 }
 
 // The engine's implementation of the core's dev hook points. Installed by
@@ -2420,6 +2754,11 @@ let asyncStartValue: unknown;
 const engineHooks: AttributionHooks = {
   interactionStart,
   interactionEnd,
+  originStart,
+  originEnd,
+  flushEnd() {
+    trackFlushEnd();
+  },
   recomputeStart(el, create) {
     frames.push({
       start: now(),
@@ -2582,6 +2921,10 @@ export const attribution: Attribution = {
     activeHold = null;
     feedbackSources.clear();
     feedbackInteractions.clear();
+    feedbackNavigations.clear();
+    navigationLog = [];
+    openNavs.clear();
+    drainSeq = 0;
     reportedCycles.clear();
     relays.clear();
     immutableReported.clear();
@@ -2605,6 +2948,10 @@ export const attribution: Attribution = {
     activeHold = null;
     feedbackSources.clear();
     feedbackInteractions.clear();
+    feedbackNavigations.clear();
+    navigationLog = [];
+    openNavs.clear();
+    drainSeq = 0;
     reportedCycles.clear();
     relays.clear();
     immutableReported.clear();
@@ -2644,6 +2991,9 @@ export const attribution: Attribution = {
   },
   holds() {
     return holdLog;
+  },
+  navigations() {
+    return navigationLog;
   },
   feedback() {
     return feedbackTables();

--- a/packages/signals/src/core/core.ts
+++ b/packages/signals/src/core/core.ts
@@ -54,7 +54,7 @@ import {
   type Refreshable
 } from "./constants.js";
 import { NotReadyError } from "./error.js";
-import { dormantNodes, link, trimStaleDeps } from "./graph.js";
+import { beginFanInPass, dormantNodes, endFanInPass, link, trimStaleDeps } from "./graph.js";
 import {
   deleteFromHeap,
   enqueueSub,
@@ -281,6 +281,9 @@ export function recompute(el: Computed<any>, create: boolean = false): void {
   el._depGen++;
   el._flags = REACTIVE_RECOMPUTING_DEPS;
   el._time = clock;
+  // Observe-tier fan-in: the pass's distinct-dep count lives in one module
+  // counter (graph.ts), bracketed here so nested pulls don't disturb it.
+  const outerFanIn = __OBSERVE__ ? beginFanInPass() : 0;
   let value = el._pendingValue === NOT_PENDING ? el._value : el._pendingValue;
   let oldHeight = el._height;
   let missedWake = false;
@@ -401,6 +404,7 @@ export function recompute(el: Computed<any>, create: boolean = false): void {
     missedWake = (el._flags & REACTIVE_MISSED_WAKE) !== 0;
     el._flags = REACTIVE_NONE | (create ? el._flags & REACTIVE_SNAPSHOT_STALE : 0);
     context = oldcontext;
+    if (__OBSERVE__) endFanInPass(el, outerFanIn);
   }
 
   if (!el._x?._error) {
@@ -636,49 +640,95 @@ export function computed<T>(
   // `T | undefined` node is a real commit #0. The typeof guard tolerates
   // non-object option values that older call shapes force through `as any`.
   const loading = options !== null && typeof options === "object" && "loadingValue" in options;
-  const self: Computed<T> = {
-    id: inheritId(options, transparent, context),
-    _config:
-      (transparent ? CONFIG_TRANSPARENT : 0) |
-      (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
-      (!context || options?.lazy ? CONFIG_AUTO_DISPOSE : 0) |
-      (options?.sync ? CONFIG_SYNC : 0) |
-      (options?._noSnapshot ? CONFIG_NO_SNAPSHOT : 0) |
-      (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
-    _equals: options?.equals ?? isEqual,
-    _disposal: null,
-    _queue: context?._queue ?? globalQueue,
-    _context: context?._context ?? defaultContext,
-    _childCount: 0,
-    _fn: fn,
-    _value: (loading ? options!.loadingValue : undefined) as T,
-    _height: 0,
-    _nextHeap: undefined,
-    _prevHeap: null as any,
-    _deps: null,
-    _depsTail: null,
-    _depGen: 0,
-    _subs: null,
-    _subsTail: null,
-    _parent: context,
-    _nextSibling: null,
-    _prevSibling: null,
-    _firstChild: null,
-    _flags: options?.lazy ? REACTIVE_LAZY : REACTIVE_NONE,
-    // A loadingValue node is born committed: commit #0 is already in _value.
-    _statusFlags: loading ? 0 : STATUS_UNINITIALIZED,
-    _time: clock,
-    _pendingValue: NOT_PENDING,
-    _transition: null,
-    _notifiedAt: -1,
-    _loading: loading,
-    // Cold machinery (async/transition/optimistic/verdict slots) lives one
-    // hop away in the lazily-allocated extension — the core literal MUST
-    // stay under V8's in-object boundary (§12: past ~39 fields every
-    // allocation spills to a backing store and creation cost ~4x's).
-    _x: null
-  } as Computed<T>;
-  if (__OBSERVE__) (self as any)._name = options?.name ?? "computed";
+  // Two literals, one per tier, selected at build time (the observe flag is
+  // a literal after replacement; the untaken branch is dead code). The observe
+  // literal is the prod literal plus its `_name` slot — a slot in the
+  // boilerplate, because a post-construction `self._name = …` forces a
+  // hidden-class transition and an out-of-object property store on EVERY node
+  // (measured: the whole of the observe tier's creation overhead). Keep the
+  // two in sync — the dist artifact test pins observe's key set to prod's
+  // plus `_name`.
+  const self: Computed<T> = __OBSERVE__
+    ? ({
+        id: inheritId(options, transparent, context),
+        _config:
+          (transparent ? CONFIG_TRANSPARENT : 0) |
+          (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
+          (!context || options?.lazy ? CONFIG_AUTO_DISPOSE : 0) |
+          (options?.sync ? CONFIG_SYNC : 0) |
+          (options?._noSnapshot ? CONFIG_NO_SNAPSHOT : 0) |
+          (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
+        _equals: options?.equals ?? isEqual,
+        _disposal: null,
+        _queue: context?._queue ?? globalQueue,
+        _context: context?._context ?? defaultContext,
+        _childCount: 0,
+        _fn: fn,
+        _value: (loading ? options!.loadingValue : undefined) as T,
+        _height: 0,
+        _nextHeap: undefined,
+        _prevHeap: null as any,
+        _deps: null,
+        _depsTail: null,
+        _depGen: 0,
+        _subs: null,
+        _subsTail: null,
+        _parent: context,
+        _nextSibling: null,
+        _prevSibling: null,
+        _firstChild: null,
+        _flags: options?.lazy ? REACTIVE_LAZY : REACTIVE_NONE,
+        _statusFlags: loading ? 0 : STATUS_UNINITIALIZED,
+        _time: clock,
+        _pendingValue: NOT_PENDING,
+        _transition: null,
+        _notifiedAt: -1,
+        _loading: loading,
+        _x: null,
+        _name: options?.name ?? "computed"
+      } as Computed<T>)
+    : ({
+        id: inheritId(options, transparent, context),
+        _config:
+          (transparent ? CONFIG_TRANSPARENT : 0) |
+          (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
+          (!context || options?.lazy ? CONFIG_AUTO_DISPOSE : 0) |
+          (options?.sync ? CONFIG_SYNC : 0) |
+          (options?._noSnapshot ? CONFIG_NO_SNAPSHOT : 0) |
+          (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
+        _equals: options?.equals ?? isEqual,
+        _disposal: null,
+        _queue: context?._queue ?? globalQueue,
+        _context: context?._context ?? defaultContext,
+        _childCount: 0,
+        _fn: fn,
+        _value: (loading ? options!.loadingValue : undefined) as T,
+        _height: 0,
+        _nextHeap: undefined,
+        _prevHeap: null as any,
+        _deps: null,
+        _depsTail: null,
+        _depGen: 0,
+        _subs: null,
+        _subsTail: null,
+        _parent: context,
+        _nextSibling: null,
+        _prevSibling: null,
+        _firstChild: null,
+        _flags: options?.lazy ? REACTIVE_LAZY : REACTIVE_NONE,
+        // A loadingValue node is born committed: commit #0 is already in _value.
+        _statusFlags: loading ? 0 : STATUS_UNINITIALIZED,
+        _time: clock,
+        _pendingValue: NOT_PENDING,
+        _transition: null,
+        _notifiedAt: -1,
+        _loading: loading,
+        // Cold machinery (async/transition/optimistic/verdict slots) lives one
+        // hop away in the lazily-allocated extension — the core literal MUST
+        // stay under V8's in-object boundary (§12: past ~39 fields every
+        // allocation spills to a backing store and creation cost ~4x's).
+        _x: null
+      } as Computed<T>);
   if (options?.unobserved) (ext(self) as NodeExtension)._unobserved = options.unobserved;
   setupComputedNode(self, options);
   return self;
@@ -727,50 +777,99 @@ export function createEffectNode<T>(
   options: NodeOptions<T> | undefined
 ): any {
   const transparent = options?.transparent ?? false;
-  const self = {
-    id: inheritId(options, transparent, context),
-    _config:
-      (transparent ? CONFIG_TRANSPARENT : 0) |
-      (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
-      (options?.sync ? CONFIG_SYNC : 0) |
-      (options?._extraConfig ?? 0) |
-      (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
-    _equals: false as unknown as Computed<T>["_equals"],
-    _disposal: null,
-    _queue: context?._queue ?? globalQueue,
-    _context: context?._context ?? defaultContext,
-    _childCount: 0,
-    _fn: fn,
-    _value: undefined as T,
-    _height: 0,
-    _nextHeap: undefined,
-    _prevHeap: null as any,
-    _deps: null,
-    _depsTail: null,
-    _depGen: 0,
-    _subs: null,
-    _subsTail: null,
-    _parent: context,
-    _nextSibling: null,
-    _prevSibling: null,
-    _firstChild: null,
-    _flags: REACTIVE_LAZY,
-    _statusFlags: STATUS_UNINITIALIZED,
-    _time: clock,
-    _pendingValue: NOT_PENDING,
-    _transition: null,
-    _notifiedAt: -1,
-    _loading: false,
-    _modified: false,
-    _prevValue: undefined as T | undefined,
-    _effectFn: effectFn,
-    _errorFn: errorFn,
-    _cleanup: undefined as (() => void) | undefined,
-    _type: type,
-    _valueTransition: null,
-    _x: null
-  } as any;
-  if (__OBSERVE__) self._name = options?.name ?? "effect";
+  // Prod and observe boilerplates — see computed() for why the observe tier
+  // gets its `_name` as a literal slot rather than a write after the fact.
+  // The default label is the node kind (tracked effects relabel their computed
+  // in trackedEffect); the wrappers in signals.ts no longer spread a name into
+  // the options to get it.
+  const self = __OBSERVE__
+    ? ({
+        id: inheritId(options, transparent, context),
+        _config:
+          (transparent ? CONFIG_TRANSPARENT : 0) |
+          (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
+          (options?.sync ? CONFIG_SYNC : 0) |
+          (options?._extraConfig ?? 0) |
+          (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
+        _equals: false as unknown as Computed<T>["_equals"],
+        _disposal: null,
+        _queue: context?._queue ?? globalQueue,
+        _context: context?._context ?? defaultContext,
+        _childCount: 0,
+        _fn: fn,
+        _value: undefined as T,
+        _height: 0,
+        _nextHeap: undefined,
+        _prevHeap: null as any,
+        _deps: null,
+        _depsTail: null,
+        _depGen: 0,
+        _subs: null,
+        _subsTail: null,
+        _parent: context,
+        _nextSibling: null,
+        _prevSibling: null,
+        _firstChild: null,
+        _flags: REACTIVE_LAZY,
+        _statusFlags: STATUS_UNINITIALIZED,
+        _time: clock,
+        _pendingValue: NOT_PENDING,
+        _transition: null,
+        _notifiedAt: -1,
+        _loading: false,
+        _modified: false,
+        _prevValue: undefined as T | undefined,
+        _effectFn: effectFn,
+        _errorFn: errorFn,
+        _cleanup: undefined as (() => void) | undefined,
+        _type: type,
+        _valueTransition: null,
+        _x: null,
+        _name: options?.name ?? "effect"
+      } as any)
+    : ({
+        id: inheritId(options, transparent, context),
+        _config:
+          (transparent ? CONFIG_TRANSPARENT : 0) |
+          (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
+          (options?.sync ? CONFIG_SYNC : 0) |
+          (options?._extraConfig ?? 0) |
+          (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
+        _equals: false as unknown as Computed<T>["_equals"],
+        _disposal: null,
+        _queue: context?._queue ?? globalQueue,
+        _context: context?._context ?? defaultContext,
+        _childCount: 0,
+        _fn: fn,
+        _value: undefined as T,
+        _height: 0,
+        _nextHeap: undefined,
+        _prevHeap: null as any,
+        _deps: null,
+        _depsTail: null,
+        _depGen: 0,
+        _subs: null,
+        _subsTail: null,
+        _parent: context,
+        _nextSibling: null,
+        _prevSibling: null,
+        _firstChild: null,
+        _flags: REACTIVE_LAZY,
+        _statusFlags: STATUS_UNINITIALIZED,
+        _time: clock,
+        _pendingValue: NOT_PENDING,
+        _transition: null,
+        _notifiedAt: -1,
+        _loading: false,
+        _modified: false,
+        _prevValue: undefined as T | undefined,
+        _effectFn: effectFn,
+        _errorFn: errorFn,
+        _cleanup: undefined as (() => void) | undefined,
+        _type: type,
+        _valueTransition: null,
+        _x: null
+      } as any);
   // Effects dispatch status through the SHARED notifier (statusNotifierOf,
   // keyed off _type) — storing it per node forced a full NodeExtension
   // allocation on EVERY effect at creation (an alloc + 19 field stores,
@@ -857,28 +956,50 @@ export function signal<T>(
   options?: NodeOptions<T>,
   firewall: Computed<unknown> | null = null
 ): Signal<T> {
-  const s = {
-    _equals: options?.equals ?? isEqual,
-    _config:
-      (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
-      (options?._noSnapshot ? CONFIG_NO_SNAPSHOT : 0),
-    _value: v,
-    _subs: null,
-    _subsTail: null,
-    _time: clock,
-    _firewall: firewall,
-    _nextChild: firewall?._x?._child || null,
-    _pendingValue: NOT_PENDING,
-    // Signal-literal diet (§12e): NO _time/_fn/_statusFlags slots. Stores
-    // materialize one signal per touched leaf, so signal bytes are store
-    // bytes. _time is write-only on signals (every read site is computed-
-    // typed error-retry gating); _fn/_statusFlags read falsy-identically as
-    // missing properties on the shared paths (undefined masks to 0).
-    _transition: null,
-    _notifiedAt: -1,
-    _x: null
-  };
-  if (__OBSERVE__) (s as any)._name = options?.name ?? "signal";
+  // Prod and observe boilerplates — see computed(). The observe literal adds
+  // `_name` and `_owner` (the creating owner, stamped by registerGraph for
+  // createSignal nodes so ownerPath can locate signal subjects; null here,
+  // and staying null on internal signals — one shape either way).
+  const s = __OBSERVE__
+    ? {
+        _equals: options?.equals ?? isEqual,
+        _config:
+          (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
+          (options?._noSnapshot ? CONFIG_NO_SNAPSHOT : 0),
+        _value: v,
+        _subs: null,
+        _subsTail: null,
+        _time: clock,
+        _firewall: firewall,
+        _nextChild: firewall?._x?._child || null,
+        _pendingValue: NOT_PENDING,
+        _transition: null,
+        _notifiedAt: -1,
+        _x: null,
+        _name: options?.name ?? "signal",
+        _owner: null as Owner | null
+      }
+    : {
+        _equals: options?.equals ?? isEqual,
+        _config:
+          (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
+          (options?._noSnapshot ? CONFIG_NO_SNAPSHOT : 0),
+        _value: v,
+        _subs: null,
+        _subsTail: null,
+        _time: clock,
+        _firewall: firewall,
+        _nextChild: firewall?._x?._child || null,
+        _pendingValue: NOT_PENDING,
+        // Signal-literal diet (§12e): NO _time/_fn/_statusFlags slots. Stores
+        // materialize one signal per touched leaf, so signal bytes are store
+        // bytes. _time is write-only on signals (every read site is computed-
+        // typed error-retry gating); _fn/_statusFlags read falsy-identically as
+        // missing properties on the shared paths (undefined masks to 0).
+        _transition: null,
+        _notifiedAt: -1,
+        _x: null
+      };
   if (__DEV__) (s as any)._internal = !!firewall;
   if (options?.unobserved) ext(s as any)._unobserved = options.unobserved;
   if (firewall) {
@@ -925,28 +1046,50 @@ export function slotSignal<T>(
   acc: boolean,
   firewall: Computed<unknown> | null = null
 ): Signal<T> {
-  const s = {
-    _equals: equals,
-    _config: CONFIG_OWNED_WRITE | CONFIG_SLOT_NODE,
-    _value: v,
-    _subs: null,
-    _subsTail: null,
-    _time: clock,
-    _firewall: firewall,
-    _nextChild: firewall?._x?._child || null,
-    _pendingValue: NOT_PENDING,
-    _transition: null,
-    _notifiedAt: -1,
-    _x: null,
-    // Slot backrefs: what the equals/unobserved closures used to capture.
-    _host: host,
-    _key: key,
-    // Store read-path caches, pre-shaped (were post-construction expandos).
-    acc,
-    px: undefined,
-    pxv: undefined
-  };
-  if (__OBSERVE__) (s as any)._name = "signal";
+  // Prod and observe boilerplates — see computed(). The store relabels the
+  // observe slot (`store.<key>`) when the attribution engine is installed.
+  const s = __OBSERVE__
+    ? {
+        _equals: equals,
+        _config: CONFIG_OWNED_WRITE | CONFIG_SLOT_NODE,
+        _value: v,
+        _subs: null,
+        _subsTail: null,
+        _time: clock,
+        _firewall: firewall,
+        _nextChild: firewall?._x?._child || null,
+        _pendingValue: NOT_PENDING,
+        _transition: null,
+        _notifiedAt: -1,
+        _x: null,
+        _host: host,
+        _key: key,
+        acc,
+        px: undefined,
+        pxv: undefined,
+        _name: "signal"
+      }
+    : {
+        _equals: equals,
+        _config: CONFIG_OWNED_WRITE | CONFIG_SLOT_NODE,
+        _value: v,
+        _subs: null,
+        _subsTail: null,
+        _time: clock,
+        _firewall: firewall,
+        _nextChild: firewall?._x?._child || null,
+        _pendingValue: NOT_PENDING,
+        _transition: null,
+        _notifiedAt: -1,
+        _x: null,
+        // Slot backrefs: what the equals/unobserved closures used to capture.
+        _host: host,
+        _key: key,
+        // Store read-path caches, pre-shaped (were post-construction expandos).
+        acc,
+        px: undefined,
+        pxv: undefined
+      };
   if (__DEV__) (s as any)._internal = !!firewall;
   if (firewall) {
     ext(firewall)._child = s as unknown as FirewallSignal<unknown>;

--- a/packages/signals/src/core/dev.ts
+++ b/packages/signals/src/core/dev.ts
@@ -2,8 +2,10 @@ import {
   attrHooks,
   setAttributionHooks,
   withInteraction,
+  withOrigin,
   type AttributionHooks,
-  type InteractionRef
+  type InteractionRef,
+  type OriginRef
 } from "./attribution-hooks.js";
 // Cycle note: core.ts imports this module; we read its live `context` binding
 // only at call time (emitDiagnostic's default subject), never during module
@@ -149,6 +151,15 @@ export interface AttributionSlot {
    * harnesses call it themselves. `fn()` when no engine is installed.
    */
   withInteraction<T>(ref: InteractionRef, fn: () => T): T;
+  /**
+   * Run `fn` as a declared unit of work — a router's navigation, described
+   * by the parametrized route it matched: root writes inside are attributed
+   * to it (under the enclosing interaction, if any), so the hold behind the
+   * route's data, the re-runs and the verdicts carry the route's name. Any
+   * router calls this around its location write; nothing else is
+   * router-specific. `fn()` when no engine is installed.
+   */
+  withOrigin<T>(ref: OriginRef, fn: () => T): T;
 }
 
 /**
@@ -238,7 +249,8 @@ const attributionSlot: AttributionSlot = {
   get installed() {
     return attrHooks;
   },
-  withInteraction
+  withInteraction,
+  withOrigin
 };
 
 export const OBSERVE: Observe = __OBSERVE__

--- a/packages/signals/src/core/dev.ts
+++ b/packages/signals/src/core/dev.ts
@@ -76,9 +76,9 @@ export type DiagnosticKind =
   /** Perceived responsiveness: the runtime behaved correctly but the user saw no feedback. */
   | "responsiveness";
 
-/** First warning when a node's live edge count reaches this size. */
+/** First warning when a change reaches (or a pass tracks) this many edges. */
 export const GRAPH_SIZE_WARN_AT = 2000;
-/** Repeat the warning at this interval after the first. */
+/** Re-warn once the count has grown by this much since the last warning. */
 export const GRAPH_SIZE_WARN_EVERY = 500;
 
 export interface DiagnosticEvent {
@@ -491,72 +491,81 @@ export function getObservers(node: Signal<any> | Computed<any>): Computed<any>[]
   return observers;
 }
 
-function shouldWarnGraphSize(count: number): boolean {
-  return count >= GRAPH_SIZE_WARN_AT && (count - GRAPH_SIZE_WARN_AT) % GRAPH_SIZE_WARN_EVERY === 0;
+/**
+ * Graph-size warnings are once per node, re-warning only when the count has
+ * grown by GRAPH_SIZE_WARN_EVERY since the last one — off-node, so the
+ * pathological handful of nodes that ever reach the threshold are the only
+ * ones that cost anything, and no node carries a bookkeeping field for it.
+ */
+const graphSizeWarnedAt = new WeakMap<object, number>();
+
+function shouldWarnGraphSize(node: object, count: number): boolean {
+  const last = graphSizeWarnedAt.get(node);
+  if (last !== undefined && count < last + GRAPH_SIZE_WARN_EVERY) return false;
+  graphSizeWarnedAt.set(node, count);
+  return true;
 }
 
 /**
- * Observe-tier: bump live edge counts after a new graph link and emit when a
- * node grows an unusually large fan-out (many subscribers on one source) or
- * fan-in (many sources on one computation). Repeat-reads that `link()`
- * dedupes never reach here. Always-on wherever the channel exists — unlike
- * the opt-in attribution engine, a graph-size pathology should surface
- * without asking. The counts also feed `WIDE_WRITE` in attribution.ts.
+ * Observe-tier: a committed change on `node` is about to re-run `count`
+ * subscribers (the notify walk in `insertSubs` counted them as it went —
+ * fan-out costs exactly one local increment in a loop that already visits
+ * every edge, and nothing at link time). Fires from GRAPH_SIZE_WARN_AT up,
+ * on the write rather than the link: a fan-out that is never written costs
+ * nothing, and one that is re-runs every subscriber this flush. Always-on
+ * wherever the channel exists — unlike the opt-in attribution engine, a
+ * graph-size pathology should surface without asking.
  */
-export function noteGraphLink(dep: Signal<any> | Computed<any>, sub: Computed<any>): void {
-  const fanOut = (dep._subCount = (dep._subCount || 0) + 1);
-  const fanIn = (sub._depCount = (sub._depCount || 0) + 1);
-  if (shouldWarnGraphSize(fanOut)) {
-    const name = dep._name;
-    const message =
-      `[HUGE_FAN_OUT] ${name ? `Signal "${name}"` : "A signal"} has ${fanOut} subscribers. ` +
-      `Each will re-run when it changes. If many independent computations read the same value ` +
-      `(for example every row of a list comparing against one selected id), prefer a per-key ` +
-      `store or projection so only the items whose result flipped update.`;
-    reportDiagnostic(
-      emitDiagnostic(
-        {
-          code: "HUGE_FAN_OUT",
-          kind: "graph",
-          severity: "warn",
-          message,
-          nodeName: name,
-          ownerId: (dep as Computed<any>).id,
-          ownerName: name,
-          data: { count: fanOut }
-        },
-        dep
-      )
-    );
-  }
-  if (shouldWarnGraphSize(fanIn)) {
-    const name = sub._name;
-    const message =
-      `[HUGE_FAN_IN] ${name ? `Computation "${name}"` : "A computation"} has ${fanIn} sources. ` +
-      `It will re-run when any of them change. Narrow the read or split the derivation so each ` +
-      `computation tracks only what it needs.`;
-    reportDiagnostic(
-      emitDiagnostic(
-        {
-          code: "HUGE_FAN_IN",
-          kind: "graph",
-          severity: "warn",
-          message,
-          nodeName: name,
-          ownerId: sub.id,
-          ownerName: name,
-          data: { count: fanIn }
-        },
-        sub
-      )
-    );
-  }
+export function noteFanOut(node: Signal<any> | Computed<any>, count: number): void {
+  if (!shouldWarnGraphSize(node, count)) return;
+  const name = node._name;
+  const message =
+    `[HUGE_FAN_OUT] ${name ? `Signal "${name}"` : "A signal"} changed with ${count} subscribers — ` +
+    `every one re-runs this flush. If many independent computations read the same value ` +
+    `(for example every row of a list comparing against one selected id), prefer a per-key ` +
+    `store or projection so only the items whose result flipped update.`;
+  reportDiagnostic(
+    emitDiagnostic(
+      {
+        code: "HUGE_FAN_OUT",
+        kind: "graph",
+        severity: "warn",
+        message,
+        nodeName: name,
+        ownerId: (node as Computed<any>).id,
+        ownerName: name,
+        data: { count }
+      },
+      node
+    )
+  );
 }
 
-/** Observe-tier: drop live edge counts when a link is removed. */
-export function unnoteGraphLink(link: Link): void {
-  const dep = link._dep;
-  const sub = link._sub;
-  if (dep._subCount) dep._subCount--;
-  if (sub._depCount) sub._depCount--;
+/**
+ * Observe-tier: a recompute pass of `node` tracked `count` distinct sources
+ * (counted by `link()` on each first touch of the pass — see graph.ts).
+ * Fires from GRAPH_SIZE_WARN_AT up, at the end of the pass that read them.
+ */
+export function noteFanIn(node: Computed<any>, count: number): void {
+  if (!shouldWarnGraphSize(node, count)) return;
+  const name = node._name;
+  const message =
+    `[HUGE_FAN_IN] ${name ? `Computation "${name}"` : "A computation"} tracked ${count} sources. ` +
+    `It will re-run when any of them change. Narrow the read or split the derivation so each ` +
+    `computation tracks only what it needs.`;
+  reportDiagnostic(
+    emitDiagnostic(
+      {
+        code: "HUGE_FAN_IN",
+        kind: "graph",
+        severity: "warn",
+        message,
+        nodeName: name,
+        ownerId: node.id,
+        ownerName: name,
+        data: { count }
+      },
+      node
+    )
+  );
 }

--- a/packages/signals/src/core/effect.ts
+++ b/packages/signals/src/core/effect.ts
@@ -277,6 +277,9 @@ export function trackedEffect(fn: () => void | (() => void), options?: NodeOptio
   node._config = (node._config & ~CONFIG_AUTO_DISPOSE) | CONFIG_CHILDREN_FORBIDDEN;
   node._modified = true;
   node._type = EFFECT_TRACKED;
+  // Observe-tier label: the computed literal defaulted its `_name` slot to
+  // "computed"; relabel by kind (a store into the slot, not a new field).
+  if (__OBSERVE__ && options?.name === undefined) node._name = "trackedEffect";
   // Status dispatch rides the SHARED notifier (statusNotifierOf keys off
   // _type): its error arm is behavior-identical to the closure that used to
   // live here, without the per-node NodeExtension allocation.

--- a/packages/signals/src/core/graph.ts
+++ b/packages/signals/src/core/graph.ts
@@ -7,15 +7,36 @@ import {
   STATUS_PENDING
 } from "./constants.js";
 import { slotUnobservedHook } from "./core.js";
-import { noteGraphLink, unnoteGraphLink } from "./dev.js";
+import { GRAPH_SIZE_WARN_AT, noteFanIn } from "./dev.js";
 import { deleteFromHeap, queueFor } from "./heap.js";
 import { disposeChildren } from "./owner.js";
 import { bumpNotifyEpoch, dirtyQueue, zombieQueue } from "./scheduler.js";
 import type { Computed, Link, Signal } from "./types.js";
 
+/**
+ * Observe-tier: distinct dependencies touched by the recompute pass in
+ * progress — `link()` counts each first touch (a reused in-order link or a
+ * new edge; repeat reads of the same dep within the pass do not count).
+ * `recompute` brackets its pass with begin/endFanInPass, saving the enclosing
+ * pass's count across nested pulls. One module counter instead of a live
+ * `_depCount` field on every computed: the per-node field was a
+ * post-construction expando that forked node shapes and taxed every link.
+ */
+let passFanIn = 0;
+
+export function beginFanInPass(): number {
+  const prev = passFanIn;
+  passFanIn = 0;
+  return prev;
+}
+
+export function endFanInPass(el: Computed<any>, prev: number): void {
+  if (passFanIn >= GRAPH_SIZE_WARN_AT) noteFanIn(el, passFanIn);
+  passFanIn = prev;
+}
+
 // https://github.com/stackblitz/alien-signals/blob/v2.0.3/src/system.ts#L100
 export function unlinkSubs(link: Link): Link | null {
-  if (__OBSERVE__) unnoteGraphLink(link);
   const dep = link._dep;
   const nextDep = link._nextDep;
   const nextSub = link._nextSub;
@@ -148,6 +169,7 @@ export function link(
       sub._depsTail = nextDep;
       // First touch of this pass: the previous pass's label is stale.
       nextDep._pendingObserver = pendingObserver;
+      if (__OBSERVE__) passFanIn++;
       return;
     }
   }
@@ -191,5 +213,5 @@ export function link(
   // New subscriber edge: staged-rewrite skips (§12d) must not miss it.
   bumpNotifyEpoch();
 
-  if (__OBSERVE__) noteGraphLink(dep, sub);
+  if (__OBSERVE__) passFanIn++;
 }

--- a/packages/signals/src/core/index.ts
+++ b/packages/signals/src/core/index.ts
@@ -67,7 +67,12 @@ export {
   type IQueue,
   type QueueCallback
 } from "./scheduler.js";
-export type { AttributionHooks, InteractionRef } from "./attribution-hooks.js";
+export type {
+  AttributionHooks,
+  InteractionRef,
+  NavigationRef,
+  OriginRef
+} from "./attribution-hooks.js";
 export {
   DEV,
   OBSERVE,

--- a/packages/signals/src/core/owner.ts
+++ b/packages/signals/src/core/owner.ts
@@ -290,22 +290,44 @@ function disposeRootSelf(this: Root, self: boolean = true): void {
 export function createOwner(options?: { id?: string; transparent?: boolean }) {
   const parent = context;
   const transparent = options?.transparent ?? false;
-  const owner = {
-    id: inheritId(options, transparent, parent),
-    _config: transparent ? CONFIG_TRANSPARENT : 0,
-    _root: true,
-    _parentComputed: (parent as Root)?._root ? (parent as Root)._parentComputed : parent,
-    _firstChild: null,
-    _nextSibling: null,
-    _prevSibling: null,
-    _disposal: null,
-    _queue: parent?._queue ?? globalQueue,
-    _context: parent?._context || defaultContext,
-    _childCount: 0,
-    _x: null,
-    _parent: parent,
-    dispose: disposeRootSelf
-  } as Root;
+  // Prod and observe boilerplates (see core.ts computed()). The observe
+  // literal carries the `_name` slot the rendering layer fills with the
+  // component label (`owner._name = "<App>"`) — a slot, so labelling a root
+  // is a plain store rather than a shape fork between labelled and plain roots.
+  const owner = __OBSERVE__
+    ? ({
+        id: inheritId(options, transparent, parent),
+        _config: transparent ? CONFIG_TRANSPARENT : 0,
+        _root: true,
+        _parentComputed: (parent as Root)?._root ? (parent as Root)._parentComputed : parent,
+        _firstChild: null,
+        _nextSibling: null,
+        _prevSibling: null,
+        _disposal: null,
+        _queue: parent?._queue ?? globalQueue,
+        _context: parent?._context || defaultContext,
+        _childCount: 0,
+        _x: null,
+        _parent: parent,
+        dispose: disposeRootSelf,
+        _name: undefined as string | undefined
+      } as Root)
+    : ({
+        id: inheritId(options, transparent, parent),
+        _config: transparent ? CONFIG_TRANSPARENT : 0,
+        _root: true,
+        _parentComputed: (parent as Root)?._root ? (parent as Root)._parentComputed : parent,
+        _firstChild: null,
+        _nextSibling: null,
+        _prevSibling: null,
+        _disposal: null,
+        _queue: parent?._queue ?? globalQueue,
+        _context: parent?._context || defaultContext,
+        _childCount: 0,
+        _x: null,
+        _parent: parent,
+        dispose: disposeRootSelf
+      } as Root);
 
   if (__DEV__ && parent && parent._config & CONFIG_CHILDREN_FORBIDDEN) {
     emitDiagnostic({

--- a/packages/signals/src/core/scheduler.ts
+++ b/packages/signals/src/core/scheduler.ts
@@ -27,7 +27,7 @@ import {
 } from "./constants.js";
 import { attrHooks } from "./attribution-hooks.js";
 import { currentOptimisticLane, ext, slotUnobservedHook } from "./core.js";
-import { DEV, emitDiagnostic, reportDiagnostic } from "./dev.js";
+import { DEV, emitDiagnostic, GRAPH_SIZE_WARN_AT, noteFanOut, reportDiagnostic } from "./dev.js";
 import { NotReadyError } from "./error.js";
 import { sweepDormant } from "./graph.js";
 import { deleteFromHeap, enqueueSub, runHeap, type Heap } from "./heap.js";
@@ -951,8 +951,12 @@ export function insertSubs(node: Signal<any> | Computed<any>, optimistic: boolea
     (cfg & CONFIG_HAS_SNAPSHOT) !== 0 && (node as any)._x?._snapshotValue !== undefined;
   const clearReask = reaskArmed;
 
+  // Observe-tier fan-out: this walk visits every subscriber edge anyway, so
+  // the graph-size count is one local increment here and no field anywhere.
+  let fanOut = 0;
   for (let s = node._subs; s !== null; s = s._nextSub) {
     const sub = s._sub;
+    if (__OBSERVE__) fanOut++;
     // A value-change notification is a new question for the subscriber: any
     // pending re-ask mark (refresh) it carried is superseded.
     if (clearReask) sub._flags &= ~REACTIVE_REASK;
@@ -982,6 +986,7 @@ export function insertSubs(node: Signal<any> | Computed<any>, optimistic: boolea
 
     enqueueSub(sub);
   }
+  if (__OBSERVE__ && fanOut >= GRAPH_SIZE_WARN_AT) noteFanOut(node, fanOut);
 }
 
 function commitPendingNode(n: Signal<any>): void {

--- a/packages/signals/src/core/scheduler.ts
+++ b/packages/signals/src/core/scheduler.ts
@@ -1279,6 +1279,10 @@ export function flush<T>(fn?: () => T): T | void {
   }
   if (halted) return;
   let count = 0;
+  // Attribution: whether this call drained anything, so `flushEnd` fires once
+  // per real drain and never for a no-op call. The declaration is dead in
+  // prod (its only write is behind __OBSERVE__) and rollup drops it.
+  let drained = false;
   // `flush()` is an explicit drain point, so it must also process an active
   // transition even if no microtask was scheduled for it yet.
   while (scheduled || activeTransition) {
@@ -1299,7 +1303,13 @@ export function flush<T>(fn?: () => T): T | void {
       );
     }
     globalQueue.flush();
+    if (__OBSERVE__) drained = true;
   }
+  // Outside every try in this function (see the rule in attribution-hooks.ts):
+  // the drain loop above is the one place all scheduled work funnels through,
+  // so this is the "committed and effects ran, or parked" instant for
+  // everything the loop processed.
+  if (__OBSERVE__ && drained && attrHooks !== null) attrHooks.flushEnd();
 }
 
 function runQueue(queue: QueueCallback[], type: number): void {

--- a/packages/signals/src/core/types.ts
+++ b/packages/signals/src/core/types.ts
@@ -120,13 +120,19 @@ export interface NodeExtension {
 export interface RawSignal<T> {
   _subs: Link | null;
   _subsTail: Link | null;
-  /**
-   * DEV-only live subscriber count. Maintained by `link`/`unlinkSubs` for
-   * graph-size diagnostics; undefined in production.
-   */
-  _subCount?: number;
   _value: T;
+  /**
+   * Observe-tier label (`name` option, or the node kind: `signal`,
+   * `computed`, `effect`…). A slot in the observe/dev literals — never a
+   * post-construction write — and absent from the prod literals entirely.
+   */
   _name?: string;
+  /**
+   * Observe-tier: the owner in scope when a user-facing signal was created
+   * (`registerGraph`), so diagnostics about the signal get an owner path.
+   * A slot in the observe/dev `signal()` literal; absent from prod.
+   */
+  _owner?: Owner | null;
   _equals: false | ((a: T, b: T) => boolean);
   _config: number;
   _time: number;
@@ -166,16 +172,17 @@ export interface Owner {
   _prevSibling: Owner | null;
   /** Cold extension — see NodeExtension (owners use the zombie-pair slots). */
   _x: NodeExtension | null;
+  /**
+   * Observe-tier label: the `name` option, the node kind (`computed`,
+   * `effect`…), or the component label the rendering layer writes on a root
+   * (`<App>`). A slot in the observe/dev literals; absent from prod.
+   */
+  _name?: string;
 }
 
 export interface Computed<T> extends RawSignal<T>, Owner {
   _deps: Link | null;
   _depsTail: Link | null;
-  /**
-   * DEV-only live source count. Maintained by `link`/`unlinkSubs` for
-   * graph-size diagnostics; undefined in production.
-   */
-  _depCount?: number;
   /** Recompute-pass counter; bumped when dep revalidation starts. */
   _depGen: number;
   _flags: number;

--- a/packages/signals/src/index.ts
+++ b/packages/signals/src/index.ts
@@ -51,6 +51,8 @@ export type {
   AttributionHooks,
   AttributionSlot,
   InteractionRef,
+  NavigationRef,
+  OriginRef,
   Dev,
   Observe,
   DevHooks,

--- a/packages/signals/src/signals.ts
+++ b/packages/signals/src/signals.ts
@@ -512,7 +512,7 @@ export function createEffect<T>(
   }
   effect(compute as any, (effectFn as any).effect || effectFn, (effectFn as any).error, {
     user: true,
-    ...(__OBSERVE__ ? { ...options, name: options?.name ?? "effect" } : options)
+    ...options
   });
 }
 
@@ -550,12 +550,7 @@ export function createRenderEffect<T>(
   effectFn: EffectFunction<NoInfer<T>, T>,
   options?: EffectOptions
 ): void {
-  effect(
-    compute as any,
-    effectFn,
-    undefined,
-    __OBSERVE__ ? { ...options, name: options?.name ?? "effect" } : options
-  );
+  effect(compute as any, effectFn, undefined, options);
 }
 
 /**
@@ -607,10 +602,7 @@ export function createTrackedEffect(
   compute: () => void | (() => void),
   options?: BaseEffectOptions
 ): void {
-  trackedEffect(
-    compute,
-    __OBSERVE__ ? { ...options, name: options?.name ?? "trackedEffect" } : options
-  );
+  trackedEffect(compute, options);
 }
 
 /**
@@ -674,7 +666,7 @@ export function createReaction(
         },
         (effectFn as any).error,
         {
-          ...(__OBSERVE__ ? { ...options, name: options?.name ?? "effect" } : options),
+          ...options,
           user: true,
           defer: true
         }

--- a/packages/signals/tests/attribution-feedback.test.ts
+++ b/packages/signals/tests/attribution-feedback.test.ts
@@ -99,6 +99,7 @@ describe("feedback()", () => {
     expect(attribution.feedback()).toEqual({
       sources: [],
       interactions: [],
+      navigations: [],
       flights: [],
       fallbacks: []
     });
@@ -350,6 +351,7 @@ describe("feedback()", () => {
     expect(attribution.feedback()).toEqual({
       sources: [],
       interactions: [],
+      navigations: [],
       flights: [],
       fallbacks: []
     });

--- a/packages/signals/tests/attribution-navigation.test.ts
+++ b/packages/signals/tests/attribution-navigation.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Navigations as a declared origin.
+ *
+ * Claim under test: a router that wraps its location write in
+ * `OBSERVE.attribution.withOrigin({ kind: "navigation", … })` gets every
+ * downstream fact named by route — the writes' origin, the re-runs' cause
+ * chains, the hold the writes wait in and its verdicts — and one
+ * `NavigationEvent` per navigation that settles exactly once: `committed`
+ * when a plain drain took the writes, `held` when they waited in a
+ * transition (the HoldEvent attached), `superseded` when a later write
+ * replaced them before they landed. Nothing in the engine knows a router;
+ * the frame is the whole contract.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { attribution } from "../src/attribution.js";
+import {
+  action,
+  createEffect,
+  createMemo,
+  createRenderEffect,
+  createRoot,
+  createSignal,
+  flush,
+  OBSERVE
+} from "../src/index.js";
+import type { NavigationRef } from "../src/index.js";
+import type { RerunEvent } from "../src/core/attribution.js";
+import type { DiagnosticEvent } from "../src/core/dev.js";
+
+afterEach(() => {
+  attribution.disable();
+  flush();
+  vi.restoreAllMocks();
+});
+
+const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
+async function until(cond: () => boolean, what: string, timeout = 5000) {
+  const start = Date.now();
+  for (;;) {
+    flush();
+    if (cond()) return;
+    if (Date.now() - start > timeout) throw new Error(`timed out waiting for ${what}`);
+    await wait(5);
+  }
+}
+
+function arm(opts: { holds?: false } = {}) {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "info").mockImplementation(() => {});
+  attribution.enable({
+    log: false,
+    hotRuns: false,
+    hotTime: false,
+    waterfalls: false,
+    holds: opts.holds ?? { infoMs: 0, warnMs: 0 }
+  });
+  const runs: RerunEvent[] = [];
+  attribution.subscribe(e => runs.push(e));
+  const silent: DiagnosticEvent[] = [];
+  OBSERVE!.diagnostics.subscribe(e => {
+    if (e.code === "SILENT_HOLD") silent.push(e);
+  });
+  return { runs, silent };
+}
+
+const CLICK = { type: "click", target: 'a.nav "Alice"' };
+const NAV: NavigationRef = {
+  kind: "navigation",
+  name: "/users/:id",
+  to: "/users/42",
+  from: "/users",
+  params: { id: "42" }
+};
+
+/** A location signal and an async page that re-fetches whenever it changes. */
+function routedApp() {
+  const [location, setLocation] = createSignal("/users", { name: "location" });
+  let resolve: ((v: string) => void) | null = null;
+  const page = createMemo(
+    () => {
+      const l = location();
+      return new Promise<string>(r => (resolve = v => r(`${v}@${l}`)));
+    },
+    { name: "page" }
+  );
+  const shown: string[] = [];
+  createRoot(() =>
+    createRenderEffect(
+      page,
+      v => {
+        shown.push(v);
+      },
+      { name: "view" }
+    )
+  );
+  return { location, setLocation, shown, resolve: (v: string) => resolve!(v) };
+}
+
+describe("withOrigin — navigation provenance", () => {
+  it("stamps the writes inside the frame as the navigation, under the enclosing interaction", () => {
+    const { runs } = arm();
+    const [location, setLocation] = createSignal("/users", { name: "location" });
+    createRoot(() => createEffect(location, () => {}, { name: "reader" }));
+    flush();
+    const before = performance.now();
+    OBSERVE!.attribution.withInteraction(CLICK, () =>
+      OBSERVE!.attribution.withOrigin(NAV, () => setLocation("/users/42"))
+    );
+    flush();
+    const run = runs.filter(r => r.nodeName === "reader").at(-1)!;
+    const origin = run.causes[0].origin!;
+    expect(origin).toMatchObject({
+      kind: "navigation",
+      name: "/users/:id",
+      to: "/users/42",
+      from: "/users",
+      params: { id: "42" },
+      interaction: { kind: "interaction", name: "click", target: CLICK.target }
+    });
+    expect(origin.at).toBeGreaterThanOrEqual(before);
+    // Downstream facts still key by the interaction that paid for it.
+    expect(run.interaction).toBe(origin.interaction);
+    const text = attribution.format(run);
+    expect(text).toContain(`— navigation to /users/:id (/users/42) (under click on a.nav "Alice")`);
+  });
+
+  it("stands alone when nothing user-dispatched encloses it (a redirect)", () => {
+    const { runs } = arm();
+    const [location, setLocation] = createSignal("/users", { name: "location" });
+    createRoot(() => createEffect(location, () => {}, { name: "reader" }));
+    flush();
+    OBSERVE!.attribution.withOrigin({ kind: "navigation", name: "/login", to: "/login" }, () =>
+      setLocation("/login")
+    );
+    flush();
+    const run = runs.filter(r => r.nodeName === "reader").at(-1)!;
+    expect(run.causes[0].origin).toEqual(
+      expect.objectContaining({ kind: "navigation", name: "/login" })
+    );
+    expect(run.causes[0].origin!.interaction).toBeUndefined();
+    expect(run.interaction).toBeUndefined();
+    // Pattern equal to the concrete path: no redundant parenthetical.
+    expect(attribution.formatOrigin(run.causes[0].origin!)).toBe("navigation to /login");
+  });
+
+  it("inherits the interaction of an action step it runs in, after the click is long gone", async () => {
+    const { runs } = arm();
+    const [location, setLocation] = createSignal("/todos", { name: "location" });
+    createRoot(() => createEffect(location, () => {}, { name: "reader" }));
+    flush();
+    const save = action(async function* save() {
+      yield wait(5);
+      OBSERVE!.attribution.withOrigin(
+        { kind: "navigation", name: "/todos/:id", to: "/todos/7", params: { id: "7" } },
+        () => setLocation("/todos/7")
+      );
+    });
+    const done = OBSERVE!.attribution.withInteraction(CLICK, () => save());
+    await done;
+    await until(() => runs.some(r => r.nodeName === "reader"), "the reader's re-run");
+    const run = runs.filter(r => r.nodeName === "reader").at(-1)!;
+    expect(run.causes[0].origin).toMatchObject({
+      kind: "navigation",
+      name: "/todos/:id",
+      interaction: { kind: "interaction", name: "click" }
+    });
+    expect(attribution.navigations().at(-1)!.interaction).toMatchObject({ name: "click" });
+  });
+
+  it("is a plain call when no engine is installed", () => {
+    // Not armed: attribution is disabled, so the core's slot has no hooks.
+    expect(OBSERVE!.attribution.installed).toBeNull();
+    const [location, setLocation] = createSignal("/a", { name: "location" });
+    const result = OBSERVE!.attribution.withOrigin(NAV, () => {
+      setLocation("/b");
+      return 42;
+    });
+    expect(result).toBe(42);
+    flush();
+    expect(location()).toBe("/b");
+    expect(attribution.navigations()).toEqual([]);
+  });
+});
+
+describe("navigations() — one settled record per frame", () => {
+  it("settles a navigation no transition held as committed at the end of the drain", () => {
+    arm();
+    const [location, setLocation] = createSignal("/users", { name: "location" });
+    createRoot(() => createEffect(location, () => {}, { name: "reader" }));
+    flush();
+    OBSERVE!.attribution.withInteraction(CLICK, () =>
+      OBSERVE!.attribution.withOrigin(NAV, () => setLocation("/users/42"))
+    );
+    const [open] = attribution.navigations();
+    expect(open).toMatchObject({
+      name: "/users/:id",
+      to: "/users/42",
+      from: "/users",
+      params: { id: "42" },
+      writes: 1,
+      interaction: { name: "click" }
+    });
+    expect(open.settledMs).toBeUndefined();
+    expect(open.outcome).toBeUndefined();
+    flush();
+    expect(open.outcome).toBe("committed");
+    expect(open.settledMs).toBeGreaterThanOrEqual(0);
+    expect(open.hold).toBeUndefined();
+    expect(attribution.navigations()).toHaveLength(1);
+  });
+
+  it("settles immediately when no write survived the equality gate", () => {
+    arm();
+    const [, setLocation] = createSignal("/users", { name: "location" });
+    OBSERVE!.attribution.withOrigin({ kind: "navigation", name: "/users", to: "/users" }, () =>
+      setLocation("/users")
+    );
+    const [nav] = attribution.navigations();
+    expect(nav.writes).toBe(0);
+    expect(nav.outcome).toBe("committed");
+  });
+
+  it("settles at frame close when a drain inside the frame already committed the writes", () => {
+    arm();
+    const [location, setLocation] = createSignal("/a", { name: "location" });
+    createRoot(() => createEffect(location, () => {}, { name: "reader" }));
+    flush();
+    OBSERVE!.attribution.withOrigin({ kind: "navigation", name: "/b", to: "/b" }, () =>
+      flush(() => setLocation("/b"))
+    );
+    const [nav] = attribution.navigations();
+    expect(nav.writes).toBe(1);
+    expect(nav.outcome).toBe("committed");
+  });
+
+  it("settles a navigation performed inside an effect (a redirect during a drain)", () => {
+    arm();
+    const [location, setLocation] = createSignal("/private", { name: "location" });
+    const [authed, setAuthed] = createSignal(true, { name: "authed" });
+    createRoot(() => {
+      createEffect(
+        authed,
+        ok => {
+          if (!ok)
+            OBSERVE!.attribution.withOrigin(
+              { kind: "navigation", name: "/login", to: "/login", from: "/private" },
+              () => setLocation("/login")
+            );
+        },
+        { name: "guard" }
+      );
+      createEffect(location, () => {}, { name: "reader" });
+    });
+    flush();
+    setAuthed(false);
+    flush();
+    expect(location()).toBe("/login");
+    const [nav] = attribution.navigations();
+    expect(nav).toMatchObject({ name: "/login", writes: 1, outcome: "committed" });
+    expect(nav.origin.interaction).toBeUndefined();
+  });
+
+  it("settles a held navigation with the hold attached, and names the hold by route", async () => {
+    const { silent } = arm();
+    const app = routedApp();
+    flush();
+    app.resolve("alice");
+    await until(() => app.shown.includes("alice@/users"), "initial load");
+
+    OBSERVE!.attribution.withInteraction({ ...CLICK, at: performance.now() }, () =>
+      OBSERVE!.attribution.withOrigin(NAV, () => app.setLocation("/users/42"))
+    );
+    flush();
+    expect(app.shown).toEqual(["alice@/users"]); // held: nothing painted
+    const [nav] = attribution.navigations();
+    expect(nav.outcome).toBeUndefined(); // still waiting on the page
+    await wait(10);
+    app.resolve("alice");
+    await until(() => app.shown.includes("alice@/users/42"), "the held page to land");
+
+    expect(nav.outcome).toBe("held");
+    expect(nav.hold).toBeDefined();
+    expect(nav.settledMs).toBeGreaterThanOrEqual(10);
+    const [hold] = attribution.holds();
+    expect(nav.hold).toBe(hold);
+    // The hold names the navigation, and joins to it by identity.
+    expect(hold.origin).toBe(nav.origin);
+    expect(hold.origin).toMatchObject({ kind: "navigation", name: "/users/:id" });
+    expect(hold.interaction).toMatchObject({ kind: "interaction", name: "click" });
+    expect(hold.heldWrites.map(w => w.name)).toEqual(["location"]);
+    expect(hold.blockers).toEqual(["page"]);
+    // The verdict reads from what the user did, through the route.
+    expect(silent).toHaveLength(1);
+    expect(silent[0].message).toContain(
+      `[SILENT_HOLD] click on a.nav "Alice" (navigation to /users/:id (/users/42)) wrote "location"`
+    );
+    expect(silent[0].data).toMatchObject({
+      navigation: { name: "/users/:id", to: "/users/42", from: "/users", params: { id: "42" } }
+    });
+  });
+
+  it("names a redirect's hold by the navigation alone when no interaction is known", async () => {
+    const { silent } = arm();
+    const app = routedApp();
+    flush();
+    app.resolve("a");
+    await until(() => app.shown.includes("a@/users"), "initial load");
+
+    OBSERVE!.attribution.withOrigin(NAV, () => app.setLocation("/users/42"));
+    flush();
+    await wait(10);
+    app.resolve("b");
+    await until(() => app.shown.includes("b@/users/42"), "the held page to land");
+
+    expect(silent[0].message).toContain(
+      `[SILENT_HOLD] navigation to /users/:id (/users/42) wrote "location"`
+    );
+    expect(attribution.holds()[0].interaction).toBeUndefined();
+  });
+
+  it("still settles a held navigation when hold tracking is off", async () => {
+    arm({ holds: false });
+    const app = routedApp();
+    flush();
+    app.resolve("a");
+    await until(() => app.shown.includes("a@/users"), "initial load");
+
+    OBSERVE!.attribution.withOrigin(NAV, () => app.setLocation("/users/42"));
+    flush();
+    const [nav] = attribution.navigations();
+    expect(nav.outcome).toBeUndefined();
+    await wait(10);
+    app.resolve("b");
+    await until(() => app.shown.includes("b@/users/42"), "the held page to land");
+
+    expect(nav.outcome).toBe("held");
+    expect(nav.hold).toBeUndefined(); // nothing recorded it
+    expect(attribution.holds()).toEqual([]);
+  });
+
+  it("marks a navigation superseded when a later one replaces its write before it lands", async () => {
+    arm();
+    const app = routedApp();
+    flush();
+    app.resolve("a");
+    await until(() => app.shown.includes("a@/users"), "initial load");
+
+    OBSERVE!.attribution.withOrigin(NAV, () => app.setLocation("/users/42"));
+    flush();
+    OBSERVE!.attribution.withOrigin(
+      { kind: "navigation", name: "/users/:id", to: "/users/43", params: { id: "43" } },
+      () => app.setLocation("/users/43")
+    );
+    flush();
+    const [first, second] = attribution.navigations();
+    expect(first.outcome).toBe("superseded");
+    expect(first.hold).toBeUndefined();
+    expect(second.outcome).toBeUndefined();
+    await wait(10);
+    app.resolve("b");
+    await until(() => app.shown.includes("b@/users/43"), "the second page to land");
+    expect(second.outcome).toBe("held");
+    expect(second.hold!.origin).toBe(second.origin);
+    expect(attribution.navigations()).toHaveLength(2);
+  });
+
+  it("folds settled navigations into feedback().navigations by route", async () => {
+    arm();
+    const app = routedApp();
+    flush();
+    app.resolve("a");
+    await until(() => app.shown.includes("a@/users"), "initial load");
+
+    // One instant navigation, one held-and-silent, one superseded — all on one route.
+    const [, setOther] = createSignal(0, { name: "other" });
+    OBSERVE!.attribution.withOrigin(
+      { kind: "navigation", name: "/users/:id", to: "/users/1" },
+      () => setOther(1)
+    );
+    flush();
+    OBSERVE!.attribution.withOrigin(
+      { kind: "navigation", name: "/users/:id", to: "/users/2" },
+      () => app.setLocation("/users/2")
+    );
+    flush();
+    OBSERVE!.attribution.withOrigin(
+      { kind: "navigation", name: "/users/:id", to: "/users/3" },
+      () => app.setLocation("/users/3")
+    );
+    flush();
+    await wait(10);
+    app.resolve("b");
+    await until(() => app.shown.includes("b@/users/3"), "the last page to land");
+
+    const [row] = attribution.feedback().navigations;
+    expect(row).toMatchObject({
+      name: "/users/:id",
+      navigations: 3,
+      held: 1,
+      silent: 1,
+      superseded: 1
+    });
+    // heldMs is the hold's own clock: it opened with the superseded
+    // navigation's write and the surviving one inherited it, so it can run
+    // longer than the survivor's own request-to-settle time.
+    expect(row.heldMs).toBeGreaterThanOrEqual(10);
+    expect(row.settledMs).toBeGreaterThan(0);
+    expect(row.worstMs).toBeGreaterThan(0);
+  });
+
+  it("clears its records on disable() and enable()", () => {
+    arm();
+    const [, setLocation] = createSignal("/a", { name: "location" });
+    OBSERVE!.attribution.withOrigin({ kind: "navigation", name: "/b", to: "/b" }, () =>
+      setLocation("/b")
+    );
+    flush();
+    expect(attribution.navigations()).toHaveLength(1);
+    attribution.disable();
+    expect(attribution.navigations()).toEqual([]);
+    arm();
+    expect(attribution.navigations()).toEqual([]);
+    expect(attribution.feedback().navigations).toEqual([]);
+  });
+});

--- a/packages/signals/tests/dist-artifacts.test.ts
+++ b/packages/signals/tests/dist-artifacts.test.ts
@@ -152,6 +152,96 @@ describe("@solidjs/signals artifacts", () => {
   });
 });
 
+describe("@solidjs/signals node literals per tier", () => {
+  // Each node factory has two object literals — prod, and observe = prod plus
+  // its diagnostic slots (`_name`; `_owner` on signals) — selected at build
+  // time. The slots MUST be in the literal: written after construction they
+  // force a hidden-class transition and an out-of-object property on every
+  // node, which was the whole of the observe tier's measured creation
+  // overhead. Two hand-kept literals can drift, so this pins the invariant
+  // from the built trees: the observe literal's keys are exactly the prod
+  // literal's keys plus the slots, and the prod literal has no slot at all.
+  // Field names are mangled per tree (`_name` is reserved), so the
+  // comparison is by count and by the reserved name.
+  async function literalKeys(tier: "prod" | "observe") {
+    const core = (await import(`../dist/${tier}/core/core.js`)) as any;
+    const owner = (await import(`../dist/${tier}/core/owner.js`)) as any;
+    const { createRoot } = (await import(`../dist/${tier}/index.js`)) as any;
+    const keys: Record<string, string[]> = {};
+    createRoot((dispose: () => void) => {
+      keys.owner = Object.keys(owner.createOwner());
+      keys.signal = Object.keys(core.signal(0));
+      keys.slotSignal = Object.keys(core.slotSignal(0, () => false, {}, "k", false));
+      keys.computed = Object.keys(core.computed(() => 0));
+      keys.effect = Object.keys(
+        core.createEffectNode(
+          () => 0,
+          () => {},
+          undefined,
+          1,
+          undefined
+        )
+      );
+      dispose();
+    });
+    return keys;
+  }
+
+  test("observe literals are the prod literals plus their slots — never a write after", async () => {
+    const prod = await literalKeys("prod");
+    const observe = await literalKeys("observe");
+    const slots: Record<string, string[]> = {
+      owner: ["_name"],
+      signal: ["_name", "_owner"],
+      slotSignal: ["_name"],
+      computed: ["_name"],
+      effect: ["_name"]
+    };
+    for (const kind of Object.keys(slots)) {
+      expect(prod[kind], `${kind} prod literal carries a slot`).not.toContain("_name");
+      expect(observe[kind], `${kind} observe literal lacks its slot`).toContain("_name");
+      expect(observe[kind].length, `${kind} literals drifted`).toBe(
+        prod[kind].length + slots[kind].length
+      );
+    }
+    // The prod computed/effect literals sit under V8's in-object boundary
+    // (~39 fields, §12); the observe slot must not push either past it.
+    expect(observe.effect.length).toBeLessThanOrEqual(38);
+    expect(observe.computed.length).toBeLessThanOrEqual(38);
+  });
+
+  test("observe defaults land in the slot, not as a later write", async () => {
+    const observe = (await import("../dist/observe/index.js")) as any;
+    const core = (await import("../dist/observe/core/core.js")) as any;
+    // Default labels and a supplied name both come out of the same literal:
+    // the key set is identical either way.
+    const plain = core.computed(() => 0);
+    const named = core.computed(() => 0, { name: "n" });
+    expect(Object.keys(named)).toEqual(Object.keys(plain));
+    expect(plain._name).toBe("computed");
+    expect(named._name).toBe("n");
+    // The default effect label comes from the node kind, not from an options
+    // spread in the wrapper (which allocated per effect in observe).
+    let effectName: string | undefined;
+    let trackedName: string | undefined;
+    observe.createRoot((dispose: () => void) => {
+      observe.createEffect(
+        () => {
+          effectName = (observe.getOwner() as any)._name;
+        },
+        () => {}
+      );
+      observe.createTrackedEffect(() => {
+        trackedName = (observe.getOwner() as any)._name;
+      });
+      observe.flush();
+      dispose();
+    });
+    expect(effectName).toBe("effect");
+    expect(trackedName).toBe("trackedEffect");
+  });
+});
+
 describe("@solidjs/signals artifacts under require()", () => {
   // Node >= 22.12 loads ESM through `require()` synchronously. That is what
   // lets the package ship ESM only: a CJS host follows the same export

--- a/packages/signals/tests/dist-artifacts.test.ts
+++ b/packages/signals/tests/dist-artifacts.test.ts
@@ -36,9 +36,10 @@ function expectObserveLive(mod: Tier) {
   expect(typeof observe.diagnostics.subscribe).toBe("function");
   expect(typeof observe.diagnostics.capture).toBe("function");
   expect(typeof observe.diagnostics.emit).toBe("function");
-  // The core's side of attribution is the slot and the interaction frame only.
+  // The core's side of attribution is the slot and the two declared frames only.
   expect(typeof observe.attribution.install).toBe("function");
   expect(typeof observe.attribution.withInteraction).toBe("function");
+  expect(typeof observe.attribution.withOrigin).toBe("function");
   expect(observe.attribution.installed).toBeNull();
   expect(observe.attribution.enable).toBeUndefined();
   expect(typeof observe.subjectOf).toBe("function");
@@ -64,12 +65,19 @@ function expectEngineDrivesCore(core: any, engine: Engine) {
       return set;
     });
     core.flush();
-    observe.attribution.withInteraction({ type: "click", target: "button#go" }, () => setCount(1));
+    observe.attribution.withInteraction({ type: "click", target: "button#go" }, () =>
+      observe.attribution.withOrigin({ kind: "navigation", name: "/go", to: "/go" }, () =>
+        setCount(1)
+      )
+    );
     core.flush();
     const rerun = runs.find(r => r.nodeName === "reader" && r.causes.length);
     expect(rerun).toBeDefined();
     expect(rerun.causes[0].name).toBe("count");
+    expect(rerun.causes[0].origin).toMatchObject({ kind: "navigation", name: "/go" });
     expect(rerun.interaction).toMatchObject({ kind: "interaction", name: "click" });
+    // The drain's flushEnd reached the engine: the navigation settled.
+    expect(attribution.navigations()[0]).toMatchObject({ name: "/go", outcome: "committed" });
   } finally {
     attribution.disable();
   }
@@ -83,9 +91,11 @@ function expectEngineInert(engine: Engine) {
   expect(attribution.history()).toEqual([]);
   expect(attribution.costs()).toEqual({ scopes: [], writes: [] });
   expect(attribution.holds()).toEqual([]);
+  expect(attribution.navigations()).toEqual([]);
   expect(attribution.feedback()).toEqual({
     sources: [],
     interactions: [],
+    navigations: [],
     flights: [],
     fallbacks: []
   });

--- a/packages/signals/tests/graph-size-diagnostics.test.ts
+++ b/packages/signals/tests/graph-size-diagnostics.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createEffect, createRoot, createSignal, flush, OBSERVE } from "../src/index.js";
+import {
+  createEffect,
+  createMemo,
+  createRoot,
+  createSignal,
+  flush,
+  OBSERVE
+} from "../src/index.js";
 import { GRAPH_SIZE_WARN_AT, GRAPH_SIZE_WARN_EVERY } from "../src/core/dev.js";
 
 afterEach(() => {
@@ -15,20 +22,34 @@ function captureGraphEvents() {
   };
 }
 
+/** `n` effects subscribed to `read`, under one disposable root. */
+function subscribe(read: () => unknown, n: number) {
+  return createRoot(d => {
+    for (let i = 0; i < n; i++) {
+      createEffect(
+        () => read(),
+        () => {}
+      );
+    }
+    return d;
+  });
+}
+
+// The core keeps no live edge counts (a per-node counter was a
+// post-construction field that forked node shapes): fan-out is counted by the
+// notify walk a committed change already makes over its subscribers, fan-in
+// by the recompute pass over the sources it tracks. So both warnings fire on
+// the WORK — the write / the recompute — not on the link.
 describe("graph-size diagnostics", () => {
-  it("warns HUGE_FAN_OUT when one signal reaches the subscriber threshold", () => {
+  it("warns HUGE_FAN_OUT when a change reaches the subscriber threshold", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const cap = captureGraphEvents();
-    const [value] = createSignal(0, { name: "hot-source" });
-    const dispose = createRoot(d => {
-      for (let i = 0; i < GRAPH_SIZE_WARN_AT; i++) {
-        createEffect(
-          () => value(),
-          () => {}
-        );
-      }
-      return d;
-    });
+    const [value, setValue] = createSignal(0, { name: "hot-source" });
+    const dispose = subscribe(value, GRAPH_SIZE_WARN_AT);
+    flush();
+    // Static structure alone is silent: nothing has re-run yet.
+    expect(cap.events()).toHaveLength(0);
+    setValue(1);
     flush();
     const events = cap.events();
     expect(events).toHaveLength(1);
@@ -37,13 +58,13 @@ describe("graph-size diagnostics", () => {
     expect(events[0].nodeName).toBe("hot-source");
     expect(events[0].data).toEqual({ count: GRAPH_SIZE_WARN_AT });
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("[HUGE_FAN_OUT]"));
-    expect(warn.mock.calls[0][0]).toContain(`has ${GRAPH_SIZE_WARN_AT} subscribers`);
+    expect(warn.mock.calls[0][0]).toContain(`with ${GRAPH_SIZE_WARN_AT} subscribers`);
     cap.stop();
     dispose();
     flush();
   });
 
-  it("warns HUGE_FAN_IN when one computation reaches the source threshold", () => {
+  it("warns HUGE_FAN_IN when a recompute tracks the source threshold", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const cap = captureGraphEvents();
     const signals = Array.from({ length: GRAPH_SIZE_WARN_AT }, (_, i) => createSignal(i));
@@ -61,6 +82,7 @@ describe("graph-size diagnostics", () => {
     const events = cap.events();
     expect(events).toHaveLength(1);
     expect(events[0].code).toBe("HUGE_FAN_IN");
+    expect(events[0].nodeName).toBe("wide-reader");
     expect(events[0].data).toEqual({ count: GRAPH_SIZE_WARN_AT });
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("[HUGE_FAN_IN]"));
     cap.stop();
@@ -68,58 +90,100 @@ describe("graph-size diagnostics", () => {
     flush();
   });
 
-  it("re-warns at the repeat interval, not on every link past the threshold", () => {
+  it("counts distinct sources per pass — repeat reads and nested pulls do not inflate", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const cap = captureGraphEvents();
-    const [value] = createSignal(0);
+    const signals = Array.from({ length: GRAPH_SIZE_WARN_AT - 1 }, (_, i) => createSignal(i));
+    const [trigger, setTrigger] = createSignal(0);
     const dispose = createRoot(d => {
-      for (let i = 0; i < GRAPH_SIZE_WARN_AT + GRAPH_SIZE_WARN_EVERY; i++) {
-        createEffect(
-          () => value(),
-          () => {}
-        );
-      }
+      createEffect(
+        () => {
+          trigger();
+          // Each source read twice: 1999 distinct deps + trigger = 2000 - 1 + 1.
+          for (const [read] of signals) (read(), read());
+        },
+        () => {}
+      );
       return d;
     });
     flush();
-    const events = cap.events();
-    expect(events).toHaveLength(2);
-    expect(events[0].data).toEqual({ count: GRAPH_SIZE_WARN_AT });
-    expect(events[1].data).toEqual({ count: GRAPH_SIZE_WARN_AT + GRAPH_SIZE_WARN_EVERY });
+    // Exactly the threshold — a double-counting pass would report ~4000.
+    expect(cap.events().map(e => e.data)).toEqual([{ count: GRAPH_SIZE_WARN_AT }]);
+    // A re-run tracks the same 2000: not grown by GRAPH_SIZE_WARN_EVERY, so silent.
+    setTrigger(1);
+    flush();
+    expect(cap.events()).toHaveLength(1);
     cap.stop();
     dispose();
     flush();
   });
 
-  it("unlink decrements the count — a rebuilt graph warns from the true size", () => {
+  it("re-warns once the count has grown by the repeat interval, not on every change", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
-    const [value] = createSignal(0);
-    const build = () =>
-      createRoot(d => {
-        for (let i = 0; i < GRAPH_SIZE_WARN_AT; i++) {
-          createEffect(
-            () => value(),
-            () => {}
-          );
-        }
-        return d;
-      });
-    const dispose1 = build();
+    const cap = captureGraphEvents();
+    const [value, setValue] = createSignal(0);
+    const dispose1 = subscribe(value, GRAPH_SIZE_WARN_AT);
+    setValue(1);
+    flush();
+    setValue(2);
+    flush();
+    // Two writes at the same size: one warning.
+    expect(cap.events().map(e => e.data)).toEqual([{ count: GRAPH_SIZE_WARN_AT }]);
+    // Grown, but by less than the interval: still one.
+    const dispose2 = subscribe(value, GRAPH_SIZE_WARN_EVERY - 1);
+    setValue(3);
+    flush();
+    expect(cap.events()).toHaveLength(1);
+    // Reaches the interval: a second warning, at the new size.
+    const dispose3 = subscribe(value, 1);
+    setValue(4);
+    flush();
+    expect(cap.events().map(e => e.data)).toEqual([
+      { count: GRAPH_SIZE_WARN_AT },
+      { count: GRAPH_SIZE_WARN_AT + GRAPH_SIZE_WARN_EVERY }
+    ]);
+    cap.stop();
+    dispose1();
+    dispose2();
+    dispose3();
+    flush();
+  });
+
+  it("a rebuilt graph warns from its live size — unlinked subscribers are not counted", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const [value, setValue] = createSignal(0);
+    const dispose1 = subscribe(value, GRAPH_SIZE_WARN_AT);
     flush();
     dispose1();
     flush();
-    // If disposal failed to decrement, the second build's counts would pass
-    // through 2500/3000/3500/4000 and emit interval warnings with counts
-    // above the threshold; a correct rebuild warns exactly once, at the
-    // threshold itself.
     const cap = captureGraphEvents();
-    const dispose2 = build();
+    const dispose2 = subscribe(value, GRAPH_SIZE_WARN_AT);
+    setValue(1);
     flush();
-    const events = cap.events();
-    expect(events).toHaveLength(1);
-    expect(events[0].data).toEqual({ count: GRAPH_SIZE_WARN_AT });
+    // The count is the walked list, so a stale tally cannot read 4000 here.
+    expect(cap.events().map(e => e.data)).toEqual([{ count: GRAPH_SIZE_WARN_AT }]);
     cap.stop();
     dispose2();
+    flush();
+  });
+
+  it("a derived change counts its own fan-out", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const cap = captureGraphEvents();
+    const [value, setValue] = createSignal(0);
+    let dispose!: () => void;
+    createRoot(d => {
+      dispose = d;
+      const doubled = createMemo(() => value() * 2, { name: "doubled" });
+      subscribe(doubled, GRAPH_SIZE_WARN_AT);
+    });
+    flush();
+    setValue(1);
+    flush();
+    const events = cap.events();
+    expect(events.map(e => [e.code, e.nodeName])).toEqual([["HUGE_FAN_OUT", "doubled"]]);
+    cap.stop();
+    dispose();
     flush();
   });
 });

--- a/packages/solid/skills/reactivity-diagnostics/SKILL.md
+++ b/packages/solid/skills/reactivity-diagnostics/SKILL.md
@@ -409,6 +409,15 @@ same fold over holds and re-runs that `costs()` is over scopes and writes:
   `longHolds.infoMs`, acknowledged or not: the spinner is not the whole
   answer there — a `Loading` keyed with `on`, a preload, a cache, or a faster
   source is (see `LONG_HOLD`).
+- `navigations` — one row per route pattern (`/users/:id`), present when the
+  router declares its navigations via `OBSERVE.attribution.withOrigin`:
+  `navigations` settled, `settledMs`/`worstMs`, the `held` subset with
+  `heldMs` and how many were `silent`, and `superseded` (the user navigated
+  again before it landed). A route that is held and silent needs the
+  affordances above where the route's data renders; a route with many
+  superseded navigations is one users give up on — make its data fast or
+  preload it on hover/intent. `attribution.navigations()` lists each
+  navigation with its `outcome` and, when held, the `HoldEvent` itself.
 - `flights` — one row per async source: `flights` started, `landed`,
   `abandoned` (superseded by a newer flight before landing), `landedMs`,
   `worstMs`. A source with many abandoned flights is re-asking on every

--- a/scripts/size/.size-limit.js
+++ b/scripts/size/.size-limit.js
@@ -729,7 +729,12 @@ module.exports = [
     path: "csr-app.js",
     // Effect ownership on finalize re-entry (#3319, 2026-09-09): 14.30 KB -> 14.34 KB,
     // measured at 14.302. Core scheduler cost; see the core-floor note.
-    limit: "14.34 KB",
+    //
+    // Navigation origin frame (2026-09-09): 14.34 -> 14.40 KB, measured at
+    // 14.37. `OBSERVE.attribution.withOrigin` (the router-agnostic
+    // navigation seam, a twin of withInteraction) and the `flushEnd` hook
+    // site after flush()'s drain loop. Observe-only: prod folds both out.
+    limit: "14.40 KB",
     modifyEsbuildConfig: observeEsbuildConfig
   },
   {
@@ -745,7 +750,14 @@ module.exports = [
     path: "csr-app-attribution.js",
     // Contested-effect re-derivation (#3322, 2026-09-09): 24.00 -> 24.08 KB,
     // measured at 24.04. Core scheduler cost; see the core-floor note.
-    limit: "24.08 KB",
+    //
+    // Navigations (2026-09-09): 24.08 -> 24.90 KB, measured at 24.86. The
+    // engine's navigation records: the `navigation` origin kind and its
+    // formatting, one NavigationEvent per withOrigin frame settled through
+    // flushEnd / hold commit / supersession, `HoldEvent.origin` and the
+    // route-named SILENT_HOLD/LONG_HOLD actor, and the `feedback().navigations`
+    // fold. Engine-only cost; the observe tier above moved 30 B.
+    limit: "24.90 KB",
     modifyEsbuildConfig: observeEsbuildConfig
   },
   {


### PR DESCRIPTION
Stacked on #3324 (base: `observe-perf`); GitHub will retarget to `next` when that merges.

## Why

Sentry's Solid support today is shaped per router — `withSentryRouterRouting` for `@solidjs/router`, a separate integration for TanStack, the same pattern as React Router v3–v7 — because React has no framework-level notion of "a navigation". Solid 2 does, almost: a navigation is a plain write to the location, and the runtime already sees everything it costs (the hold behind route data, the re-runs, the blockers, the silence). The one thing it can't see is that the writes *were* a navigation, and to which route.

This PR adds that seam, in the engine's existing vocabulary, so the router-specific surface collapses to one call **inside the router** and every consumer (Sentry, devtools, `@solidjs/diagnostics`) reads navigations from the runtime with zero per-router code.

## The seam

```ts
OBSERVE
  ? OBSERVE.attribution.withOrigin(
      { kind: "navigation", name: match.pattern, to, from, params: match.params },
      () => setLocation(to)
    )
  : setLocation(to);
```

Twin of `withInteraction`: a declared frame whose writes are attributed to the ref, nested under the enclosing interaction when there is one (a link click), standing alone otherwise (a redirect). `OriginRef` is a discriminated union (`NavigationRef` today) so kinds can be added without the seam changing shape.

## What the engine does with it

- **Provenance**: `navigation` is a first-class `ChangeOrigin.kind` (`name`/`to`/`from`/`params`). Cause chains read `← signal "location" write … — navigation to /users/:id (/users/42) (under click on a.nav "Alice")`. A `navigate()` from an action step after a `yield` still inherits the click.
- **Holds named by route**: `HoldEvent.origin`; `SILENT_HOLD`/`LONG_HOLD` messages start from the actor — `click on a.nav (navigation to /users/:id) wrote "location" …`, or `navigation to /login wrote …` for a redirect — with `data.navigation` on the event.
- **`attribution.navigations()`**: one `NavigationEvent` per frame, settled exactly once:
  - `committed` — a plain drain took the writes (settle = end of that drain, the instant the screen had them);
  - `held` — they waited in a transition (settle = its commit; `hold` carries the `HoldEvent` when hold tracking recorded one; still settles with hold tracking off);
  - `superseded` — a later write replaced them before they landed (the user navigated again).
  
  A navigation whose write didn't survive the equality gate settles at once with `writes: 0`. `origin` on the event is the same object as `ChangeRecord.origin` / `HoldEvent.origin`, so records join by identity.
- **`feedback().navigations`**: per route pattern — count, `settledMs`/`worstMs`, `held`/`heldMs`/`silent`, `superseded`, `redirected`. The route-level table a router integration used to build itself.

## Late-bound on purpose (second commit)

Two things about the frame are read late, so the seam ships in its final shape rather than growing a second API:

- **The ref is re-read at settle.** The engine keeps the object passed to `withOrigin` and copies `name`/`to`/`params` from it again when the navigation settles (and when a hold on it is judged). A router whose match is coarse at write time — a lazy route subtree that resolves inside the hold — describes `/admin/*`, then assigns the exact pattern and params onto the same object once it knows them; the settled record, the hold's verdict and the feedback row all read the refined name. `from`/`at` are read once, at open. No `refine()` method.
- **A redirect is a hop, not a new navigation.** `NavigationRef.redirect: n` (`n >= 1`, the hop depth both routers already track — `_navigation` in `@solidjs/router`, the tx depth in TanStack) re-enters the pending navigation's frame instead of opening one. Its write replaces the pending one with the *same origin object*, so nothing is superseded; the record keeps the user's request time and interaction (so `settledMs` runs from the click, not the hop); the abandoned destination moves to `NavigationEvent.redirects`; the hold joins by identity as before. `formatOrigin` reads `navigation to /login (redirected from /users/42)`, and a chain reads `redirected from /users/42 → /login`. With nothing pending to fold onto, a `redirect` frame opens a navigation of its own.

### Hold census fix (found by the router-shaped test)

Memos compute eagerly. A router's internal `createMemo(() => isPending(location))` — Solid Router 2.0's `routingPending` has this shape — subscribes to the pending companion whether or not the app ever renders the memo, and the census counted any subscriber as "the screen acknowledged". So every Solid Router navigation would have read as acknowledged, never `SILENT_HOLD`, even with no routing indicator on screen. The census now requires a companion to **reach an effect**, through however many memos: a memo alone is not the screen. Two tests pin both directions (router memo unrendered → `SILENT_HOLD`, `latestOnly: 0`; the same memo read by a render effect → `isPending:location` acknowledged).

## Core changes

- `withOrigin` + `originStart`/`originEnd` hooks (`attribution-hooks.ts`), exposed as `OBSERVE.attribution.withOrigin`.
- **One new hook, `flushEnd`**, fired once per `flush()` drain (after the loop, outside every `try`) so the engine has the "committed and effects ran, or parked" instant for writes no transition ever held — transitions are created lazily only when async is hit, so instant navigations never produced a settle signal before. Cost: one null check per drain in observe; the site and its `drained` flag fold out in prod.
- `formatOrigin` renders `navigation to <pattern> (<to>)`.

## Verification

- **Prod dist byte-identical** for every `dist/prod/*.js` except `attribution.js` (the inert twin gained `navigations()` and the `navigations: []` table).
- New `tests/attribution-navigation.test.ts` (21 tests): stamping under an interaction, standalone, through an action step; no-engine passthrough; settle paths — committed at drain end, zero-write immediate, drain inside the frame, redirect inside an effect during a drain, held with hold attached and route-named verdict, redirect-named verdict, held with hold tracking off, superseded, feedback fold, reset on disable/enable; lazy-match refinement during a hold; redirect folding (held chain with click-relative timing and chain-named verdict, successive hops, synchronous nested hop, no-pending fallback); router-shaped census in both directions.
- `dist-artifacts.test.ts` drives a navigation end to end through the built observe artifacts and asserts `flushEnd` reached the engine.
- Full suites green: signals 1646, solid 594, web 712, diagnostics 31; `tsc -p tsconfig.build.json` clean.
- Size: prod scenarios unchanged; observe tier +30 B (14.34 → 14.40 KB limit, did not move in the second commit), observe + engine +0.78 KB then +0.26 KB (24.08 → 25.20 KB limit), all annotated in `.size-limit.js`.

## What the routers need to do

Match eagerly, then wrap the location write in the call above (both `@solidjs/router` and TanStack Solid Router can match synchronously); pass `redirect: depth` on the hop when a guard or loader redirects; assign the exact pattern onto the ref once a lazy subtree resolves. That is the whole contract. Server side, the same label wants to land on the request event so the server transaction is named by the router — that folds into the trace-context item (C1), not this PR.

## Not in this PR

- `@solidjs/diagnostics` artifact/browser bridge don't yet include `navigations` (they also omit `waterfalls`); follow-up.
- `RerunEvent` carries no navigation field — cause records already carry the origin.

Co-authored-by: Claude via Cursor

Made with [Cursor](https://cursor.com)
