### PR TITLE
fix(web): stretch the flash key from the deployment secret

### DIFF
--- a/.changeset/flash-key-derivation.md
+++ b/.changeset/flash-key-derivation.md
@@ -1,0 +1,9 @@
+---
+"@solidjs/web": patch
+---
+
+The flash cookie key is now derived with PBKDF2 instead of a single SHA-256 hash.
+
+- Guessing a weak `secret` from a captured cookie is now 100,000 times more expensive.
+- Set `secret` to a high-entropy value of 32 bytes or more. The option docs show how to generate one.
+- Flash cookies in flight when you deploy read as no flash, the same as a secret rotation.

--- a/packages/web/server-functions/src/flash.ts
+++ b/packages/web/server-functions/src/flash.ts
@@ -58,14 +58,29 @@ function resolveSecret() {
   return configuredSecret !== undefined ? configuredSecret : globalThis.__SOLID_SECRET__;
 }
 
-// The flash key is a DOMAIN-SEPARATED derivation of the deployment secret:
-// SHA-256 over the domain string then the secret's UTF-8 bytes, imported as
-// raw AES-256-GCM key material. The digest normalizes arbitrary-length
-// secrets to the key size and keeps the secret itself out of the CryptoKey;
-// the domain prefix means a future feature deriving its own key from the
-// same secret (a different domain string) shares no key material with the
-// flash — one secret, per-purpose keys, never cross-decryptable.
+// The flash key is a DOMAIN-SEPARATED derivation of the deployment secret,
+// stretched with PBKDF2-HMAC-SHA-256 into raw AES-256-GCM key material.
+//
+// The domain string is the salt, so a future feature deriving its own key
+// from the same secret (a different domain string) shares no key material
+// with the flash: one secret, per-purpose keys, never cross-decryptable.
+// It is a fixed salt, so the iteration count is what buys the work factor,
+// not salt uniqueness.
+//
+// Stretching is the point. `secret` accepts any non-empty string, so a
+// deployment may hand this a short human-chosen value, and a single captured
+// cookie is an offline oracle for it. Under a bare digest that recovers the
+// secret at full hash speed, and recovering it means reading every flash
+// payload (the submitted form input, passwords included) and forging new
+// ones. The iterations do not make a weak secret safe, they only raise the
+// price; the `secret` option documents the entropy requirement.
 const FLASH_KEY_DOMAIN = "solid.flash.v1\0";
+
+// Capped at 100k because that is the ceiling some edge runtimes enforce on
+// PBKDF2, and a key that cannot derive there is a flash that never sends.
+// Paid once per process per secret (the derived key is cached) and only on
+// the no-JS path, so the cost never reaches an ordinary request.
+const FLASH_KEY_ITERATIONS = 100_000;
 
 let cachedSecret;
 let cachedKey;
