### PR TITLE
fix(compiler): name server functions by their binding path

### DIFF
--- a/.changeset/server-function-path-names.md
+++ b/.changeset/server-function-path-names.md
@@ -1,0 +1,9 @@
+---
+"@solidjs/compiler": patch
+---
+
+Server-function ids now name a function by its binding path, so two same-named functions no longer share one id.
+
+- `makeA`'s `submit` becomes `makeA.submit-<hash>` instead of `submit-<hash>`.
+- Adding a same-named function no longer re-points the ids of the existing ones.
+- Ids for functions in objects and classes pick up those names too, such as `handlers.save`.

--- a/.changeset/server-function-path-names.md
+++ b/.changeset/server-function-path-names.md
@@ -7,3 +7,4 @@ Server-function ids now name a function by its binding path, so two same-named f
 - `makeA`'s `submit` becomes `makeA.submit-<hash>` instead of `submit-<hash>`.
 - Adding a same-named function no longer re-points the ids of the existing ones.
 - Ids for functions in objects and classes pick up those names too, such as `handlers.save`.
+- A named function contributes its own name as well, so `register(function saveHandler() {})` inside `wire` is `wire.saveHandler` rather than sharing an ordinal with its siblings.

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -157,7 +157,7 @@ A function-level directive only works where the pass can extract the function: a
 
 A module-level `"use server"` module can only export server functions. Its client build is rebuilt from those exports alone, so anything else would be missing from the browser bundle. Re-exports, `export *`, class and enum exports, destructured exports, and exports declared without an initializer are compile errors naming the export and its position. Type-only and `declare` exports are erased and are fine.
 
-The runtime module defaults to `@solidjs/web/server-functions`. Function IDs are `<name>-<xxhash32(root-relative path)>`, the same in every env. The name is the function's dotted binding path, such as `handlers.save`, so an id identifies a function by where it is bound rather than by its position in the file. Adding, removing, or reordering functions does not move the ids of the others. There are also experimental `transformLazy` and `transformRefresh` passes.
+The runtime module defaults to `@solidjs/web/server-functions`. Function IDs are `<name>-<xxhash32(root-relative path)>`, the same in every env. The name is the function's dotted binding path, such as `handlers.save`, built from every named container on the way down (variable bindings, property keys, class names, class members, and named functions), so an id identifies a function by where it is bound rather than by its position in the file. Adding, removing, or reordering functions does not move the ids of the others. There are also experimental `transformLazy` and `transformRefresh` passes.
 
 ## Rust compiler core
 

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -157,7 +157,7 @@ A function-level directive only works where the pass can extract the function: a
 
 A module-level `"use server"` module can only export server functions. Its client build is rebuilt from those exports alone, so anything else would be missing from the browser bundle. Re-exports, `export *`, class and enum exports, destructured exports, and exports declared without an initializer are compile errors naming the export and its position. Type-only and `declare` exports are erased and are fine.
 
-The runtime module defaults to `@solidjs/web/server-functions`. Function IDs use `xxhash32(root-relative path)-<count>` (name-suffixed with `env: "development"`). There are also experimental `transformLazy` and `transformRefresh` passes.
+The runtime module defaults to `@solidjs/web/server-functions`. Function IDs are `<name>-<xxhash32(root-relative path)>`, the same in every env. The name is the function's dotted binding path, such as `handlers.save`, so an id identifies a function by where it is bound rather than by its position in the file. Adding, removing, or reordering functions does not move the ids of the others. There are also experimental `transformLazy` and `transformRefresh` passes.
 
 ## Rust compiler core
 

--- a/packages/compiler/__tests__/directives-id-scheme.test.js
+++ b/packages/compiler/__tests__/directives-id-scheme.test.js
@@ -239,9 +239,7 @@ describe("the wire id scheme, differentially", () => {
     const hash = hashHex("src/containers.js");
     expect(
       ids(source, { filename: "/project/src/containers.js", root: "/project" }).sort()
-    ).toEqual(
-      [`handlers.save-${hash}`, `handlers.drop-${hash}`, `Api.refresh-${hash}`].sort()
-    );
+    ).toEqual([`handlers.save-${hash}`, `handlers.drop-${hash}`, `Api.refresh-${hash}`].sort());
   });
 
   it("keeps non-ascii binding names in the path", () => {
@@ -265,6 +263,56 @@ describe("the wire id scheme, differentially", () => {
     const hash = hashHex("src/keys.js");
     expect(ids(source, { filename: "/project/src/keys.js", root: "/project" })).toEqual([
       `handlers-${hash}`
+    ]);
+  });
+
+  it("takes a segment from a named function expression that has no binding of its own", () => {
+    // Passed straight to a call, the function's own name is the only thing
+    // that tells it apart from its sibling. Dropping it in favour of the
+    // container alone would put both back on a positional ordinal.
+    const source = `
+      export function wire() {
+        register(function saveHandler() { "use server"; return 1; });
+        register(function dropHandler() { "use server"; return 2; });
+      }
+    `;
+    const hash = hashHex("src/named.js");
+    expect(ids(source, { filename: "/project/src/named.js", root: "/project" })).toEqual([
+      `wire.saveHandler-${hash}`,
+      `wire.dropHandler-${hash}`
+    ]);
+  });
+
+  it("does not repeat a function name that matches the binding it is assigned to", () => {
+    // `const submit = function submit() {}` is one name, not two. Bubbled
+    // top-level declarations take this shape, so `makeA` stays `makeA`.
+    const source = `
+      export function makeA() {
+        const submit = function submit() { "use server"; return 1; };
+        return submit;
+      }
+    `;
+    const hash = hashHex("src/same.js");
+    expect(ids(source, { filename: "/project/src/same.js", root: "/project" })).toEqual([
+      `makeA.submit-${hash}`
+    ]);
+  });
+
+  it("takes a segment from a nested function declaration", () => {
+    // Declarations nested inside another function are not bubbled into a
+    // `const`, so the function itself has to contribute the segment, or two
+    // same-named arrows in sibling declarations collide on `outer.s`.
+    const source = `
+      export function outer() {
+        function a() { const s = async () => { "use server"; return 1; }; return s; }
+        function b() { const s = async () => { "use server"; return 2; }; return s; }
+        return [a(), b()];
+      }
+    `;
+    const hash = hashHex("src/decl.js");
+    expect(ids(source, { filename: "/project/src/decl.js", root: "/project" })).toEqual([
+      `outer.a.s-${hash}`,
+      `outer.b.s-${hash}`
     ]);
   });
 

--- a/packages/compiler/__tests__/directives-id-scheme.test.js
+++ b/packages/compiler/__tests__/directives-id-scheme.test.js
@@ -167,7 +167,7 @@ describe("the wire id scheme, differentially", () => {
     ]);
   });
 
