### PR TITLE
chore(h): fix JSX runtime clean path

### DIFF
--- a/packages/h/package.json
+++ b/packages/h/package.json
@@ -47,7 +47,7 @@
   },
   "scripts": {
     "build": "npm-run-all -nl build:clean types:copy build:js",
-    "build:clean": "rimraf dist/ coverage/ /jsx-runtime/dist",
+    "build:clean": "rimraf dist/ coverage/ jsx-runtime/dist/",
     "build:js": "rollup -c",
     "types": "npm-run-all -nl types:clean types:copy types:h types:jsx",
     "types:clean": "rimraf types/",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Fix the `@solidjs/h` clean script so it removes the package-local JSX runtime output. The previous `/jsx-runtime/dist` argument was an absolute path. As a result, `rimraf` looked for the directory at the filesystem root instead of cleaning `packages/h/jsx-runtime/dist/`. This could allow stale JSX runtime bundles, such as old CommonJS artifacts, to survive subsequent builds.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

  - Added a temporary stale artifact to `packages/h/jsx-runtime/dist/`.
  - Ran `pnpm --filter @solidjs/h run build`.
  - Verified that the stale artifact and old `jsx.cjs` output were removed.
  - Verified that the current `jsx.js` bundle was regenerated.