### PR TITLE
fix(signals): release projection leaf nodes when their readers let go (#3351)

### DIFF
--- a/.changeset/projection-leaf-release.md
+++ b/.changeset/projection-leaf-release.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Projection leaf nodes are released when their readers let go (#3351). Every node materialized under a projection or derived store is linked into the projection computed's firewall child chain; the chain was append-only, so a long-lived keyed record retained one node — and the last value it served — per leaf ever read, until the projection itself was disposed. The chain is now doubly linked and the unobserved sweep unlinks the node in O(1), so deleted rows and their nested objects are collectable while the projection stays live, and the per-mark child walk covers live leaves only.

--- a/packages/signals/src/core/core.ts
+++ b/packages/signals/src/core/core.ts
@@ -1001,6 +1001,7 @@ export function signal<T>(
         _time: clock,
         _firewall: firewall,
         _nextChild: firewall?._x?._child || null,
+        _prevChild: null,
         _pendingValue: NOT_PENDING,
         _transition: null,
         _notifiedAt: -1,
@@ -1019,6 +1020,7 @@ export function signal<T>(
         _time: clock,
         _firewall: firewall,
         _nextChild: firewall?._x?._child || null,
+        _prevChild: null,
         _pendingValue: NOT_PENDING,
         // Signal-literal diet (§12e): NO _time/_fn/_statusFlags slots. Stores
         // materialize one signal per touched leaf, so signal bytes are store
@@ -1031,10 +1033,7 @@ export function signal<T>(
       };
   if (__DEV__) (s as any)._internal = !!firewall;
   if (options?.unobserved) ext(s as any)._unobserved = options.unobserved;
-  if (firewall) {
-    ext(firewall)._child = s as FirewallSignal<unknown>;
-    firewall._config |= CONFIG_FW_CHILDREN;
-  }
+  if (firewall) linkFirewallChild(firewall, s as FirewallSignal<unknown>);
   if (
     snapshotCaptureActive &&
     !(s._config & CONFIG_NO_SNAPSHOT) &&
@@ -1067,6 +1066,35 @@ export function setSlotUnobserved(fn: (node: Signal<any>) => void): void {
   slotUnobservedHook = fn;
 }
 
+/** Push a new node onto its firewall's child chain (the literal already
+ * points `_nextChild` at the old head). Doubly linked so a released leaf
+ * unlinks in O(1) — the chain is walked per mark of the projection and
+ * would otherwise grow by one node per leaf ever read (#3351). */
+function linkFirewallChild(firewall: Computed<unknown>, s: FirewallSignal<unknown>): void {
+  const head = s._nextChild;
+  if (head !== null) head._prevChild = s;
+  ext(firewall)._child = s;
+  firewall._config |= CONFIG_FW_CHILDREN;
+}
+
+/** Release a firewall child the store no longer addresses (unobserved sweep
+ * dropped it from its target's cache): unlink it from the chain so the
+ * projection stops retaining it and its last value. The node keeps its own
+ * `_nextChild` so a walk that is mid-chain on it still terminates. Nodes in
+ * `_companionChildren` stay there — companions are permanent by contract
+ * and snap through that set, not the chain. */
+export function unlinkFirewallChild(node: Signal<any>): void {
+  const n = node as FirewallSignal<any>;
+  const fw = n._firewall;
+  if (!fw) return;
+  const prev = n._prevChild;
+  const next = n._nextChild;
+  if (prev !== null) prev._nextChild = next;
+  else if (fw._x!._child === n) fw._x!._child = next;
+  if (next !== null) next._prevChild = prev;
+  n._prevChild = null;
+}
+
 export function slotSignal<T>(
   v: T,
   equals: (a: T, b: T) => boolean,
@@ -1087,6 +1115,7 @@ export function slotSignal<T>(
         _time: clock,
         _firewall: firewall,
         _nextChild: firewall?._x?._child || null,
+        _prevChild: null,
         _pendingValue: NOT_PENDING,
         _transition: null,
         _notifiedAt: -1,
@@ -1107,6 +1136,7 @@ export function slotSignal<T>(
         _time: clock,
         _firewall: firewall,
         _nextChild: firewall?._x?._child || null,
+        _prevChild: null,
         _pendingValue: NOT_PENDING,
         _transition: null,
         _notifiedAt: -1,
@@ -1120,10 +1150,7 @@ export function slotSignal<T>(
         pxv: undefined
       };
   if (__DEV__) (s as any)._internal = !!firewall;
-  if (firewall) {
-    ext(firewall)._child = s as unknown as FirewallSignal<unknown>;
-    firewall._config |= CONFIG_FW_CHILDREN;
-  }
+  if (firewall) linkFirewallChild(firewall, s as unknown as FirewallSignal<unknown>);
   if (snapshotCaptureActive && !((firewall?._statusFlags ?? 0) & STATUS_PENDING)) {
     ext(s as any)._snapshotValue = v === undefined ? NO_SNAPSHOT : v;
     (s as any)._config |= CONFIG_HAS_SNAPSHOT;

--- a/packages/signals/src/core/types.ts
+++ b/packages/signals/src/core/types.ts
@@ -152,7 +152,10 @@ export interface RawSignal<T> {
 
 export interface FirewallSignal<T> extends RawSignal<T> {
   _firewall: Computed<any>;
+  /** Doubly-linked child chain on the firewall's extension (`_x._child` is
+   * the head): released leaves unlink in O(1) (#3351). */
   _nextChild: FirewallSignal<unknown> | null;
+  _prevChild: FirewallSignal<unknown> | null;
 }
 
 export type Signal<T> = RawSignal<T> | FirewallSignal<T>;

--- a/packages/signals/src/store/next/store.ts
+++ b/packages/signals/src/store/next/store.ts
@@ -44,6 +44,7 @@ import {
   setSlotUnobserved,
   signal,
   slotSignal,
+  unlinkFirewallChild,
   untrack,
   ext
 } from "../../core/core.js";
@@ -245,6 +246,10 @@ setSlotUnobserved((node: any): void => {
   if (t.n && t.n[key as any] === node) {
     delete t.n[key as any];
     t.nc--;
+    // Projection leaves also leave the firewall child chain (#3351): a
+    // dropped node is unreachable through the store — a fresh read makes a
+    // fresh node — so the chain would only retain it and its last value.
+    unlinkFirewallChild(node);
   }
 });
 
@@ -325,7 +330,10 @@ export function getHasNode(
         equals: isEqual,
         unobserved() {
           if ((created as any)._x?._affectsCount) return;
-          if (target.h && target.h[key] === created) delete target.h[key];
+          if (target.h && target.h[key] === created) {
+            delete target.h[key];
+            unlinkFirewallChild(created);
+          }
         }
       },
       (target.fam?.node as any) ?? undefined
@@ -350,7 +358,10 @@ export function getKeySetNode(target: StoreNextTarget): Signal<number> {
       {
         equals: false,
         unobserved() {
-          if (target.k === created) target.k = null;
+          if (target.k === created) {
+            target.k = null;
+            unlinkFirewallChild(created);
+          }
         }
       },
       (target.fam?.node as any) ?? undefined
@@ -374,7 +385,10 @@ function getDeepNode(target: StoreNextTarget): Signal<number> {
       {
         equals: false,
         unobserved() {
-          if (target.dk === created) target.dk = null;
+          if (target.dk === created) {
+            target.dk = null;
+            unlinkFirewallChild(created);
+          }
         }
       },
       (target.fam?.node as any) ?? undefined

--- a/packages/signals/tests/gc.test.ts
+++ b/packages/signals/tests/gc.test.ts
@@ -1,10 +1,13 @@
 import {
   createEffect,
   createMemo,
+  createProjection,
+  createRenderEffect,
   createRoot,
   createSignal,
   flush,
-  getOwner
+  getOwner,
+  mapArray
 } from "../src/index.js";
 
 function gc() {
@@ -89,6 +92,61 @@ if (global.gc) {
 
     await gc();
     expect(ref.deref()).toBeUndefined();
+  });
+
+  // #3351: a live keyed projection must not retain deleted rows through its
+  // leaf nodes. Deleting a key drops the readers, the readers drop the
+  // nodes, and the nodes leave the projection's firewall child chain — so
+  // the row objects (and the nested objects nodes last served) are collectable
+  // while the projection itself stays alive.
+  it("keyed projection releases deleted rows while it stays live", async () => {
+    type Row = { id: string; pos: { x: number } };
+    const N = 200;
+    const [rows, setRows] = createSignal<Row[]>([]);
+    const refs: WeakRef<object>[] = [];
+    const { record, dispose } = createRoot(dispose => {
+      const record = createProjection<Record<string, Row>>(
+        draft => {
+          const seen = new Set<string>();
+          for (const r of rows()) {
+            seen.add(r.id);
+            if (draft[r.id] !== r) draft[r.id] = r;
+          }
+          for (const k of Object.keys(draft)) if (!seen.has(k)) delete draft[k];
+        },
+        {},
+        { key: null }
+      );
+      const ids = createMemo(() => Object.keys(record));
+      createMemo(
+        mapArray(ids, id => {
+          createRenderEffect(
+            () => record[id]?.pos.x,
+            () => {}
+          );
+          return id;
+        })
+      )();
+      return { record, dispose };
+    });
+    flush();
+    setRows(
+      Array.from({ length: N }, (_, i) => {
+        const r: Row = { id: "n" + i, pos: { x: i } };
+        refs.push(new WeakRef(r), new WeakRef(r.pos));
+        return r;
+      })
+    );
+    flush();
+    await gc();
+    expect(refs.filter(r => r.deref() === undefined)).toHaveLength(0);
+
+    setRows([]);
+    flush();
+    await gc();
+    expect(Object.keys(record)).toEqual([]);
+    expect(refs.filter(r => r.deref() !== undefined)).toHaveLength(0);
+    dispose();
   });
 } else {
   it("", () => {});

--- a/packages/signals/tests/store/projection-slot-release.test.ts
+++ b/packages/signals/tests/store/projection-slot-release.test.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it } from "vitest";
+import {
+  $TARGET,
+  createEffect,
+  createMemo,
+  createProjection,
+  createRenderEffect,
+  createRoot,
+  createSignal,
+  createStore,
+  flush,
+  mapArray
+} from "../../src/index.js";
+
+/**
+ * Projection leaf nodes are released when their readers let go (#3351).
+ *
+ * Every node materialized under a projection family (value, presence,
+ * key-set, deep witness) is linked into the projection computed's firewall
+ * child chain so a mark on the derive reaches their subscribers. The chain
+ * was append-only: the unobserved sweep dropped a node from the target's
+ * cache but left it linked, so a long-lived keyed record grew by one node
+ * per leaf ever read — every deleted row's slots (and the last raw they held)
+ * stayed reachable until the projection itself was disposed. The rc.1 store
+ * rewrite lost the disposal the legacy store had for exactly this shape
+ * (the js-framework-benchmark keyed rows). These tests pin it structurally;
+ * gc.test.ts pins the heap side.
+ */
+
+type Row = { id: string; pos: { x: number; y: number } };
+const row = (i: number): Row => ({ id: "n" + i, pos: { x: i, y: 0 } });
+
+/** Nodes linked into a projection's firewall child chain. */
+function chain(proj: any): any[] {
+  const out: any[] = [];
+  for (let c = proj[$TARGET].fam.node._x?._child ?? null; c !== null; c = c._nextChild) out.push(c);
+  return out;
+}
+const chainLength = (proj: any) => chain(proj).length;
+/** Cached value/presence nodes on a target. */
+const nodeKeys = (target: any) => (target.n ? Object.keys(target.n) : []);
+const hasKeys = (target: any) => (target.h ? Object.keys(target.h) : []);
+
+describe("projection leaf release (#3351)", () => {
+  it("a keyed record releases every slot of a deleted key once its readers let go", () => {
+    const N = 40;
+    const [rows, setRows] = createSignal<Row[]>([]);
+    const seenX: number[] = [];
+    const { record, dispose } = createRoot(dispose => {
+      const record = createProjection<Record<string, Row>>(
+        draft => {
+          const seen = new Set<string>();
+          for (const r of rows()) {
+            seen.add(r.id);
+            if (draft[r.id] !== r) draft[r.id] = r;
+          }
+          for (const k of Object.keys(draft)) if (!seen.has(k)) delete draft[k];
+        },
+        {},
+        { key: null }
+      );
+      const ids = createMemo(() => Object.keys(record));
+      // One reader per key, each touching a value node on the record, a
+      // presence node, and a nested value node on the row target.
+      createMemo(
+        mapArray(ids, id => {
+          createRenderEffect(
+            () => (id in record ? record[id]!.pos.x : -1),
+            x => {
+              seenX.push(x);
+            }
+          );
+          return id;
+        })
+      )();
+      return { record, dispose };
+    });
+    flush();
+    const baseline = chainLength(record);
+    const recordTarget = (record as any)[$TARGET];
+
+    setRows(Array.from({ length: N }, (_, i) => row(i)));
+    flush();
+    expect(seenX).toHaveLength(N);
+    expect(nodeKeys(recordTarget)).toHaveLength(N);
+    expect(hasKeys(recordTarget)).toHaveLength(N);
+    // record value node + presence node per key, plus the nested `pos` and
+    // `pos.x` nodes on each row's own target.
+    const filled = chainLength(record);
+    expect(filled).toBeGreaterThanOrEqual(baseline + 4 * N);
+
+    setRows([]);
+    flush();
+    expect(Object.keys(record)).toEqual([]);
+    // The readers were disposed with their rows: every slot they held is
+    // gone from the caches AND from the chain.
+    expect(nodeKeys(recordTarget)).toEqual([]);
+    expect(hasKeys(recordTarget)).toEqual([]);
+    expect(chainLength(record)).toBe(baseline);
+    // Nothing left in the chain points at a deleted row's objects.
+    for (const node of chain(record)) {
+      const v = node._value;
+      expect(v !== null && typeof v === "object" && "pos" in v).toBe(false);
+    }
+
+    // Refill + empty again: the chain does not ratchet across cycles.
+    setRows(Array.from({ length: N }, (_, i) => row(i + N)));
+    flush();
+    setRows([]);
+    flush();
+    expect(chainLength(record)).toBe(baseline);
+    dispose();
+  });
+
+  it("js-framework-benchmark selection: rows read selected[id]; removed rows release their slot", () => {
+    // The jsfb shape: a selection projection keyed by row id (`draft[prev]
+    // = false; draft[id] = true`), and every rendered row reads its own
+    // `selected[row.id]`. A node materializes per rendered row; when rows are
+    // removed (clear, swap, every-10th delete) their readers go away and the
+    // slots must go with them — on the legacy store this was the explicit
+    // disposal the rewrite lost. The record itself keeps its keys (they are
+    // the app's data); only the subscription nodes are what's reclaimed.
+    type Row = { id: number; label: string };
+    const [data, setData] = createSignal<Row[]>([]);
+    const [selectedId, setSelectedId] = createSignal<number | null>(null);
+    const rendered = new Map<number, boolean>();
+    const { selected, dispose } = createRoot(dispose => {
+      let prev: number | null = null;
+      const selected = createProjection<Record<number, boolean>>(
+        draft => {
+          const id = selectedId();
+          if (prev !== null) draft[prev] = false;
+          if (id !== null) draft[id] = true;
+          prev = id;
+        },
+        {},
+        { key: null }
+      );
+      createMemo(
+        mapArray(data, row => {
+          createRenderEffect(
+            () => !!selected[row.id],
+            on => {
+              rendered.set(row.id, on);
+            }
+          );
+          return row;
+        })
+      )();
+      return { selected, dispose };
+    });
+    flush();
+    const target = (selected as any)[$TARGET];
+    const baseline = chainLength(selected);
+    const make = (n: number, from = 0) =>
+      Array.from({ length: n }, (_, i) => ({ id: from + i, label: "row " + (from + i) }));
+
+    const rows = make(1000);
+    setData(rows);
+    flush();
+    expect(nodeKeys(target)).toHaveLength(1000);
+    expect(chainLength(selected)).toBe(baseline + 1000);
+
+    setSelectedId(5);
+    flush();
+    expect(rendered.get(5)).toBe(true);
+    setSelectedId(7);
+    flush();
+    expect(rendered.get(5)).toBe(false);
+    expect(rendered.get(7)).toBe(true);
+
+    // Remove every 10th row: exactly those slots go, the rest stay.
+    setData(rows.filter(r => r.id % 10 !== 0));
+    flush();
+    expect(nodeKeys(target)).toHaveLength(900);
+    expect(nodeKeys(target)).not.toContain("10");
+    expect(chainLength(selected)).toBe(baseline + 900);
+
+    // Clear: every slot released, the record keeps the app's stale keys.
+    setData([]);
+    flush();
+    expect(nodeKeys(target)).toEqual([]);
+    expect(chainLength(selected)).toBe(baseline);
+    expect(Object.keys(selected)).toEqual(["5", "7"]);
+
+    // Create 1000 fresh rows twice (jsfb "create" then "create" again — new
+    // ids each time): steady state, no growth from rows that are gone.
+    setData(make(1000, 1000));
+    flush();
+    setSelectedId(1001);
+    flush();
+    expect(rendered.get(1001)).toBe(true);
+    expect(chainLength(selected)).toBe(baseline + 1000);
+    setData(make(1000, 2000));
+    flush();
+    expect(chainLength(selected)).toBe(baseline + 1000);
+    expect(nodeKeys(target).every(k => Number(k) >= 2000)).toBe(true);
+    dispose();
+  });
+
+  it("rows projection: removed rows release their leaf nodes", () => {
+    type Bench = { id: number; label: string };
+    const [data, setData] = createSignal<Bench[]>([]);
+    const labels: string[] = [];
+    const { rows, dispose } = createRoot(dispose => {
+      const rows = createProjection<Bench[]>(draft => {
+        const next = data();
+        for (let i = 0; i < next.length; i++) if (draft[i] !== next[i]) draft[i] = next[i];
+        draft.length = next.length;
+      }, []);
+      createMemo(
+        mapArray(
+          () => rows,
+          r => {
+            createRenderEffect(
+              () => r.label,
+              l => {
+                labels.push(l);
+              }
+            );
+            return r;
+          }
+        )
+      )();
+      return { rows, dispose };
+    });
+    flush();
+    const baseline = chainLength(rows);
+
+    const make = (n: number, from = 0) =>
+      Array.from({ length: n }, (_, i) => ({ id: from + i, label: "row " + (from + i) }));
+    const all = make(100);
+    setData(all);
+    flush();
+    expect(labels).toHaveLength(100);
+    const rowTargets = all.map((_, i) => (rows[i] as any)[$TARGET]);
+    for (const t of rowTargets) expect(nodeKeys(t)).toEqual(["label"]);
+    expect(chainLength(rows)).toBeGreaterThanOrEqual(baseline + 100);
+
+    // Remove every other row (same objects — the kept rows keep their
+    // readers and their nodes), then clear.
+    setData(all.filter(r => r.id % 2 === 0));
+    flush();
+    for (const t of rowTargets) expect(nodeKeys(t)).toEqual(t.v.id % 2 === 0 ? ["label"] : []);
+    setData([]);
+    flush();
+    for (const t of rowTargets) expect(nodeKeys(t)).toEqual([]);
+    expect(chainLength(rows)).toBe(baseline);
+
+    // Replace with fresh rows: steady state, no growth from the old ones.
+    setData(make(100, 1000));
+    flush();
+    const steady = chainLength(rows);
+    setData(make(100, 2000));
+    flush();
+    expect(chainLength(rows)).toBe(steady);
+    dispose();
+  });
+
+  it("a slot still read after its key was deleted stays linked until the reader releases", () => {
+    const [gone, setGone] = createSignal(false);
+    const seen: unknown[] = [];
+    let disposeReader!: () => void;
+    const record = createRoot(() => {
+      const record = createProjection<{ a?: number; b: number }>(
+        draft => {
+          if (gone()) delete draft.a;
+          else draft.a = 1;
+        },
+        { b: 2 },
+        { key: null }
+      );
+      disposeReader = createRoot(d => {
+        createEffect(
+          () => record.a,
+          v => {
+            seen.push(v);
+          }
+        );
+        return d;
+      });
+      return record;
+    });
+    flush();
+    const target = (record as any)[$TARGET];
+    expect(nodeKeys(target)).toEqual(["a"]);
+    const linked = chainLength(record);
+
+    setGone(true);
+    flush();
+    expect(seen).toEqual([1, undefined]);
+    // The effect is still subscribed to `a`: the node is live, not leaked.
+    expect(nodeKeys(target)).toEqual(["a"]);
+    expect(chainLength(record)).toBe(linked);
+
+    disposeReader();
+    expect(nodeKeys(target)).toEqual([]);
+    expect(chainLength(record)).toBe(linked - 1);
+
+    // A fresh read materializes a fresh node — the chain does not double up.
+    createRoot(() => {
+      createEffect(
+        () => record.a,
+        () => {}
+      );
+    });
+    flush();
+    expect(nodeKeys(target)).toEqual(["a"]);
+    expect(chainLength(record)).toBe(linked);
+  });
+
+  it("presence, key-set and deep-witness nodes unlink like value nodes", () => {
+    const [tick, setTick] = createSignal(0);
+    const record = createRoot(() =>
+      createProjection<Record<string, number>>(
+        draft => {
+          draft["k" + tick()] = tick();
+        },
+        {},
+        { key: null }
+      )
+    );
+    flush();
+    const target = (record as any)[$TARGET];
+    const before = chainLength(record);
+    const dispose = createRoot(d => {
+      createEffect(
+        () => ["k0" in record, Object.keys(record).length],
+        () => {}
+      );
+      return d;
+    });
+    flush();
+    expect(hasKeys(target)).toEqual(["k0"]);
+    expect(target.k).not.toBeNull();
+    expect(chainLength(record)).toBe(before + 2);
+    dispose();
+    expect(hasKeys(target)).toEqual([]);
+    expect(target.k).toBeNull();
+    expect(chainLength(record)).toBe(before);
+    setTick(1);
+    flush();
+    expect(record.k1).toBe(1);
+  });
+
+  it("derived stores (createStore(fn, seed)) release slots the same way", () => {
+    const [src, setSrc] = createStore<Record<string, { n: number }>>({});
+    const { view, dispose } = createRoot(dispose => {
+      const [view] = createStore<Record<string, { n: number }>>(
+        draft => {
+          for (const k of Object.keys(draft)) if (!(k in src)) delete draft[k];
+          for (const k of Object.keys(src)) draft[k] = src[k];
+        },
+        {},
+        { key: null }
+      );
+      const keys = createMemo(() => Object.keys(view));
+      createMemo(
+        mapArray(keys, k => {
+          createRenderEffect(
+            () => view[k]?.n,
+            () => {}
+          );
+          return k;
+        })
+      )();
+      return { view, dispose };
+    });
+    flush();
+    const baseline = chainLength(view);
+    setSrc(s => {
+      for (let i = 0; i < 20; i++) s["k" + i] = { n: i };
+    });
+    flush();
+    expect(chainLength(view)).toBeGreaterThanOrEqual(baseline + 40);
+    setSrc(s => {
+      for (let i = 0; i < 20; i++) delete s["k" + i];
+    });
+    flush();
+    expect(Object.keys(view)).toEqual([]);
+    expect(nodeKeys((view as any)[$TARGET])).toEqual([]);
+    expect(chainLength(view)).toBe(baseline);
+    dispose();
+  });
+});

--- a/scripts/size/.size-limit.js
+++ b/scripts/size/.size-limit.js
@@ -163,7 +163,12 @@ module.exports = [
     // alternative (park the whole flush) measured +70 B but left the write
     // that caused the flush readable while its own render stayed stale.
     // Lanes are exempt by construction (they never enter the ordinary queue).
-    limit: "8.18 KB",
+    // Firewall child chain doubly linked (#3351, 2026-09-10): 8.18 -> 8.22 KB,
+    // measured at 8.181 (was 8.152). `_prevChild` on the signal literals (both
+    // tiers) plus linkFirewallChild/unlinkFirewallChild: a projection leaf the
+    // unobserved sweep drops now leaves the chain in O(1) instead of being
+    // retained (with its last value) for the projection's lifetime.
+    limit: "8.22 KB",
     modifyEsbuildConfig
   },
   {
@@ -347,7 +352,11 @@ module.exports = [
     // landing now calls instead of swapping the backing, and privatizeCommitted
     // CASes the parent slot (a pre-existing overlay bug: a child flatten
     // resurrected a slot the parent's earlier fold had replaced or deleted).
-    limit: "14.75 KB",
+    // Firewall child chain doubly linked (#3351, 2026-09-10): 14.75 -> 14.83 KB,
+    // measured at 14.776 (was 14.696). The core-floor arm plus the slot-node
+    // literal's `_prevChild` and the unlink calls in the four unobserved
+    // hooks (value, presence, key-set, deep witness).
+    limit: "14.83 KB",
     modifyEsbuildConfig
   },
   {
@@ -429,7 +438,9 @@ module.exports = [
     // measured at 10.14. Core scheduler cost; see the core-floor note.
     // Effect ownership on finalize re-entry (#3319, 2026-09-09): 10.17 KB -> 10.27 KB,
     // measured at 10.237. Core scheduler cost; see the core-floor note.
-    limit: "10.27 KB",
+    // Firewall child chain doubly linked (#3351, 2026-09-10): 10.27 -> 10.32 KB,
+    // measured at 10.272. Core cost; see the core-floor note.
+    limit: "10.32 KB",
     modifyEsbuildConfig
   },
   {
@@ -685,7 +696,10 @@ module.exports = [
     // mapArray SMALL-MOVE fast path (#3227, rebased 2026-09-10): 26.70 KB ->
     // 27.34 KB, measured at 27.29 on the rebased tree (+600 B over 26.69).
     // See the hydrating (no stores) note; same cost, every <For> scenario.
-    limit: "27.34 KB",
+    // Firewall child chain doubly linked (#3351, 2026-09-10): 27.34 -> 27.48 KB,
+    // measured at 27.430 (was 27.273; +80 B of it is the createStore arm, the
+    // rest brotli layout across the store family bundle). See the createStore note.
+    limit: "27.48 KB",
     modifyEsbuildConfig
   },
   {


### PR DESCRIPTION
Fixes #3351.

## What

Every node materialized under a projection or derived-store family (value slot, presence, key-set, deep witness) is linked into the projection computed's firewall child chain via `_nextChild`, so a mark on the derive reaches leaf subscribers. The chain was singly linked and append-only: the unobserved sweep dropped a node from its target's cache (`t.n`/`t.h`/`t.k`/`t.dk`) but never unlinked it. A long-lived keyed record therefore retained one node — and the last value it served — per leaf ever read, until the projection itself was disposed. That is Dan's case B: 12.7 of 18.9 MB retained after deleting every row.

How it regressed: the rc.1 rewrite kept the legacy store's drop-from-map disposal (which is why the caches look clean in the issue's dump) but added this second reference that never let go. The #3038 companion-walk gating and `markNode`'s `CONFIG_FW_CHILDREN` gate were both already paying for the symptom ("one node per materialized leaf, O(all leaves ever read)").

## Fix

- `FirewallSignal` gains `_prevChild`; `signal()`/`slotSignal()` link through `linkFirewallChild`, and `unlinkFirewallChild` removes a node in O(1). The dead node keeps its own `_nextChild` so a walk that is mid-chain on it still terminates. `_companionChildren` is left alone — companions are permanent by contract and snap through that set, not the chain.
- The four store unobserved hooks call `unlinkFirewallChild` when they drop the node.
- Side effect: `markNode`'s per-mark child walk now covers live leaves only.

Dan's repro, prod dist, retained after delete-all: A 1.4 → 1.1 MB, **B 12.2 → 0.4 MB**, C 0.5 → 0.1 MB (synchronous measurement; with an async gc every row, proxy, `pos`, `data` and row projection deref to `undefined`).

## Tests

`tests/store/projection-slot-release.test.ts` — structural, deterministic (chain length via `$TARGET`), all fail on `next`:
- keyed record: fill 40 / delete all / refill — chain back to baseline, no node still holds a `pos`
- **js-framework-benchmark selection map** (`draft[prev] = false; draft[id] = true`, rows read `selected[row.id]`): remove every 10th row → exactly those slots go; clear → baseline while the record keeps its keys; create fresh ids twice → no growth
- rows projection with per-row `label` readers
- a slot still read after its key was deleted stays linked until the reader releases; a fresh read is one fresh node
- presence, key-set and deep-witness nodes unlink like value nodes
- derived `createStore(fn, seed)`

`tests/gc.test.ts` — WeakRefs to 200 rows and their nested objects, all collected after delete-all while the projection is live (runs under `pnpm test:gc`; 400/400 alive on `next`).

## Size

`_prevChild` is one field on every signal literal (both tiers): core floor 8.152 → 8.181 KB, createStore 14.696 → 14.776, isPending 10.229 → 10.272, hydrating+stores 27.273 → 27.430 (brotli noise inflates that one). Four caps bumped with notes.

## Verification

signals 152 files / 1695 tests green (dev tier); prod-tier store failures identical to baseline (dev-only assertions); solid-js and web suites green; size gate green.

Note: `gc.test.ts` is not in CI (`test:gc` only) and has a pre-existing failure unrelated to this ("should gc effect lazily" never flushes). Left as is.

Made with [Cursor](https://cursor.com)