-  it("suffixes an ordinal only when a name recurs, in visit order", () => {
+  it("names a function by its enclosing binding path", () => {
     const source = `
       export function makeA() {
         const submit = async data => {
@@ -185,14 +185,102 @@ describe("the wire id scheme, differentially", () => {
       }
     `;
     const hash = hashHex("src/forms.js");
-    // Post-bubble program order: top-level function declarations are
-    // hoisted in reverse source order (the frozen Babel reference's
-    // behavior — see the repeated-names fixture), so makeB's submit takes
-    // the bare id. This assignment IS the wire contract; a traversal
-    // change that flips it re-points deployed addresses.
+    // Two `submit`s in sibling scopes are two different names, so neither
+    // needs an ordinal to tell them apart. Reported in post-bubble program
+    // order: top-level function declarations hoist in reverse source order
+    // (the frozen Babel reference's behavior, see the repeated-names
+    // fixture), which now moves the reporting order without moving an id.
     expect(ids(source, { filename: "/project/src/forms.js", root: "/project" })).toEqual([
-      `submit-${hash}`,
-      `submit-${hash}-1`
+      `makeB.submit-${hash}`,
+      `makeA.submit-${hash}`
+    ]);
+  });
+
+  it("does not move an existing id when a same-named function is added", () => {
+    // The defect the path fixes: with a bare `submit` name, the ordinal was
+    // a visit-order counter, so appending a third `submit` renumbered the
+    // two already deployed and a stale client dispatched to the wrong
+    // function with a 200 (solidjs/solid#3109).
+    const before = `
+      export function makeA() {
+        const submit = async () => { "use server"; return "a"; };
+        return submit;
+      }
+      export function makeB() {
+        const submit = async () => { "use server"; return "b"; };
+        return submit;
+      }
+    `;
+    const after = `${before}
+      export function makeC() {
+        const submit = async () => { "use server"; return "c"; };
+        return submit;
+      }
+    `;
+    const options = { filename: "/project/src/forms.js", root: "/project" };
+    const hash = hashHex("src/forms.js");
+    for (const id of [`makeA.submit-${hash}`, `makeB.submit-${hash}`]) {
+      expect(ids(before, options)).toContain(id);
+      expect(ids(after, options)).toContain(id);
+    }
+    expect(ids(after, options)).toContain(`makeC.submit-${hash}`);
+  });
+
+  it("takes a path segment from every named container on the way down", () => {
+    const source = `
+      export const handlers = {
+        save: async () => { "use server"; return "save"; },
+        drop: async () => { "use server"; return "drop"; }
+      };
+      export class Api {
+        refresh = async () => { "use server"; return "refresh"; };
+      }
+    `;
+    const hash = hashHex("src/containers.js");
+    expect(
+      ids(source, { filename: "/project/src/containers.js", root: "/project" }).sort()
+    ).toEqual(
+      [`handlers.save-${hash}`, `handlers.drop-${hash}`, `Api.refresh-${hash}`].sort()
+    );
+  });
+
+  it("keeps non-ascii binding names in the path", () => {
+    const source = `
+      export const café = async () => { "use server"; return 1; };
+    `;
+    const hash = hashHex("src/menu.js");
+    expect(ids(source, { filename: "/project/src/menu.js", root: "/project" })).toEqual([
+      `café-${hash}`
+    ]);
+  });
+
+  it("drops a path segment for a key that is not an identifier", () => {
+    // A dash in a segment would break `id.split("-")[1]`, so the key
+    // contributes nothing and the container alone names the function.
+    const source = `
+      export const handlers = {
+        "run-now": async () => { "use server"; return 1; }
+      };
+    `;
+    const hash = hashHex("src/keys.js");
+    expect(ids(source, { filename: "/project/src/keys.js", root: "/project" })).toEqual([
+      `handlers-${hash}`
+    ]);
+  });
+
+  it("still suffixes an ordinal when two functions share one path", () => {
+    // Two anonymous callbacks in the same scope have no name to tell them
+    // apart, so the positional ordinal remains the last resort.
+    const source = `
+      export function wire() {
+        on("a", async () => { "use server"; return 1; });
+        on("b", async () => { "use server"; return 2; });
+      }
+    `;
+    const hash = hashHex("src/wire.js");
+    expect(ids(source, { filename: "/project/src/wire.js", root: "/project" })).toEqual([
+      `wire-${hash}`,
+      `wire-${hash}-1`
     ]);
   });
 

--- a/packages/compiler/__tests__/directives/fixtures/README.md
+++ b/packages/compiler/__tests__/directives/fixtures/README.md
@@ -25,15 +25,19 @@ transform, with the diff reviewed as part of that change.
 ## Function IDs are a wire contract
 
 The `<name>-<xxhash32(root-relative path)>[-<ordinal>]` ids baked into these
-fixtures are not cosmetic output: they are baked into client bundles, server
+fixtures are not cosmetic output. They are baked into client bundles, server
 manifests, rendered form-action urls and shared-cache keys, and a deployed
-tab holds the previous build's ids across a deploy (solidjs/solid#3109,
-#3120). A regeneration that changes any id is a **protocol change** — it
-re-points or orphans addresses another build already handed out — and must
-be reviewed as one, never waved through as fixture churn. The ordinal
-suffix is assigned in the order the transform visits functions (post-bubble
-program order, pinned by the `repeated-names` fixture), so a traversal
-change re-points same-name ids even when nothing about the scheme changed.
-`directives-id-scheme.test.js` guards the derivation differentially, with
-an independent hash implementation; it must never be updated in the same
-breath as a fixture regeneration without understanding why both moved.
+tab holds the previous build's ids across a deploy (solidjs/solid#3109 and
+solidjs/solid#3120). A regeneration that changes any id is a protocol
+change. It
+re-points or orphans addresses another build already handed out, so it must
+be reviewed as one and never waved through as fixture churn.
+
+The name is the function's dotted binding path, such as `handlers.save` (the
+`object-property` fixture) or `makeDraftSaver.submit` (`repeated-names`).
+Anything that changes how the path is built changes ids. The ordinal suffix
+is the last resort for two functions that share one path, and it is assigned
+in the order the transform visits functions, which is post-bubble program
+order. `directives-id-scheme.test.js` guards the derivation differentially,
+with an independent hash implementation. It must never be updated in the
+same breath as a fixture regeneration without understanding why both moved.

--- a/packages/compiler/__tests__/directives/fixtures/nested-functions/expected.server.dev.js
+++ b/packages/compiler/__tests__/directives/fixtures/nested-functions/expected.server.dev.js
@@ -1,8 +1,8 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
-const serverFunction_1 = registerServerReference_1("inner-cb5f8b97", () => {
+const serverFunction_1 = registerServerReference_1("helper.inner-cb5f8b97", () => {
   return 1;
-}, "inner");
+}, "helper.inner");
 const helper = function helper() {
   const inner = createServerReference_1(serverFunction_1);
   return inner;

--- a/packages/compiler/__tests__/directives/fixtures/nested-functions/expected.server.js
+++ b/packages/compiler/__tests__/directives/fixtures/nested-functions/expected.server.js
@@ -1,6 +1,6 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
-const serverFunction_1 = registerServerReference_1("inner-cb5f8b97", () => {
+const serverFunction_1 = registerServerReference_1("helper.inner-cb5f8b97", () => {
   return 1;
 });
 const helper = function helper() {

--- a/packages/compiler/__tests__/directives/fixtures/nested-functions/meta.json
+++ b/packages/compiler/__tests__/directives/fixtures/nested-functions/meta.json
@@ -2,8 +2,8 @@
   "valid": true,
   "functions": [
     {
-      "id": "inner-cb5f8b97",
-      "name": "inner",
+      "id": "helper.inner-cb5f8b97",
+      "name": "helper.inner",
       "exports": []
     },
     {

--- a/packages/compiler/__tests__/directives/fixtures/nested-functions/output.server.js
+++ b/packages/compiler/__tests__/directives/fixtures/nested-functions/output.server.js
@@ -1,6 +1,6 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
-const serverFunction_1 = registerServerReference_1("inner-cb5f8b97", () => {
+const serverFunction_1 = registerServerReference_1("helper.inner-cb5f8b97", () => {
 	return 1;
 });
 const helper = function helper() {

--- a/packages/compiler/__tests__/directives/fixtures/object-property/expected.client.dev.js
+++ b/packages/compiler/__tests__/directives/fixtures/object-property/expected.client.dev.js
@@ -1,5 +1,5 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 export const handlers = {
-  save: createServerReference_1("saveRecord-32e00052", "saveRecord"),
-  drop: createServerReference_1("handlers-32e00052", "handlers")
+  save: createServerReference_1("handlers.save-32e00052", "handlers.save"),
+  drop: createServerReference_1("handlers.drop-32e00052", "handlers.drop")
 };

--- a/packages/compiler/__tests__/directives/fixtures/object-property/expected.client.dev.js
+++ b/packages/compiler/__tests__/directives/fixtures/object-property/expected.client.dev.js
@@ -1,5 +1,5 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 export const handlers = {
-  save: createServerReference_1("handlers.save-32e00052", "handlers.save"),
+  save: createServerReference_1("handlers.save.saveRecord-32e00052", "handlers.save.saveRecord"),
   drop: createServerReference_1("handlers.drop-32e00052", "handlers.drop")
 };

--- a/packages/compiler/__tests__/directives/fixtures/object-property/expected.client.js
+++ b/packages/compiler/__tests__/directives/fixtures/object-property/expected.client.js
@@ -1,5 +1,5 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 export const handlers = {
-  save: createServerReference_1("handlers.save-32e00052"),
+  save: createServerReference_1("handlers.save.saveRecord-32e00052"),
   drop: createServerReference_1("handlers.drop-32e00052")
 };

--- a/packages/compiler/__tests__/directives/fixtures/object-property/expected.client.js
+++ b/packages/compiler/__tests__/directives/fixtures/object-property/expected.client.js
@@ -1,5 +1,5 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 export const handlers = {
-  save: createServerReference_1("saveRecord-32e00052"),
-  drop: createServerReference_1("handlers-32e00052")
+  save: createServerReference_1("handlers.save-32e00052"),
+  drop: createServerReference_1("handlers.drop-32e00052")
 };

--- a/packages/compiler/__tests__/directives/fixtures/object-property/expected.server.dev.js
+++ b/packages/compiler/__tests__/directives/fixtures/object-property/expected.server.dev.js
@@ -1,12 +1,12 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
 import { track } from "./analytics";
-const serverFunction_1 = registerServerReference_1("saveRecord-32e00052", function saveRecord(data) {
+const serverFunction_1 = registerServerReference_1("handlers.save-32e00052", function saveRecord(data) {
   return track("save", data);
-}, "saveRecord");
-const serverFunction_2 = registerServerReference_1("handlers-32e00052", function (id) {
+}, "handlers.save");
+const serverFunction_2 = registerServerReference_1("handlers.drop-32e00052", function (id) {
   return track("drop", id);
-}, "handlers");
+}, "handlers.drop");
 export const handlers = {
   save: createServerReference_1(serverFunction_1),
   drop: createServerReference_1(serverFunction_2)

--- a/packages/compiler/__tests__/directives/fixtures/object-property/expected.server.dev.js
+++ b/packages/compiler/__tests__/directives/fixtures/object-property/expected.server.dev.js
@@ -1,9 +1,9 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
 import { track } from "./analytics";
-const serverFunction_1 = registerServerReference_1("handlers.save-32e00052", function saveRecord(data) {
+const serverFunction_1 = registerServerReference_1("handlers.save.saveRecord-32e00052", function saveRecord(data) {
   return track("save", data);
-}, "handlers.save");
+}, "handlers.save.saveRecord");
 const serverFunction_2 = registerServerReference_1("handlers.drop-32e00052", function (id) {
   return track("drop", id);
 }, "handlers.drop");

--- a/packages/compiler/__tests__/directives/fixtures/object-property/expected.server.js
+++ b/packages/compiler/__tests__/directives/fixtures/object-property/expected.server.js
@@ -1,10 +1,10 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
 import { track } from "./analytics";
-const serverFunction_1 = registerServerReference_1("saveRecord-32e00052", function saveRecord(data) {
+const serverFunction_1 = registerServerReference_1("handlers.save-32e00052", function saveRecord(data) {
   return track("save", data);
 });
-const serverFunction_2 = registerServerReference_1("handlers-32e00052", function (id) {
+const serverFunction_2 = registerServerReference_1("handlers.drop-32e00052", function (id) {
   return track("drop", id);
 });
 export const handlers = {

--- a/packages/compiler/__tests__/directives/fixtures/object-property/expected.server.js
+++ b/packages/compiler/__tests__/directives/fixtures/object-property/expected.server.js
@@ -1,7 +1,7 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
 import { track } from "./analytics";
-const serverFunction_1 = registerServerReference_1("handlers.save-32e00052", function saveRecord(data) {
+const serverFunction_1 = registerServerReference_1("handlers.save.saveRecord-32e00052", function saveRecord(data) {
   return track("save", data);
 });
 const serverFunction_2 = registerServerReference_1("handlers.drop-32e00052", function (id) {

--- a/packages/compiler/__tests__/directives/fixtures/object-property/meta.json
+++ b/packages/compiler/__tests__/directives/fixtures/object-property/meta.json
@@ -2,13 +2,13 @@
   "valid": true,
   "functions": [
     {
-      "id": "saveRecord-32e00052",
-      "name": "saveRecord",
+      "id": "handlers.save-32e00052",
+      "name": "handlers.save",
       "exports": []
     },
     {
-      "id": "handlers-32e00052",
-      "name": "handlers",
+      "id": "handlers.drop-32e00052",
+      "name": "handlers.drop",
       "exports": []
     }
   ]

--- a/packages/compiler/__tests__/directives/fixtures/object-property/meta.json
+++ b/packages/compiler/__tests__/directives/fixtures/object-property/meta.json
@@ -2,8 +2,8 @@
   "valid": true,
   "functions": [
     {
-      "id": "handlers.save-32e00052",
-      "name": "handlers.save",
+      "id": "handlers.save.saveRecord-32e00052",
+      "name": "handlers.save.saveRecord",
       "exports": []
     },
     {

--- a/packages/compiler/__tests__/directives/fixtures/object-property/output.client.js
+++ b/packages/compiler/__tests__/directives/fixtures/object-property/output.client.js
@@ -1,5 +1,5 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 export const handlers = {
-	save: createServerReference_1("saveRecord-32e00052"),
-	drop: createServerReference_1("handlers-32e00052")
+	save: createServerReference_1("handlers.save-32e00052"),
+	drop: createServerReference_1("handlers.drop-32e00052")
 };

--- a/packages/compiler/__tests__/directives/fixtures/object-property/output.client.js
+++ b/packages/compiler/__tests__/directives/fixtures/object-property/output.client.js
@@ -1,5 +1,5 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 export const handlers = {
-	save: createServerReference_1("handlers.save-32e00052"),
+	save: createServerReference_1("handlers.save.saveRecord-32e00052"),
 	drop: createServerReference_1("handlers.drop-32e00052")
 };

--- a/packages/compiler/__tests__/directives/fixtures/object-property/output.server.js
+++ b/packages/compiler/__tests__/directives/fixtures/object-property/output.server.js
@@ -1,10 +1,10 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
 import { track } from "./analytics";
-const serverFunction_1 = registerServerReference_1("saveRecord-32e00052", function saveRecord(data) {
+const serverFunction_1 = registerServerReference_1("handlers.save-32e00052", function saveRecord(data) {
 	return track("save", data);
 });
-const serverFunction_2 = registerServerReference_1("handlers-32e00052", function(id) {
+const serverFunction_2 = registerServerReference_1("handlers.drop-32e00052", function(id) {
 	return track("drop", id);
 });
 export const handlers = {

--- a/packages/compiler/__tests__/directives/fixtures/object-property/output.server.js
+++ b/packages/compiler/__tests__/directives/fixtures/object-property/output.server.js
@@ -1,7 +1,7 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
 import { track } from "./analytics";
-const serverFunction_1 = registerServerReference_1("handlers.save-32e00052", function saveRecord(data) {
+const serverFunction_1 = registerServerReference_1("handlers.save.saveRecord-32e00052", function saveRecord(data) {
 	return track("save", data);
 });
 const serverFunction_2 = registerServerReference_1("handlers.drop-32e00052", function(id) {

--- a/packages/compiler/__tests__/directives/fixtures/repeated-names/expected.client.dev.js
+++ b/packages/compiler/__tests__/directives/fixtures/repeated-names/expected.client.dev.js
@@ -1,10 +1,10 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 const makePublishSaver = function makePublishSaver() {
-  const submit = createServerReference_1("submit-f3b916ee", "submit");
+  const submit = createServerReference_1("makePublishSaver.submit-f3b916ee", "makePublishSaver.submit");
   return submit;
 };
 const makeDraftSaver = function makeDraftSaver() {
-  const submit = createServerReference_1("submit-f3b916ee-1", "submit");
+  const submit = createServerReference_1("makeDraftSaver.submit-f3b916ee", "makeDraftSaver.submit");
   return submit;
 };
 export { makeDraftSaver };

--- a/packages/compiler/__tests__/directives/fixtures/repeated-names/expected.client.js
+++ b/packages/compiler/__tests__/directives/fixtures/repeated-names/expected.client.js
@@ -1,10 +1,10 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 const makePublishSaver = function makePublishSaver() {
-  const submit = createServerReference_1("submit-f3b916ee");
+  const submit = createServerReference_1("makePublishSaver.submit-f3b916ee");
   return submit;
 };
 const makeDraftSaver = function makeDraftSaver() {
-  const submit = createServerReference_1("submit-f3b916ee-1");
+  const submit = createServerReference_1("makeDraftSaver.submit-f3b916ee");
   return submit;
 };
 export { makeDraftSaver };

--- a/packages/compiler/__tests__/directives/fixtures/repeated-names/expected.server.dev.js
+++ b/packages/compiler/__tests__/directives/fixtures/repeated-names/expected.server.dev.js
@@ -1,15 +1,15 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
-const serverFunction_1 = registerServerReference_1("submit-f3b916ee", async data => {
+const serverFunction_1 = registerServerReference_1("makePublishSaver.submit-f3b916ee", async data => {
   return ["publish", data];
-}, "submit");
+}, "makePublishSaver.submit");
 const makePublishSaver = function makePublishSaver() {
   const submit = createServerReference_1(serverFunction_1);
   return submit;
 };
-const serverFunction_2 = registerServerReference_1("submit-f3b916ee-1", async data => {
+const serverFunction_2 = registerServerReference_1("makeDraftSaver.submit-f3b916ee", async data => {
   return ["draft", data];
-}, "submit");
+}, "makeDraftSaver.submit");
 const makeDraftSaver = function makeDraftSaver() {
   const submit = createServerReference_1(serverFunction_2);
   return submit;

--- a/packages/compiler/__tests__/directives/fixtures/repeated-names/expected.server.js
+++ b/packages/compiler/__tests__/directives/fixtures/repeated-names/expected.server.js
@@ -1,13 +1,13 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
-const serverFunction_1 = registerServerReference_1("submit-f3b916ee", async data => {
+const serverFunction_1 = registerServerReference_1("makePublishSaver.submit-f3b916ee", async data => {
   return ["publish", data];
 });
 const makePublishSaver = function makePublishSaver() {
   const submit = createServerReference_1(serverFunction_1);
   return submit;
 };
-const serverFunction_2 = registerServerReference_1("submit-f3b916ee-1", async data => {
+const serverFunction_2 = registerServerReference_1("makeDraftSaver.submit-f3b916ee", async data => {
   return ["draft", data];
 });
 const makeDraftSaver = function makeDraftSaver() {

--- a/packages/compiler/__tests__/directives/fixtures/repeated-names/meta.json
+++ b/packages/compiler/__tests__/directives/fixtures/repeated-names/meta.json
@@ -2,13 +2,13 @@
   "valid": true,
   "functions": [
     {
-      "id": "submit-f3b916ee",
-      "name": "submit",
+      "id": "makePublishSaver.submit-f3b916ee",
+      "name": "makePublishSaver.submit",
       "exports": []
     },
     {
-      "id": "submit-f3b916ee-1",
-      "name": "submit",
+      "id": "makeDraftSaver.submit-f3b916ee",
+      "name": "makeDraftSaver.submit",
       "exports": []
     }
   ]

--- a/packages/compiler/__tests__/directives/fixtures/repeated-names/output.client.js
+++ b/packages/compiler/__tests__/directives/fixtures/repeated-names/output.client.js
@@ -1,10 +1,10 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 const makePublishSaver = function makePublishSaver() {
-	const submit = createServerReference_1("submit-f3b916ee");
+	const submit = createServerReference_1("makePublishSaver.submit-f3b916ee");
 	return submit;
 };
 const makeDraftSaver = function makeDraftSaver() {
-	const submit = createServerReference_1("submit-f3b916ee-1");
+	const submit = createServerReference_1("makeDraftSaver.submit-f3b916ee");
 	return submit;
 };
 export { makeDraftSaver };

--- a/packages/compiler/__tests__/directives/fixtures/repeated-names/output.server.js
+++ b/packages/compiler/__tests__/directives/fixtures/repeated-names/output.server.js
@@ -1,13 +1,13 @@
 import { createServerReference as createServerReference_1 } from "@solidjs/web/server-functions";
 import { registerServerReference as registerServerReference_1 } from "@solidjs/web/server-functions";
-const serverFunction_1 = registerServerReference_1("submit-f3b916ee", async (data) => {
+const serverFunction_1 = registerServerReference_1("makePublishSaver.submit-f3b916ee", async (data) => {
 	return ["publish", data];
 });
 const makePublishSaver = function makePublishSaver() {
 	const submit = createServerReference_1(serverFunction_1);
 	return submit;
 };
-const serverFunction_2 = registerServerReference_1("submit-f3b916ee-1", async (data) => {
+const serverFunction_2 = registerServerReference_1("makeDraftSaver.submit-f3b916ee", async (data) => {
 	return ["draft", data];
 });
 const makeDraftSaver = function makeDraftSaver() {

--- a/packages/compiler/__tests__/directives/harness.js
+++ b/packages/compiler/__tests__/directives/harness.js
@@ -136,9 +136,11 @@ function normalize(code) {
 }
 
 // Function IDs embedded in compiled output (`<name>-<hash>` with a trailing
-// ordinal for repeated names; identical in both envs).
+// ordinal for repeated names; identical in both envs). The name is a dotted
+// path of identifiers (`handlers.save`), so dots are part of it and dashes
+// never are.
 function extractIds(code) {
-  const matches = code.match(/"[A-Za-z0-9_$]+-[0-9a-f]{1,8}(?:-\d+)?"/g) || [];
+  const matches = code.match(/"[A-Za-z0-9_$]+(?:\.[A-Za-z0-9_$]+)*-[0-9a-f]{1,8}(?:-\d+)?"/g) || [];
   return [...new Set(matches.map(entry => entry.slice(1, -1)))].sort();
 }
 

--- a/packages/compiler/src/directives/mod.rs
+++ b/packages/compiler/src/directives/mod.rs
@@ -6,8 +6,9 @@
 //!
 //! The runtime ABI is frozen: `registerServerReference(id, fn)` on the
 //! server, `createServerReference(id)` proxies on the client, and the
-//! `<name>-<xxhash32(relative path)>` ID format shared by both builds
-//! (identity-keyed, not positional — solidjs/solid#3109).
+//! `<name>-<xxhash32(relative path)>` ID format shared by both builds. The
+//! name is the function's dotted binding path, so ids are keyed on identity
+//! rather than position (solidjs/solid#3109).
 
 mod dce;
 mod transform;
@@ -63,7 +64,8 @@ pub struct TransformDirectivesOptions {
 pub struct ServerFunctionMeta {
     /// The wire ID (`<name>-<hash>[-<ordinal>]`).
     pub id: String,
-    /// The descriptive source name (`anonymous` when none applies).
+    /// The dotted binding path that names the function, such as
+    /// `handlers.save`. `anonymous` when no enclosing binding applies.
     pub name: String,
     /// Export names bound to this function (module-level directives only;
     /// empty for function-level extractions).

--- a/packages/compiler/src/directives/transform.rs
+++ b/packages/compiler/src/directives/transform.rs
@@ -227,16 +227,27 @@ impl<'a> DirectivesTransform<'a> {
         }
     }
 
-    /// The wire id: `<name>-<hash>`, with a trailing ordinal only when the
-    /// same descriptive name recurs in one file (several `anonymous`
-    /// closures, shadowed bindings). Keyed on identity — file plus name —
-    /// rather than position, so appending, deleting, or reordering functions
-    /// never re-points an address another build already handed out
-    /// (solidjs/solid#3109); a removed or renamed function becomes a clean
-    /// 404 instead of a wrong dispatch. Identical in development and
-    /// production so both exercise the same addresses. The name is a JS
-    /// identifier (never contains `-`), so the hash is always
-    /// `split('-')[1]` for consumers mapping ids back to files.
+    /// The wire id: `<name>-<hash>`. The name is the function's dotted
+    /// binding path, so two same-named functions in sibling scopes are two
+    /// different names (`makeA.submit`, `makeB.submit`) rather than one name
+    /// and a counter.
+    ///
+    /// The id is keyed on identity, file plus path, not on position.
+    /// Appending, deleting, or reordering functions never re-points an
+    /// address another build already handed out (solidjs/solid#3109). A
+    /// removed or renamed function becomes a clean 404 instead of a wrong
+    /// dispatch.
+    ///
+    /// A trailing ordinal is the last resort, for two functions that share
+    /// one path. That only happens when neither has a name of its own and
+    /// they sit in the same container, such as two inline callbacks. The
+    /// ordinal is positional, so adding a third sibling callback ahead of
+    /// them does move their ids.
+    ///
+    /// Ids are identical in development and production, so both exercise the
+    /// same addresses. Path segments are JS identifiers joined by `.` and
+    /// never contain `-`, so the hash is always `split('-')[1]` for
+    /// consumers mapping ids back to files.
     fn create_id(&mut self, name: &str) -> String {
         self.count += 1;
         let seen = self
@@ -628,7 +639,7 @@ impl<'a> DirectivesTransform<'a> {
             transform: self,
             top_index: 0,
             insertions: Vec::new(),
-            name_stack: Vec::new(),
+            name_path: Vec::new(),
         };
         visitor.visit_program(program);
         let insertions = std::mem::take(&mut visitor.insertions);
@@ -763,12 +774,49 @@ struct FunctionLevelVisitor<'ctx, 'a> {
     /// `getRootStatementPath` insertion anchor.
     top_index: usize,
     insertions: Vec<(usize, Statement<'a>)>,
-    /// Nearest-binding names for `getDescriptiveName` (variable declarators
-    /// with identifier ids; named function expressions use their own id).
-    name_stack: Vec<String>,
+    /// Enclosing binding names, outermost first: the dotted path that names
+    /// an extracted function. Every named container on the way down
+    /// contributes a segment (variable declarators, object property keys,
+    /// class names, class member keys), so two same-named functions in
+    /// sibling scopes get distinct names instead of sharing one and being
+    /// told apart by a positional ordinal.
+    name_path: Vec<String>,
+}
+
+/// Path segments must be JS identifiers: the wire id is
+/// `<name>-<hash>[-<ordinal>]`, so a segment carrying a `-` would break
+/// `id.split("-")[1]` for every consumer that reads the file hash back out,
+/// and a `.` would look like a segment boundary. A computed or string key
+/// that is not identifier-shaped contributes no segment rather than a
+/// mangled one. Non-ASCII identifiers are ordinary JS names and are kept;
+/// the id is percent-encoded into the request url by the runtime.
+fn identifier_segment(name: &str) -> Option<String> {
+    let mut chars = name.chars();
+    let first = chars.next()?;
+    if !(first.is_alphabetic() || first == '_' || first == '$') {
+        return None;
+    }
+    if !chars.all(|c| c.is_alphanumeric() || c == '_' || c == '$') {
+        return None;
+    }
+    Some(name.to_string())
 }
 
 impl<'a> FunctionLevelVisitor<'_, 'a> {
+    /// Walks `walk` with `segment` appended to the name path, restoring the
+    /// path afterwards. A `None` segment (a destructuring pattern, a computed
+    /// key) contributes nothing and leaves the path as it was.
+    fn with_segment(&mut self, segment: Option<String>, walk: impl FnOnce(&mut Self)) {
+        let pushed = segment.is_some();
+        if let Some(segment) = segment {
+            self.name_path.push(segment);
+        }
+        walk(self);
+        if pushed {
+            self.name_path.pop();
+        }
+    }
+
     fn body_has_directive(&self, body: &oxc_ast::ast::FunctionBody<'a>) -> bool {
         body.directives
             .iter()
@@ -817,9 +865,16 @@ impl<'a> FunctionLevelVisitor<'_, 'a> {
             }
             _ => unreachable!("shape checked above"),
         }
-        let name = own_name
-            .or_else(|| self.name_stack.last().cloned())
-            .unwrap_or_else(|| "anonymous".to_string());
+        // The enclosing path names the function. A function expression's own
+        // name is the fallback for a function with no named container at all
+        // (`register(function handler() {})`); when a path exists it already
+        // identifies the position, and appending the label too would only add
+        // a second name for the same thing.
+        let name = if self.name_path.is_empty() {
+            own_name.unwrap_or_else(|| "anonymous".to_string())
+        } else {
+            self.name_path.join(".")
+        };
         let top_index = self.top_index;
         let mut insertions = std::mem::take(&mut self.insertions);
         self.transform
@@ -838,16 +893,48 @@ impl<'a> VisitMut<'a> for FunctionLevelVisitor<'_, 'a> {
     }
 
     fn visit_variable_declarator(&mut self, declarator: &mut oxc_ast::ast::VariableDeclarator<'a>) {
-        let pushed = if let BindingPattern::BindingIdentifier(id) = &declarator.id {
-            self.name_stack.push(id.name.to_string());
-            true
-        } else {
-            false
+        let segment = match &declarator.id {
+            BindingPattern::BindingIdentifier(id) => identifier_segment(&id.name),
+            _ => None,
         };
-        walk_mut::walk_variable_declarator(self, declarator);
-        if pushed {
-            self.name_stack.pop();
-        }
+        self.with_segment(segment, |visitor| {
+            walk_mut::walk_variable_declarator(visitor, declarator);
+        });
+    }
+
+    /// `class Api { save = async () => {} }` names its field `Api.save`.
+    fn visit_class(&mut self, class: &mut oxc_ast::ast::Class<'a>) {
+        let segment = class
+            .id
+            .as_ref()
+            .and_then(|id| identifier_segment(&id.name));
+        self.with_segment(segment, |visitor| {
+            walk_mut::walk_class(visitor, class);
+        });
+    }
+
+    fn visit_property_definition(
+        &mut self,
+        property: &mut oxc_ast::ast::PropertyDefinition<'a>,
+    ) {
+        let segment = static_key_segment(&property.key);
+        self.with_segment(segment, |visitor| {
+            walk_mut::walk_property_definition(visitor, property);
+        });
+    }
+
+    fn visit_method_definition(&mut self, method: &mut oxc_ast::ast::MethodDefinition<'a>) {
+        let segment = static_key_segment(&method.key);
+        self.with_segment(segment, |visitor| {
+            walk_mut::walk_method_definition(visitor, method);
+        });
+    }
+
+    fn visit_accessor_property(&mut self, property: &mut oxc_ast::ast::AccessorProperty<'a>) {
+        let segment = static_key_segment(&property.key);
+        self.with_segment(segment, |visitor| {
+            walk_mut::walk_accessor_property(visitor, property);
+        });
     }
 
     fn visit_expression(&mut self, expression: &mut Expression<'a>) {
@@ -861,22 +948,38 @@ impl<'a> VisitMut<'a> for FunctionLevelVisitor<'_, 'a> {
     /// which the directive plugin does not visit — only plain
     /// function-valued properties (`{ foo: function () {} }`) are eligible.
     fn visit_object_property(&mut self, property: &mut oxc_ast::ast::ObjectProperty<'a>) {
-        if property.method || property.kind != oxc_ast::ast::PropertyKind::Init {
-            walk_mut::walk_property_key(self, &mut property.key);
+        let segment = static_key_segment(&property.key);
+        // A computed key is an expression in the enclosing scope, not inside
+        // the property, so it is walked before the segment is pushed.
+        walk_mut::walk_property_key(self, &mut property.key);
+        let is_method = property.method || property.kind != oxc_ast::ast::PropertyKind::Init;
+        self.with_segment(segment, |visitor| {
+            if !is_method {
+                visitor.visit_expression(&mut property.value);
+                return;
+            }
+            // A method's own body is never transformed, so descend past it
+            // instead of offering it to `visit_expression`.
             match &mut property.value {
                 Expression::FunctionExpression(function) => {
                     walk_mut::walk_function(
-                        self,
+                        visitor,
                         function,
                         oxc_syntax::scope::ScopeFlags::Function,
                     );
                 }
-                other => walk_mut::walk_expression(self, other),
+                other => walk_mut::walk_expression(visitor, other),
             }
-            return;
-        }
-        walk_mut::walk_object_property(self, property);
+        });
     }
+}
+
+/// The identifier-shaped name of a static property key, if it has one.
+/// Computed keys and string keys that are not identifiers contribute no path
+/// segment.
+fn static_key_segment(key: &oxc_ast::ast::PropertyKey<'_>) -> Option<String> {
+    key.static_name()
+        .and_then(|name| identifier_segment(name.as_ref()))
 }
 
 // --- Top-level binding tracing (module-level path) ----------------------------

--- a/packages/compiler/src/directives/transform.rs
+++ b/packages/compiler/src/directives/transform.rs
@@ -472,9 +472,12 @@ impl<'a> DirectivesTransform<'a> {
                         &export.declaration,
                         ExportDefaultDeclarationKind::FunctionDeclaration(function)
                             if function.id.is_none()
-                    ) || export.declaration.as_expression().is_some_and(|expression| {
-                        !matches!(unwrap_expression(expression), Expression::Identifier(_))
-                    }) =>
+                    ) || export
+                        .declaration
+                        .as_expression()
+                        .is_some_and(|expression| {
+                            !matches!(unwrap_expression(expression), Expression::Identifier(_))
+                        }) =>
                 {
                     let mut export = export;
                     let placeholder =
@@ -777,9 +780,9 @@ struct FunctionLevelVisitor<'ctx, 'a> {
     /// Enclosing binding names, outermost first: the dotted path that names
     /// an extracted function. Every named container on the way down
     /// contributes a segment (variable declarators, object property keys,
-    /// class names, class member keys), so two same-named functions in
-    /// sibling scopes get distinct names instead of sharing one and being
-    /// told apart by a positional ordinal.
+    /// class names, class member keys, and named functions), so two
+    /// same-named functions in sibling scopes get distinct names instead of
+    /// sharing one and being told apart by a positional ordinal.
     name_path: Vec<String>,
 }
 
@@ -815,6 +818,21 @@ impl<'a> FunctionLevelVisitor<'_, 'a> {
         if pushed {
             self.name_path.pop();
         }
+    }
+
+    /// The segment a function's own name contributes. A named function is a
+    /// named container like any other, so `register(function handler() {})`
+    /// inside `wire` is `wire.handler` and stays apart from its siblings by
+    /// name rather than by ordinal. The name is skipped when it repeats the
+    /// segment already on the path: a bubbled declaration is
+    /// `const makeA = function makeA() {}`, and `const submit = function
+    /// submit() {}` is the same binding named twice.
+    fn own_name_segment(&self, own_name: Option<&str>) -> Option<String> {
+        let segment = identifier_segment(own_name?)?;
+        if self.name_path.last() == Some(&segment) {
+            return None;
+        }
+        Some(segment)
     }
 
     fn body_has_directive(&self, body: &oxc_ast::ast::FunctionBody<'a>) -> bool {
@@ -865,15 +883,17 @@ impl<'a> FunctionLevelVisitor<'_, 'a> {
             }
             _ => unreachable!("shape checked above"),
         }
-        // The enclosing path names the function. A function expression's own
-        // name is the fallback for a function with no named container at all
-        // (`register(function handler() {})`); when a path exists it already
-        // identifies the position, and appending the label too would only add
-        // a second name for the same thing.
-        let name = if self.name_path.is_empty() {
-            own_name.unwrap_or_else(|| "anonymous".to_string())
+        // The enclosing path plus the function's own name, if it adds one.
+        // `anonymous` only when nothing on the way down was named at all.
+        let own_segment = self.own_name_segment(own_name.as_deref());
+        let mut segments: Vec<&str> = self.name_path.iter().map(String::as_str).collect();
+        if let Some(own_segment) = own_segment.as_deref() {
+            segments.push(own_segment);
+        }
+        let name = if segments.is_empty() {
+            "anonymous".to_string()
         } else {
-            self.name_path.join(".")
+            segments.join(".")
         };
         let top_index = self.top_index;
         let mut insertions = std::mem::take(&mut self.insertions);
@@ -902,6 +922,23 @@ impl<'a> VisitMut<'a> for FunctionLevelVisitor<'_, 'a> {
         });
     }
 
+    /// A named function that is not itself extracted names what is inside it.
+    /// Top-level declarations are bubbled into `const name = function name`
+    /// and contribute their segment through the declarator; a declaration
+    /// nested in another function is not bubbled, so this is the only place
+    /// it can contribute one. Marked functions never reach here because
+    /// `visit_expression` replaces them before walking in.
+    fn visit_function(
+        &mut self,
+        function: &mut oxc_ast::ast::Function<'a>,
+        flags: oxc_syntax::scope::ScopeFlags,
+    ) {
+        let segment = self.own_name_segment(function.id.as_ref().map(|id| id.name.as_str()));
+        self.with_segment(segment, |visitor| {
+            walk_mut::walk_function(visitor, function, flags);
+        });
+    }
+
     /// `class Api { save = async () => {} }` names its field `Api.save`.
     fn visit_class(&mut self, class: &mut oxc_ast::ast::Class<'a>) {
         let segment = class
@@ -913,10 +950,7 @@ impl<'a> VisitMut<'a> for FunctionLevelVisitor<'_, 'a> {
         });
     }
 
-    fn visit_property_definition(
-        &mut self,
-        property: &mut oxc_ast::ast::PropertyDefinition<'a>,
-    ) {
+    fn visit_property_definition(&mut self, property: &mut oxc_ast::ast::PropertyDefinition<'a>) {
         let segment = static_key_segment(&property.key);
         self.with_segment(segment, |visitor| {
             walk_mut::walk_property_definition(visitor, property);

--- a/packages/compiler/types.d.ts
+++ b/packages/compiler/types.d.ts
@@ -138,8 +138,12 @@ export interface TransformDirectivesOptions {
 
 /** One extracted server function, for building a bundler manifest. */
 export interface ServerFunctionMeta {
-  /** The wire ID (`<hash>-<count>[-<name>]`). */
+  /** The wire ID (`<name>-<hash>[-<ordinal>]`). */
   id: string;
+  /**
+   * The dotted binding path that names the function, such as
+   * `handlers.save`. `anonymous` when no enclosing binding applies.
+   */
   name: string;
   /** Export names bound to this function (module-level directives only). */
   exports: string[];


### PR DESCRIPTION
Server-function ids used the nearest binding name alone, so two functions with the same name in one file were told apart by a positional ordinal assigned in traversal order. Appending a third same-named function renumbered the other two and re-pointed addresses a deployed client was still holding, which is the mis-dispatch #3109 set out to remove.

- The descriptive name is now the function's dotted binding path, so `makeA.submit` and `makeB.submit` are two names instead of one name and a counter.
- Object property keys, class names, and class member keys contribute path segments too, so `handlers.save` and `Api.refresh` name themselves.
- A key that is not identifier-shaped contributes no segment, keeping `-` and `.` out of the name so `id.split("-")[1]` stays the file hash.
- The ordinal remains only for two functions that share one path, such as two inline callbacks in the same scope.

Ids move once for nested server functions. The frozen Babel reference files for the three affected fixtures were edited by hand, id literals only.