### PR TITLE
perf(signals): projection root writes take the overlay path (#3352)

### DIFF
--- a/.changeset/projection-root-write-overlay.md
+++ b/.changeset/projection-root-write-overlay.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Projection and derived-store drafts now open as prototype overlays like plain stores, so a derive that touches one root key of a wide keyed record is O(written) instead of cloning the whole raw on every recompute (#3352: ~17 ms → ~0.02 ms per derive at 20k keys). Optimistic families, chained backings, and arrays keep the clone path. Also fixes an overlay commit bug this surfaced: a child's flatten could resurrect a slot that the parent's earlier fold in the same batch had replaced or deleted.

--- a/packages/signals/src/store/next/store.ts
+++ b/packages/signals/src/store/next/store.ts
@@ -497,13 +497,20 @@ function ensurePB(target: StoreNextTarget): Record<PropertyKey, any> {
   }
   if (activeTransition !== null) foldBatches.set(target, activeTransition);
   if (pb === null) {
-    // Prototype-chain overlay (#3044): plain-data non-array containers
-    // outside projection/optimistic families open drafts in O(1) — own keys
-    // are the writes, reads fall through to committed. Everything else
-    // (arrays: splice/length semantics; families: seeding/revert machinery;
-    // accessor containers: live getters) keeps the descriptor clone.
+    // Prototype-chain overlay (#3044): plain-data non-array containers open
+    // drafts in O(1) — own keys are the writes, reads fall through to
+    // committed. Projection and derived-store families take it too (#3352:
+    // a derive touching one root key of a wide keyed record paid an
+    // O(keys) clone per recompute). Everything else keeps the descriptor
+    // clone: arrays (splice/length semantics), OPTIMISTIC families (the
+    // view-seeding below writes and deletes on the draft container, and the
+    // tentative discard/truth-park hand whole backings around), chained
+    // backings (the committed layer is another store's proxy — an overlay
+    // would route every read-through into its traps), accessor containers
+    // (live getters).
     if (
-      target.fam === null &&
+      !target.fam?.opt &&
+      !target.ch &&
       !Array.isArray(target.v) &&
       (target.sc ? !target.a : scanAccessorsOnce(target))
     ) {
@@ -707,7 +714,14 @@ function privatizeCommitted(target: StoreNextTarget): void {
   if (target.u) {
     privatizeCommitted(target.u);
     devAssertNeverUserMutation(target.u.v);
-    target.u.v[parentSlotKey(target, before)] = target.v;
+    // CAS, same as drainFolds' path copy: re-point the parent slot only
+    // while it still holds the raw we cloned. A parent that folded EARLIER
+    // in this drain may have replaced or deleted this slot (the same batch
+    // wrote the child and then `parent.row = fresh` / `parent.length = 0`)
+    // — an unconditional write resurrected the dropped child over it.
+    const pv = target.u.v;
+    const slot = parentSlotKey(target, before);
+    if (pv[slot] === before) pv[slot] = target.v;
   }
 }
 
@@ -725,6 +739,25 @@ function parentSlotKey(target: StoreNextTarget, expected: unknown): PropertyKey 
   if (at === -1) return pk;
   target.pk = at;
   return at;
+}
+
+/** Overlay commit (#3044): apply the batch's writes onto an OWNED committed
+ * backing in place — O(written), not O(container). Unowned backings
+ * privatize first (clone once, parents re-slotted) — the never-mutate-user-
+ * data contract holds. Shared by the deferred fold (drainFolds) and the
+ * projection landing's immediate commit (notifyWrites). */
+function flattenOverlay(t: StoreNextTarget, pb: Record<PropertyKey, any>): void {
+  privatizeCommitted(t);
+  const v = t.v;
+  for (const key of Reflect.ownKeys(pb)) copyOwn(v, pb, key);
+  if (t.del !== null) {
+    for (const key of t.del) delete (v as any)[key];
+    t.del = null;
+  }
+  (t.fam?.map ?? storeNextLookup).delete(pb);
+  t.pb = null;
+  t.ovl = false;
+  t.wk = null; // written-keys window closes with the commit
 }
 
 function drainFolds(): void {
@@ -782,24 +815,11 @@ function drainFolds(): void {
         continue;
       }
       if (t.ovl) {
-        // Overlay flatten (#3044): apply this batch's writes onto an OWNED
-        // committed backing in place — O(written), not O(container). The
-        // backing keeps its identity, so the `t.v === old` gate below skips
-        // path copying (the parent slot already points here) and the
-        // adopted-notify (setter notifications happened at write time).
-        // Unowned backings privatize first (clone once, parents re-slotted)
-        // — the never-mutate-user-data contract holds.
-        privatizeCommitted(t);
-        const v = t.v;
-        for (const key of Reflect.ownKeys(pb)) copyOwn(v, pb, key);
-        if (t.del !== null) {
-          for (const key of t.del) delete (v as any)[key];
-          t.del = null;
-        }
-        (t.fam?.map ?? storeNextLookup).delete(pb);
-        t.pb = null;
-        t.ovl = false;
-        t.wk = null; // written-keys window closes with the fold commit
+        // Overlay flatten (#3044): the backing keeps its identity, so the
+        // `t.v === old` gate below skips path copying (the parent slot
+        // already points here) and the adopted-notify (setter notifications
+        // happened at write time).
+        flattenOverlay(t, pb);
       } else if (t.v !== old) {
         // Privatized mid-batch (#3271): an earlier fold in this drain
         // path-copied THROUGH this target — privatizeCommitted cloned the
@@ -1112,6 +1132,10 @@ function notifyWrites(t: StoreNextTarget): void {
     // Landed truth (post-await write-override): immediately visible to every
     // reader — any staged held view is superseded.
     if (t.ht !== null) t.ht = t.hv = null;
+    // Overlay landing (#3352): flatten in place — identity-stable, and
+    // privatizeCommitted re-slots the parent itself when it has to clone an
+    // unowned seed, so no path copy is needed.
+    if (t.ovl) return flattenOverlay(t, pb);
     const oldBacking = t.v;
     t.pb = null;
     t.v = pb;

--- a/packages/signals/src/store/next/target.ts
+++ b/packages/signals/src/store/next/target.ts
@@ -112,7 +112,9 @@ export interface StoreNextTarget {
    * (`Object.create(v)` — own keys are this batch's writes, everything else
    * reads through). O(written) per flush instead of O(container) clones
    * (#3044); commit flattens own keys onto an owned committed backing in
-   * place. Only plain-data non-array non-family containers qualify;
+   * place. Plain-data non-array containers qualify, including projection
+   * and derived-store families (#3352); optimistic families, chained
+   * backings, and accessor containers keep the descriptor clone.
    * `materializePB` downgrades to the clone path when a consumer needs a
    * real container (reconcile, draft escape). */
   ovl: boolean;

--- a/packages/signals/tests/store/overlay.test.ts
+++ b/packages/signals/tests/store/overlay.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { createEffect, createRoot, createStore, flush, snapshot } from "../../src/index.js";
+import {
+  createEffect,
+  createRoot,
+  createStore,
+  deep,
+  flush,
+  snapshot,
+  untrack
+} from "../../src/index.js";
 
 /**
  * Prototype-overlay pending backings (#3044): plain-data object drafts open
@@ -183,5 +191,41 @@ describe("overlay pending backings (#3044)", () => {
     flush();
     expect(reads).toEqual([1, 7]);
     expect(keys).toBe(1);
+  });
+
+  // The overlay flatten privatizes the child's committed backing and
+  // re-slots it into the parent. When the PARENT folded earlier in the same
+  // drain (queued first) and that batch also replaced or deleted the child's
+  // slot, the re-slot must not write over the parent's fold — it resurrected
+  // the dropped child (found via the #3352 derived-store variant).
+  it("child flatten does not resurrect a slot the parent's fold replaced", () => {
+    const [store, setStore] = createStore<{ x: number; row: { id: number; selected: boolean } }>({
+      x: 0,
+      row: { id: 1, selected: true }
+    });
+    createRoot(() => untrack(() => deep(store)));
+    setStore(s => {
+      s.x = 1; // parent queued first
+      s.row.selected = false; // child overlay
+      s.row = { id: 2, selected: true }; // slot replaced at the parent
+    });
+    flush();
+    expect(snapshot(store)).toEqual({ x: 1, row: { id: 2, selected: true } });
+  });
+
+  it("child flatten does not resurrect a slot the parent's fold deleted", () => {
+    const [store, setStore] = createStore<{ x: number; row?: { id: number; selected: boolean } }>({
+      x: 0,
+      row: { id: 1, selected: true }
+    });
+    createRoot(() => untrack(() => deep(store)));
+    setStore(s => {
+      s.x = 1;
+      s.row!.selected = false;
+      delete s.row;
+    });
+    flush();
+    expect(snapshot(store)).toEqual({ x: 1 });
+    expect("row" in store).toBe(false);
   });
 });

--- a/packages/signals/tests/store/projection-root-overlay.test.ts
+++ b/packages/signals/tests/store/projection-root-overlay.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createEffect,
+  createProjection,
+  createRoot,
+  createSignal,
+  createStore,
+  flush
+} from "../../src/index.js";
+
+/**
+ * Projection drafts open as prototype overlays (#3352): a derive that
+ * touches ONE root key of a large keyed record must not clone the whole raw
+ * on its first write. The #3044 overlay was scoped to plain stores; this
+ * pins that non-optimistic families (projections, derived stores) take the
+ * same O(written) path, and that the paths a family adds on top — the
+ * write-override immediate commit, chained seeds, held views — still hold.
+ *
+ * The complexity guard is deterministic, not timed: `cloneRaw` is the only
+ * store code that calls `Object.getOwnPropertyDescriptors`, so a spy on it
+ * counts container clones exactly. One clone is legitimate per lifetime —
+ * privatizing the user's seed at the first fold (never-mutate-user-data).
+ */
+const KEYS = 2000;
+const seed = () => Object.fromEntries(Array.from({ length: KEYS }, (_, i) => [`k${i}`, { n: i }]));
+
+const clones = () => vi.spyOn(Object, "getOwnPropertyDescriptors");
+/** Clones of a store container (vitest's own matchers scan descriptors of
+ * their internal state too — filter by a key only our records carry). */
+const recordClones = (spy: ReturnType<typeof clones>, probe: string) =>
+  spy.mock.calls.filter(([o]) => o !== null && typeof o === "object" && probe in o).length;
+afterEach(() => vi.restoreAllMocks());
+
+describe("projection root writes are O(written) (#3352)", () => {
+  it("a derive deleting + re-adding one root key does not clone the record", () => {
+    const [tick, setTick] = createSignal(0);
+    const proj = createRoot(() =>
+      createProjection<Record<string, { n: number }>>(
+        draft => {
+          const i = tick();
+          delete draft[`k${i}`];
+          draft[`k${i}`] = { n: -1 - i };
+        },
+        seed(),
+        { key: null }
+      )
+    );
+    void proj.k0;
+    flush();
+    expect(proj.k0).toEqual({ n: -1 });
+
+    const spy = clones();
+    for (let i = 1; i <= 5; i++) {
+      setTick(i);
+      flush();
+      expect(proj[`k${i}`]).toEqual({ n: -1 - i });
+      expect(proj[`k${i - 1}`]).toEqual({ n: -i });
+    }
+    expect(recordClones(spy, "k0")).toBe(0);
+    expect(Object.keys(proj)).toHaveLength(KEYS);
+    expect(proj.k1999).toEqual({ n: 1999 });
+  });
+
+  it("root deletes in a derive read as absent everywhere and notify", () => {
+    const [gone, setGone] = createSignal<string | null>(null);
+    const seenB: unknown[] = [];
+    const seenKeys: string[][] = [];
+    const proj = createRoot(() => {
+      const proj = createProjection<Record<string, { n: number } | undefined>>(
+        draft => {
+          const g = gone();
+          if (g !== null) {
+            delete draft[g];
+            expect(g in draft).toBe(false);
+            expect(draft[g]).toBeUndefined();
+            expect(Object.keys(draft)).not.toContain(g);
+          }
+        },
+        { a: { n: 1 }, b: { n: 2 }, c: { n: 3 } },
+        { key: null }
+      );
+      createEffect(
+        () => proj.b,
+        v => {
+          seenB.push(v);
+        }
+      );
+      createEffect(
+        () => Object.keys(proj),
+        v => {
+          seenKeys.push(v);
+        }
+      );
+      return proj;
+    });
+    flush();
+    expect(seenB).toEqual([{ n: 2 }]);
+    expect(seenKeys).toEqual([["a", "b", "c"]]);
+
+    const spy = clones();
+    setGone("b");
+    flush();
+    // Exactly the one-time seed privatization (the first derive wrote nothing,
+    // so no fold had cloned the user's object yet) — not a per-derive clone.
+    expect(recordClones(spy, "a")).toBe(1);
+    expect("b" in proj).toBe(false);
+    expect(proj.b).toBeUndefined();
+    expect(Object.keys(proj)).toEqual(["a", "c"]);
+    expect(Object.getOwnPropertyDescriptor(proj, "b")).toBeUndefined();
+    expect(seenB).toEqual([{ n: 2 }, undefined]);
+    expect(seenKeys).toEqual([
+      ["a", "b", "c"],
+      ["a", "c"]
+    ]);
+
+    // Now owned: the next derive's root delete opens an overlay, no clone.
+    setGone("c");
+    flush();
+    expect(recordClones(spy, "a")).toBe(1);
+    expect(Object.keys(proj)).toEqual(["a"]);
+    expect(seenKeys).toHaveLength(3);
+  });
+
+  it("derived store setter root writes do not clone the record", () => {
+    const [store, setStore] = createRoot(() =>
+      createStore<Record<string, { n: number }>>(() => {}, seed(), { key: null })
+    );
+    void store.k0;
+    flush();
+    setStore(d => {
+      d.k0 = { n: -1 };
+    });
+    flush(); // first fold privatizes the seed (the one legitimate clone)
+    expect(store.k0).toEqual({ n: -1 });
+
+    const spy = clones();
+    for (let i = 1; i <= 5; i++) {
+      setStore(d => {
+        delete d[`k${i}`];
+        d[`k${i}`] = { n: -1 - i };
+      });
+      flush();
+      expect(store[`k${i}`]).toEqual({ n: -1 - i });
+    }
+    expect(recordClones(spy, "k0")).toBe(0);
+    expect(Object.keys(store)).toHaveLength(KEYS);
+  });
+
+  it("post-await landings on a root key commit in place without cloning", async () => {
+    let resolve!: (v: number) => void;
+    const [tick, setTick] = createSignal(1);
+    const proj = createRoot(() =>
+      createProjection<Record<string, { n: number } | undefined>>(
+        async draft => {
+          const i = tick();
+          const n = await new Promise<number>(r => (resolve = r));
+          delete draft.k0;
+          draft.k0 = { n };
+          draft[`k${i}`] = { n: -n };
+        },
+        seed(),
+        { key: null }
+      )
+    );
+    flush();
+    resolve(100);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(proj.k0).toEqual({ n: 100 });
+    expect(proj.k1).toEqual({ n: -100 });
+    expect(proj.k2).toEqual({ n: 2 });
+    flush();
+
+    const spy = clones();
+    setTick(7);
+    flush();
+    resolve(200);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(proj.k0).toEqual({ n: 200 });
+    expect(proj.k7).toEqual({ n: -200 });
+    expect(recordClones(spy, "k0")).toBe(0);
+    flush();
+    expect(proj.k0).toEqual({ n: 200 });
+    expect(proj.k7).toEqual({ n: -200 });
+    expect(Object.keys(proj)).toHaveLength(KEYS);
+  });
+
+  it("a projection seeded with another store (chained backing) keeps deriving", () => {
+    const source = { a: 1, b: 2 };
+    const [extra, setExtra] = createSignal(10);
+    const { src, setSrc, proj } = createRoot(() => {
+      const [src, setSrc] = createStore<Record<string, number>>(source);
+      const proj = createProjection<Record<string, number>>(
+        draft => {
+          draft.c = extra();
+          delete draft.b;
+        },
+        src as any,
+        { key: null }
+      );
+      return { src, setSrc, proj };
+    });
+    void proj.a;
+    flush();
+    expect(proj.a).toBe(1);
+    expect(proj.c).toBe(10);
+    expect("b" in proj).toBe(false);
+    // The derive never writes the source family.
+    expect(src.c).toBeUndefined();
+    expect(src.b).toBe(2);
+    expect(source).toEqual({ a: 1, b: 2 });
+
+    setExtra(20);
+    flush();
+    expect(proj.c).toBe(20);
+    expect("b" in proj).toBe(false);
+    setSrc(s => {
+      s.a = 5;
+    });
+    flush();
+    expect(src.a).toBe(5);
+    expect(source).toEqual({ a: 1, b: 2 });
+    expect(src.c).toBeUndefined();
+  });
+
+  it("the seed object is never mutated", () => {
+    const s = seed();
+    const [tick, setTick] = createSignal(0);
+    const proj = createRoot(() =>
+      createProjection<Record<string, { n: number } | undefined>>(
+        draft => {
+          const i = tick();
+          draft[`k${i}`] = { n: -1 - i };
+          delete draft.k1999;
+        },
+        s,
+        { key: null }
+      )
+    );
+    void proj.k0;
+    flush();
+    setTick(1);
+    flush();
+    expect(proj.k1).toEqual({ n: -2 });
+    expect("k1999" in proj).toBe(false);
+    expect(s.k0).toEqual({ n: 0 });
+    expect(s.k1).toEqual({ n: 1 });
+    expect(s.k1999).toEqual({ n: 1999 });
+  });
+});

--- a/packages/signals/tests/store/projection-root-write.bench.ts
+++ b/packages/signals/tests/store/projection-root-write.bench.ts
@@ -1,0 +1,78 @@
+// Projection root-write micro-bench (#3352 repro shape): a derive over a
+// wide keyed record that touches ONE root key per recompute. Before the
+// overlay path covered families, every recompute's first root-level write
+// cloned the whole raw (O(keys) — ~17ms per derive at 20k keys); the plain
+// store doing the identical root delete + set was already O(1) via the
+// #3044 prototype overlay. Guard the parity: the projection derive and the
+// store setter should sit at the same per-commit floor, and the nested
+// write (a small target — always cheap) is the reference.
+import { bench, describe } from "vitest";
+import { createProjection, createRoot, createSignal, createStore, flush } from "../../src/index.js";
+
+const KEYS = 20_000;
+const seed = () => Object.fromEntries(Array.from({ length: KEYS }, (_, i) => [`k${i}`, { n: i }]));
+
+describe(`one root key per commit, ${KEYS}-key record`, () => {
+  // Fixtures are built once and reused: the shape is a long-lived record
+  // (the reporter's model), so the steady state IS the measurement — the
+  // one-time seed privatization is warmed out in setup.
+  let tick = 0;
+  let bump!: (n: number) => void;
+  let bumpNested!: (n: number) => void;
+  let setStore!: (fn: (d: Record<string, { n: number }>) => void) => void;
+  createRoot(() => {
+    const [t, setT] = createSignal(0, { ownedWrite: true });
+    const proj = createProjection<Record<string, { n: number }>>(
+      draft => {
+        const i = t() % KEYS;
+        delete draft[`k${i}`];
+        draft[`k${i}`] = { n: -i };
+      },
+      seed(),
+      { key: null }
+    );
+    void proj.k0;
+    flush();
+    bump = setT;
+
+    const [t2, setT2] = createSignal(0, { ownedWrite: true });
+    const nested = createProjection<Record<string, { n: number }>>(
+      draft => {
+        const i = t2() % KEYS;
+        draft[`k${i}`].n = -i;
+      },
+      seed(),
+      { key: null }
+    );
+    void nested.k0;
+    flush();
+    bumpNested = setT2;
+
+    const [store, set] = createStore<Record<string, { n: number }>>(seed());
+    void store.k0;
+    set(d => {
+      d.k0 = { n: -1 };
+    });
+    flush();
+    setStore = set;
+  });
+
+  bench("projection derive: delete + set one ROOT key (#3352)", () => {
+    bump(++tick);
+    flush();
+  });
+
+  bench("projection derive: write one NESTED field (reference)", () => {
+    bumpNested(++tick);
+    flush();
+  });
+
+  bench("createStore setter: delete + set one root key (#3044 overlay)", () => {
+    const i = ++tick % KEYS;
+    setStore(d => {
+      delete d[`k${i}`];
+      d[`k${i}`] = { n: -i };
+    });
+    flush();
+  });
+});

--- a/scripts/size/.size-limit.js
+++ b/scripts/size/.size-limit.js
@@ -339,7 +339,15 @@ module.exports = [
     // snapshot's wrapper redirect below chained families, and the ownKeys /
     // getOwnPropertyDescriptor trap bodies extracted into visibleKeys /
     // visibleDescriptor so the deep() walk shares them.
-    limit: "14.70 KB",
+    // Projection root writes on the overlay path (#3352, 2026-09-10): 14.70 ->
+    // 14.75 KB, measured at 14.696 (was 14.654; brotli layout swung equivalent
+    // variants 14.658–14.700). ensurePB's overlay
+    // eligibility widens to non-optimistic families (chained backings stay on
+    // the clone), the overlay flatten is a shared helper the write-override
+    // landing now calls instead of swapping the backing, and privatizeCommitted
+    // CASes the parent slot (a pre-existing overlay bug: a child flatten
+    // resurrected a slot the parent's earlier fold had replaced or deleted).
+    limit: "14.75 KB",
     modifyEsbuildConfig
   },
   {


### PR DESCRIPTION
Fixes #3352.

## What

A `createProjection` (or derived `createStore(fn, seed)`) derive that touched one root-level key of a wide keyed record cloned the whole raw on its first write of every recompute (`ensurePB` → `cloneRaw`, O(keys)). The #3044 prototype-overlay fix that made plain stores O(written) explicitly carved out families. This widens overlay eligibility to non-optimistic families:

- `ensurePB`: `fam === null` → `!fam?.opt && !ch`. Optimistic families stay on the clone (view-seeding writes/deletes on the draft container; truth-park / tentative-discard hand whole backings around). Chained backings stay on the clone (an overlay over another store's proxy would route every read-through into its traps). Arrays and accessor containers unchanged.
- The overlay flatten is extracted into `flattenOverlay()`; the post-await write-override landing in `notifyWrites` now flattens in place instead of installing `pb` as the committed backing.

Reporter's repro, prod build, 20k keys: root delete+set per derive **17.57 ms → 0.02 ms** median; nested-field and plain-store cases unchanged.

## Pre-existing bug surfaced

Two existing derived-store tests failed and led to a real #3044 bug that reproduces on plain stores on `next` today:

```ts
setStore(s => { s.x = 1; s.row.selected = false; s.row = { id: 2 } });
// committed row = { id: 1, selected: false } — the replacement was lost
```

When the parent folds first in a drain and the same batch replaced/deleted the child's slot, the child's overlay flatten went through `privatizeCommitted`, whose parent re-slot was unconditional and wrote the dropped child back over the parent's fold. It now CASes the slot the way `drainFolds`' path copy already does. Two regression tests in `overlay.test.ts` (both fail on the original source).

## Tests / bench

- `tests/store/projection-root-overlay.test.ts`: deterministic clone counts (spy on `Object.getOwnPropertyDescriptors`, which only `cloneRaw` calls on store containers) for the sync derive, root deletes, derived-store setter, and the post-await landing; chained seed still derives; seed never mutated.
- `tests/store/projection-root-write.bench.ts`: the #3352 shape at 20k keys next to the plain-store setter (dev tier: 76 ms → 0.021 ms per derive).

## Verification

- signals 151 files / 1690 tests green (dev tier); prod-tier store failures identical to baseline (dev-only assertions).
- solid-js and web suites green.
- Size gate: `signals: + createStore` 14.654 → 14.696 KB (cap 14.70 → 14.75, note in `.size-limit.js`); other scenarios within existing headroom.

Made with [Cursor](https://cursor.com)