### PR TITLE
fix(web): keep the server-function registry on globalThis across runtime re-evaluation

### DIFF
--- a/.changeset/share-server-function-registry-across-reloads.md
+++ b/.changeset/share-server-function-registry-across-reloads.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/web": patch
+---
+
+Keep the server-function dispatch registry on `globalThis` so a re-evaluated runtime (Vite's SSR program reload after an edit in dev) shares one registry with the RPC seam: `query()`-declared reads no longer answer 405 after the first HMR update (#3346).

--- a/packages/web/server-functions/src/server.ts
+++ b/packages/web/server-functions/src/server.ts
@@ -983,7 +983,24 @@ function bindDeferredBody(value, scope) {
   return value;
 }
 
-const REGISTRATIONS = new Map();
+// The dispatch registry is PROCESS state, not module state: it rides
+// registered symbols on globalThis, like the RPC seam it is reached through
+// (registry.ts `provideServerFunctionRPC`, first write wins). Under
+// `vite dev` this module is inlined into the SSR module runner, and an edit
+// to any module without a hot boundary makes the runner "program reload":
+// every module — this one included — is evaluated again into a fresh
+// instance, while the seam keeps handing integrations the FIRST instance's
+// `GET`. With per-instance maps a router's `query()` re-declared its reads
+// into the dead instance and dispatch, imported through the runner,
+// consulted the live one: after the first edit every declared read
+// answered 405 (#3346). One process, one registry: a grant made through
+// any copy's `GET` is the grant every copy's dispatch sees, and a rebind
+// revokes it (#3129) in the same maps the re-declaration re-grants it.
+function processState<T>(key: string, create: () => T): T {
+  const slot = Symbol.for(key);
+  return globalThis[slot] || (globalThis[slot] = create());
+}
+const REGISTRATIONS = processState("solid.ServerFunctionRegistrations", () => new Map());
 // Declared-method bookkeeping keyed by function id (internal, not public
 // API): the server half of `GET` records entries here so the HTTP handler
 // can gate GET dispatch — a GET request to a function that never declared
@@ -992,11 +1009,14 @@ const REGISTRATIONS = new Map();
 // "GET" (#3237): what a declaration asserts is safe is a function, and
 // dispatch is reached by an id, so the grant carries the one thing that
 // can tell them apart later (see `declaresRead` and `GET`).
-const METHODS = new Map();
+const METHODS = processState("solid.ServerFunctionMethods", () => new Map());
 // Which registered function a reference NAMES, so a declaration made about
 // the reference can be recorded against the binding it was made about
 // rather than against its id alone (see `GET`).
-const REFERENCE_BINDINGS = new WeakMap();
+const REFERENCE_BINDINGS = processState(
+  "solid.ServerFunctionReferenceBindings",
+  () => new WeakMap()
+);
 
 // Whether the id's CURRENT binding is the function a `GET()` grant was made
 // to — the one question both dispatch gates ask (#3237): the method gate

--- a/packages/web/test/server/server-functions-registry-reload.spec.tsx
+++ b/packages/web/test/server/server-functions-registry-reload.spec.tsx
@@ -1,0 +1,74 @@
+/**
+ * The dispatch registry survives a re-evaluation of the runtime (#3346).
+ *
+ * Under `vite dev` the server-function runtime is inlined into the SSR
+ * module runner, and any edit to a module without a hot boundary makes the
+ * runner "program reload": every module — the runtime included — is
+ * evaluated again into a fresh instance. The RPC seam integrations reach
+ * `GET` through (`getServerFunctionRPC`, a globalThis slot, first write
+ * wins) keeps handing out the FIRST instance's `GET`, so a router's
+ * `query()` re-declared its reads into the dead instance while dispatch —
+ * imported through the runner — consulted the live one: after the first
+ * edit every declared read answered 405 (`Allow: POST`).
+ *
+ * The registry is therefore process state, keyed on registered symbols like
+ * the seam itself: a grant made through any copy's `GET` is the grant every
+ * copy's dispatch sees, and the rebind revocation (#3129) fires in the same
+ * maps the re-declaration re-grants.
+ *
+ * Runs against the built bundle like the other server-function specs; the
+ * second instance is that bundle evaluated again after `vi.resetModules`.
+ */
+import { expect, it, vi } from "vitest";
+import { getServerFunctionRPC } from "@solidjs/web";
+import * as booted from "@solidjs/web/server-functions/server";
+
+const provideEvent = <T,>(_event: unknown, run: () => T): T => run();
+
+const readRequest = (id: string) =>
+  new Request(`https://app.example/_server/${id}`, {
+    method: "GET",
+    headers: { "Sec-Fetch-Site": "same-origin" }
+  });
+
+// What a router's query() does at module scope: register the compiled
+// function, then declare the read through the seam — never through a
+// direct import of the runtime.
+function declareThroughSeam(runtime: typeof booted, id: string, fn: (...args: any[]) => any) {
+  const reference = runtime.createServerReference(runtime.registerServerReference(id, fn));
+  return getServerFunctionRPC()!.GET(reference);
+}
+
+it("a re-evaluated runtime shares the registry the seam's GET writes to (#3346)", async () => {
+  // boot: the first instance registers the read and fills the seam
+  const first = vi.fn(async () => "first evaluation");
+  declareThroughSeam(booted, "reload-read", first);
+  expect(getServerFunctionRPC()!.GET).toBe(booted.GET);
+  const before = await booted.handleServerFunctionRequest(readRequest("reload-read"), {
+    provideEvent
+  });
+  expect(before.status).toBe(200);
+  expect(await before.text()).toContain("first evaluation");
+
+  // program reload: the runtime is evaluated again, the seam is not
+  vi.resetModules();
+  const reloaded: typeof booted = await import("@solidjs/web/server-functions/server");
+  expect(reloaded.handleServerFunctionRequest).not.toBe(booted.handleServerFunctionRequest);
+  expect(getServerFunctionRPC()!.GET).toBe(booted.GET);
+
+  // the re-evaluated module registers its fresh closure and re-declares it
+  // through the seam, which still hands out the first instance's GET
+  const second = vi.fn(async () => "second evaluation");
+  declareThroughSeam(reloaded, "reload-read", second);
+
+  // dispatch through the live instance finds the grant and runs the live
+  // function
+  const after = await reloaded.handleServerFunctionRequest(readRequest("reload-read"), {
+    provideEvent
+  });
+  expect(after.status).toBe(200);
+  expect(after.headers.get("Allow")).toBeNull();
+  expect(await after.text()).toContain("second evaluation");
+  expect(second).toHaveBeenCalledTimes(1);
+  expect(first).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
Closes #3346.

## The bug

After any edit in `vite dev`, every `query()`-wrapped server function answered `405 Method Not Allowed` (`Allow: POST`) on client navigation, and the app showed "Server function call failed with status 405". Reproduced with the reporter's app (`solid-devtools-get-405`) on rc.7.

## Mechanism

The dispatch registry (`REGISTRATIONS`, `METHODS`, `REFERENCE_BINDINGS` in `server-functions/src/server.ts`) was module-instance state, but the RPC seam integrations reach `GET` through (`provideServerFunctionRPC` in `registry.ts`) is a `globalThis` slot where the first write wins.

Under `vite dev` the plugin inlines `@solidjs/web` into the SSR module runner (`ssr.noExternal`), so an edit to any module without a hot boundary makes the runner `(ssr) program reload` and evaluate the runtime again into a fresh instance with empty maps. Its `provideRPC()` is a no-op (the global is already set), so the router's `query()` → `rpc.GET(fn)` recorded the grant in the **first** instance while `/_server` dispatch, imported through the runner, consulted the **second**. Instrumenting the installed bundle with an instance id shows it directly:

```
[vite] (ssr) program reload
[sf-server] NEW MODULE INSTANCE bmmgi
[sf-server] provideRPC inst=bmmgi globalAlreadySet=true
[sf-server] rebind inst=bmmgi id=getFarewell-449adeb5 hadPrev=false grantDeleted=false
[sf-server] GET grant recorded inst=extqi id=getFarewell-449adeb5
[sf-server] declaresRead inst=bmmgi id=getFarewell-449adeb5 METHODS.has=false REGISTRATIONS.has=true same=false
```

The #3150 rebind revocation is not involved: the fresh instance has no prior registration to revoke (`hadPrev=false`). The devtools package is incidental too; any SSR-graph edit triggers it.

## The fix

The three maps now ride registered symbols on `globalThis` (`solid.ServerFunctionRegistrations` / `...Methods` / `...ReferenceBindings`), the same idiom as the seam. One process, one registry: a grant made through any copy's `GET` is the grant every copy's dispatch sees, and the #3129 rebind revocation runs in the same maps the re-declaration re-grants.

## Regression test

`test/server/server-functions-registry-reload.spec.tsx` mirrors the dev sequence against the built bundle: the statically imported bundle is the booted instance and fills the seam; `vi.resetModules()` plus a dynamic import yields a second instance of the same bundle. Both declare their read through `getServerFunctionRPC().GET` like the router. The test asserts the premise (the seam still hands out the first instance's `GET`) and that dispatch through the second instance answers 200 with the second function's result. It fails with the app's exact 405 before the fix.

## Verification

- Web server suite before/after: identical apart from the new spec flipping to passing (the two pre-existing failing files, `exports-server-conditions` and `ssr-stream`, are unchanged).
- `tsc` on the build config is clean; prettier passes.
- End to end: the same source-level patch applied to the reporter's app's installed rc.7 bundle, replaying the issue's steps in a browser. After the edit and the program reload, both reads answer 200 and the page stays intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