@@ -75,10 +90,22 @@ function resolveFlashKey() {
   if (typeof secret !== "string" || secret.length === 0) return null;
   if (secret !== cachedSecret) {
     cachedSecret = secret;
+    const encoder = new TextEncoder();
     cachedKey = crypto.subtle
-      .digest("SHA-256", new TextEncoder().encode(FLASH_KEY_DOMAIN + secret))
-      .then(digest =>
-        crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, ["encrypt", "decrypt"])
+      .importKey("raw", encoder.encode(secret), "PBKDF2", false, ["deriveKey"])
+      .then(material =>
+        crypto.subtle.deriveKey(
+          {
+            name: "PBKDF2",
+            salt: encoder.encode(FLASH_KEY_DOMAIN),
+            iterations: FLASH_KEY_ITERATIONS,
+            hash: "SHA-256"
+          },
+          material,
+          { name: "AES-GCM", length: 256 },
+          false,
+          ["encrypt", "decrypt"]
+        )
       );
   }
   return cachedKey;

--- a/packages/web/server-functions/src/server.ts
+++ b/packages/web/server-functions/src/server.ts
@@ -391,10 +391,24 @@ export interface ServerFunctionsServerConfig {
    * back to the one the Solid bundler plugin injects into the server build
    * (a fresh value per build), and with neither present the outcome is
    * simply not flashed — the form post still redirects cleanly, and dev
-   * builds warn once. Any non-empty string works; rotating it (or
-   * redeploying with the plugin's value) invalidates in-flight flashes,
-   * which are 60-second one-shot cookies — the next render reads "no
-   * flash".
+   * builds warn once.
+   *
+   * Use a HIGH-ENTROPY value, 32 bytes or more, and keep it out of source
+   * control:
+   *
+   * ```sh
+   * node -e "console.log(crypto.randomBytes(32).toString('base64url'))"
+   * ```
+   *
+   * A captured cookie is an offline oracle for this value. Key derivation
+   * stretches it (PBKDF2-HMAC-SHA-256), which raises the price of a guess
+   * but does not make a guessable secret safe, and recovering it means
+   * reading every flash payload and forging new ones. A passphrase, an app
+   * name, or anything else a person would think up is not enough.
+   *
+   * Rotating it (or redeploying with the plugin's value) invalidates
+   * in-flight flashes. They are 60-second one-shot cookies, so the next
+   * render reads "no flash".
    */
   secret?: string;
 }

--- a/packages/web/test/server/server-functions-flash-key-derivation.spec.tsx
+++ b/packages/web/test/server/server-functions-flash-key-derivation.spec.tsx
@@ -84,7 +84,7 @@ async function stretchedKey(secret: string, iterations = FLASH_KEY_ITERATIONS) {
   );
 }
 
-async function opens(packed: Uint8Array, key: CryptoKey) {
+async function opens(packed: Uint8Array<ArrayBuffer>, key: CryptoKey) {
   try {
     await crypto.subtle.decrypt(
       { name: "AES-GCM", iv: packed.subarray(0, IV_BYTES) },

--- a/packages/web/test/server/server-functions-flash-key-derivation.spec.tsx
+++ b/packages/web/test/server/server-functions-flash-key-derivation.spec.tsx
@@ -1,0 +1,154 @@
+/**
+ * THE FLASH KEY IS STRETCHED, NOT JUST HASHED.
+ *
+ * `secret` accepts any non-empty string, so a deployment can hand the runtime
+ * a short human-chosen value. A captured cookie is an offline oracle for that
+ * value: guess a secret, derive the key, try to decrypt. Under a bare digest
+ * each guess costs one hash, so a guessable secret falls quickly, and
+ * recovering it means reading every flash payload (the submitted form input,
+ * passwords included) and forging new ones.
+ *
+ * Derivation is PBKDF2-HMAC-SHA-256 over the secret, salted with the domain
+ * string, so each guess costs the iteration count instead. That does not make
+ * a weak secret safe. It raises the price, and the `secret` option documents
+ * the entropy requirement.
+ *
+ * These tests pin the derivation by attacking the cookie the public API
+ * produces: the bare digest must NOT open it, and PBKDF2 with the documented
+ * parameters must. Weaken either half and one of them fails.
+ *
+ * Like the other server-function specs, these run against the built bundles.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  FLASH_COOKIE,
+  decodeFlashCookie,
+  encodeFlashCookie
+} from "@solidjs/web/server-functions/server";
+
+// Must match the runtime's own constants. They are deliberately duplicated
+// here: a test that imported them could not catch a change to them.
+const FLASH_KEY_DOMAIN = "solid.flash.v1\0";
+const FLASH_KEY_ITERATIONS = 100_000;
+const IV_BYTES = 12;
+
+const SECRET = "spec-deployment-key";
+
+function withKey(key = SECRET) {
+  (globalThis as any).__SOLID_SECRET__ = key;
+}
+
+afterEach(() => {
+  delete (globalThis as any).__SOLID_SECRET__;
+});
+
+// The wire value out of a Set-Cookie, minus the `1.` format version.
+function packedOf(setCookie: string | null) {
+  expect(setCookie).not.toBeNull();
+  const end = setCookie!.indexOf("; ");
+  const pair = end < 0 ? setCookie! : setCookie!.slice(0, end);
+  const value = pair.slice(FLASH_COOKIE.length + 1);
+  expect(value.startsWith("1.")).toBe(true);
+  const binary = atob(value.slice(2).replace(/-/g, "+").replace(/_/g, "/"));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+// What the derivation used to be: one SHA-256 over domain + secret.
+async function bareDigestKey(secret: string) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(FLASH_KEY_DOMAIN + secret)
+  );
+  return crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, ["decrypt"]);
+}
+
+// What it is now.
+async function stretchedKey(secret: string, iterations = FLASH_KEY_ITERATIONS) {
+  const encoder = new TextEncoder();
+  const material = await crypto.subtle.importKey("raw", encoder.encode(secret), "PBKDF2", false, [
+    "deriveKey"
+  ]);
+  return crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: encoder.encode(FLASH_KEY_DOMAIN),
+      iterations,
+      hash: "SHA-256"
+    },
+    material,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["decrypt"]
+  );
+}
+
+async function opens(packed: Uint8Array, key: CryptoKey) {
+  try {
+    await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: packed.subarray(0, IV_BYTES) },
+      key,
+      packed.subarray(IV_BYTES)
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("the flash key is stretched from the deployment secret", () => {
+  it("does not open under a bare digest of the secret", async () => {
+    withKey();
+    const packed = packedOf(await encodeFlashCookie("/login", { ok: true }, []));
+    expect(await opens(packed, await bareDigestKey(SECRET))).toBe(false);
+  });
+
+  it("opens under PBKDF2 with the documented parameters", async () => {
+    withKey();
+    const packed = packedOf(await encodeFlashCookie("/login", { ok: true }, []));
+    expect(await opens(packed, await stretchedKey(SECRET))).toBe(true);
+  });
+
+  it("is bound to the iteration count", async () => {
+    withKey();
+    const packed = packedOf(await encodeFlashCookie("/login", { ok: true }, []));
+    // A cheaper derivation is a different key. Lowering the count silently
+    // would be the whole bug back again.
+    expect(await opens(packed, await stretchedKey(SECRET, 1_000))).toBe(false);
+  });
+
+  it("is bound to the domain salt, so another purpose's key cannot read it", async () => {
+    withKey();
+    const packed = packedOf(await encodeFlashCookie("/login", { ok: true }, []));
+    const encoder = new TextEncoder();
+    const material = await crypto.subtle.importKey("raw", encoder.encode(SECRET), "PBKDF2", false, [
+      "deriveKey"
+    ]);
+    const otherPurpose = await crypto.subtle.deriveKey(
+      {
+        name: "PBKDF2",
+        salt: encoder.encode("solid.other.v1\0"),
+        iterations: FLASH_KEY_ITERATIONS,
+        hash: "SHA-256"
+      },
+      material,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["decrypt"]
+    );
+    expect(await opens(packed, otherPurpose)).toBe(false);
+  });
+
+  it("still round-trips a submission through the public API", async () => {
+    withKey();
+    const form = new FormData();
+    form.set("user", "ada@example.com");
+    const cookie = await encodeFlashCookie("/login", { receipt: "RCPT-1" }, [form]);
+    const end = cookie!.indexOf("; ");
+    const submission = (await decodeFlashCookie(end < 0 ? cookie! : cookie!.slice(0, end)))!;
+    expect(submission.url).toBe("/login");
+    expect(submission.result).toEqual({ receipt: "RCPT-1" });
+    expect((submission.input[0] as FormData).get("user")).toBe("ada@example.com");
+  });
+});


### PR DESCRIPTION
A captured flash cookie is an offline oracle for `secret`, and the option accepts any non-empty string. Under a single SHA-256 each guess cost one hash, so a short or human-chosen secret fell quickly. Recovering it means reading every flash payload and forging new ones.

- Derive the key with PBKDF2-HMAC-SHA-256 at 100,000 iterations, salted with the same domain string as before. The cap is the ceiling some edge runtimes enforce on PBKDF2.
- Document the entropy requirement on the `secret` option and show how to generate a value. Stretching raises the price of a guess. It does not make a guessable secret safe.

The derivation runs once per process per secret and only on the no-JS form path, so ordinary requests are unaffected. The derived key changes, so in-flight flashes read as no flash, the same as a secret rotation.

Tested with a spec that attacks the cookie the public API produces: the old bare digest must not open it, PBKDF2 with the documented parameters must, and neither a lower iteration count nor another domain salt does.
