### PR TITLE
chore: stale gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,17 +16,7 @@ packages/babel-plugin/index.js
 .pnpm-store/
 .types-build/
 
-packages/solid/src/jsx.d.ts
-packages/solid-web/src/jsx.d.ts
-packages/solid-web/src/jsx-properties.d.ts
-packages/solid-h/jsx-runtime/src/jsx.d.ts
-packages/solid-h/jsx-runtime/src/jsx-properties.d.ts
-packages/solid/web/server/server.d.ts
-packages/solid/web/src/client.d.ts
-packages/solid/universal/src/universal.d.ts
-
 # vscode devcontainers see issues #419 and #421 for context
 /.devcontainer.json
 /devcontainer
-packages/solid-web/test/harness/__artifacts__/
 packages/test-integration/tests/fixtures/downloaded/

--- a/.gitignore
+++ b/.gitignore
@@ -3,20 +3,14 @@ dist/
 lib/
 # ...but an example's source tree may legitimately have one (src/lib/api.ts).
 !examples/*/src/lib/
-.vscode/
 .cursor/*
 !.cursor/rules/
-.idea/
 coverage/
 types/
 types-cjs/
 packages/babel-plugin/index.js
-.DS_Store
 .turbo/
 .pnpm-store/
 .types-build/
 
-# vscode devcontainers see issues #419 and #421 for context
-/.devcontainer.json
-/devcontainer
 packages/test-integration/tests/fixtures/downloaded/


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Clean up the root `.gitignore` so it only contains entries that are relevant to working with this repository.

- Remove stale declaration and test artifact paths left behind by package restructuring.
  - Remove personal editor, OS, and devcontainer entries.
  - Keep generated build outputs, dependency directories, coverage files, and test caches ignored.
  - Preserve the existing Cursor distinction: personal `.cursor/*` files remain ignored, while shared `.cursor/rules/` stay versioned as project-level contributor guidance.

Editor- and OS-specific files such as .vscode/, .idea/, and .DS_Store are better handled by each contributor's global Git ignore configuration, since they reflect personal tooling rather than the project itself. I use Neovim, which generates its own artifacts - swap files, backups, undo history - and Cursor adds more too (.cursor/*), though .cursor/rules/ is kept since it's project convention, not personal tooling. Multiply the personal-tooling artifacts by every editor a contributor might use, and baking them all into the repo's .gitignore simply doesn't scale - it's a per-machine problem, better solved once, globally, than repeatedly, per project.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

 - `git diff --check`.
  - Verified current build, type, coverage, dependency, and test-cache paths remain ignored.
  - Verified project Cursor files remain ignored while `.cursor/rules/` remains available to Git,