### PR TITLE
fix(compiler): reject `this` and `arguments` captures in server functions

### DIFF
--- a/.changeset/reject-this-arguments-server-function-capture.md
+++ b/.changeset/reject-this-arguments-server-function-capture.md
@@ -1,0 +1,8 @@
+---
+"@solidjs/compiler": patch
+---
+
+An arrow marked `"use server"` that reads `this` or `arguments` is now a compile error instead of silently breaking at runtime.
+
+- The arrow is extracted to module top level, where `this` is undefined and `arguments` does not exist.
+- A marked `function` is unaffected, and so is any `function` or class nested inside the server function.

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -151,6 +151,8 @@ result.code;
 result.functions; // [{ id, name, exports }] for manifest building
 ```
 
+A function-level `"use server"` function is extracted out of its lexical position, so it may only reference its own parameters and locals, module top-level bindings, and globals. Capturing anything else is a compile error. That includes `this` and `arguments` in a marked arrow, which an arrow takes from the function it was written in. Use a `function` if the server function needs its own `this` or `arguments`.
+
 The runtime module defaults to `@solidjs/web/server-functions`. Function IDs use `xxhash32(root-relative path)-<count>` (name-suffixed with `env: "development"`). There are also experimental `transformLazy` and `transformRefresh` passes.
 
 ## Rust compiler core

--- a/packages/compiler/__tests__/directives-validation.test.js
+++ b/packages/compiler/__tests__/directives-validation.test.js
@@ -131,6 +131,79 @@ describe('"use server" closure-capture validation', () => {
       ].join("\n");
       expect(() => compile(code)).toThrow(/`conn` is declared in an enclosing function/);
     });
+
+    it("rejects an arrow capturing `this`", () => {
+      const code = [
+        "class Box {",
+        "  make() {",
+        "    return async () => {",
+        '      "use server";',
+        "      return this.value;",
+        "    };",
+        "  }",
+        "}",
+        "export { Box };"
+      ].join("\n");
+      expect(() => compile(code)).toThrow(
+        /server functions cannot capture `this` from an enclosing function/
+      );
+    });
+
+    it("rejects `this` in a class field initializer", () => {
+      const code = [
+        "export class Service {",
+        "  refresh = async () => {",
+        '    "use server";',
+        "    return this.id;",
+        "  };",
+        "}"
+      ].join("\n");
+      expect(() => compile(code)).toThrow(/cannot capture `this`/);
+    });
+
+    it("rejects `this` read from a nested arrow", () => {
+      const code = [
+        "class Box {",
+        "  make() {",
+        "    return async () => {",
+        '      "use server";',
+        "      return [1, 2].map(() => this.value);",
+        "    };",
+        "  }",
+        "}",
+        "export { Box };"
+      ].join("\n");
+      expect(() => compile(code)).toThrow(/cannot capture `this`/);
+    });
+
+    it("rejects an arrow capturing `arguments`", () => {
+      const code = [
+        "export function outer() {",
+        "  return async () => {",
+        '    "use server";',
+        "    return arguments.length;",
+        "  };",
+        "}"
+      ].join("\n");
+      expect(() => compile(code)).toThrow(
+        /server functions cannot capture `arguments` from an enclosing function/
+      );
+    });
+
+    it("rejects `this` captures in client mode too", () => {
+      const code = [
+        "class Box {",
+        "  make() {",
+        "    return async () => {",
+        '      "use server";',
+        "      return this.value;",
+        "    };",
+        "  }",
+        "}",
+        "export { Box };"
+      ].join("\n");
+      expect(() => compile(code, { mode: "client" })).toThrow(/cannot capture `this`/);
+    });
   });
 
   describe("allowed", () => {
@@ -181,6 +254,43 @@ describe('"use server" closure-capture validation', () => {
         '  "use server";',
         "  console.log(process.env.NODE_ENV);",
         "  return globalThis.crypto.randomUUID();",
+        "};"
+      ].join("\n");
+      expect(compile(code).valid).toBe(true);
+    });
+
+    it("allows `this` and `arguments` in a marked function expression", () => {
+      // A `function` carries its own `this` and `arguments` with it, so
+      // extraction does not change what they mean.
+      const code = [
+        "export function outer() {",
+        "  return function () {",
+        '    "use server";',
+        "    return [this, arguments.length];",
+        "  };",
+        "}"
+      ].join("\n");
+      expect(compile(code).valid).toBe(true);
+    });
+
+    it("allows `this` inside a function or class nested in the server function", () => {
+      const code = [
+        "export const go = async () => {",
+        '  "use server";',
+        "  class Row { label() { return this.name; } }",
+        "  const build = function () { return this.kind; };",
+        "  return { Row, build, m() { return this.own; } };",
+        "};"
+      ].join("\n");
+      expect(compile(code).valid).toBe(true);
+    });
+
+    it("allows a declared binding named `arguments`", () => {
+      const code = [
+        "export const go = async (...args) => {",
+        '  "use server";',
+        "  const argumentsList = args;",
+        "  return argumentsList.length;",
         "};"
       ].join("\n");
       expect(compile(code).valid).toBe(true);

--- a/packages/compiler/src/directives/validate.rs
+++ b/packages/compiler/src/directives/validate.rs
@@ -17,6 +17,14 @@
 //!   `function`/`class`),
 //! - true globals / unresolved references.
 //!
+//! `this` and `arguments` are the same problem without a declaration to
+//! point at. An arrow takes both from its enclosing function, so an arrow
+//! marked `"use server"` reads them from wherever it lands. Hoisted to
+//! module top level that is `undefined` for `this` and nothing at all for
+//! `arguments`, so both are rejected too. A marked `function` binds its own,
+//! and so does any `function` or class nested inside the server function, so
+//! those are left alone.
+//!
 //! Module-level directives are unaffected (the whole module runs on the
 //! server, so its closures are intact); the caller skips this pass for them.
 //! Eligibility mirrors the transform exactly: functions the transform would
@@ -51,6 +59,7 @@ pub(crate) fn validate_captures(
         scoping: semantic.scoping(),
         directive,
         server_scope: None,
+        binds_own_this: false,
         error: None,
     };
     validator.visit_program(program);
@@ -61,28 +70,80 @@ pub(crate) fn validate_captures(
     }
 }
 
-struct CaptureError {
-    name: String,
-    reference_span: Span,
-    declaration_span: Span,
-    declared_in_function: bool,
+enum CaptureError {
+    /// A named binding from an intermediate enclosing scope.
+    Binding {
+        name: String,
+        reference_span: Span,
+        declaration_span: Span,
+        declared_in_function: bool,
+    },
+    /// `this` or `arguments`, taken from an enclosing function because the
+    /// server function is an arrow. There is no declaration to point at.
+    Implicit { name: Implicit, span: Span },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Implicit {
+    This,
+    Arguments,
+}
+
+impl Implicit {
+    fn name(self) -> &'static str {
+        match self {
+            Implicit::This => "this",
+            Implicit::Arguments => "arguments",
+        }
+    }
+
+    /// What the reference resolves to once the function sits at module top
+    /// level, and the way out.
+    fn explanation(self) -> &'static str {
+        match self {
+            Implicit::This => {
+                "where `this` is undefined. Pass the value in as a parameter instead"
+            }
+            Implicit::Arguments => {
+                "where `arguments` does not exist. Declare a rest parameter instead"
+            }
+        }
+    }
 }
 
 fn format_error(error: CaptureError, code: &str, filename: &str) -> String {
-    let (line, column) = line_column(code, error.reference_span.start);
-    let (decl_line, decl_column) = line_column(code, error.declaration_span.start);
-    let scope_kind = if error.declared_in_function {
-        "function"
-    } else {
-        "block"
-    };
-    format!(
-        "{filename}:{line}:{column}: server functions cannot capture non-top-level variables: \
-         `{name}` is declared in an enclosing {scope_kind} (at {filename}:{decl_line}:{decl_column}). \
-         Server functions may only reference their own parameters and locals, module top-level \
-         bindings, imports, and globals.",
-        name = error.name,
-    )
+    match error {
+        CaptureError::Binding {
+            name,
+            reference_span,
+            declaration_span,
+            declared_in_function,
+        } => {
+            let (line, column) = line_column(code, reference_span.start);
+            let (decl_line, decl_column) = line_column(code, declaration_span.start);
+            let scope_kind = if declared_in_function {
+                "function"
+            } else {
+                "block"
+            };
+            format!(
+                "{filename}:{line}:{column}: server functions cannot capture non-top-level variables: \
+                 `{name}` is declared in an enclosing {scope_kind} (at {filename}:{decl_line}:{decl_column}). \
+                 Server functions may only reference their own parameters and locals, module top-level \
+                 bindings, imports, and globals.",
+            )
+        }
+        CaptureError::Implicit { name, span } => {
+            let (line, column) = line_column(code, span.start);
+            format!(
+                "{filename}:{line}:{column}: server functions cannot capture `{implicit}` from an \
+                 enclosing function: this one is an arrow, so it is extracted to module top level \
+                 {explanation}.",
+                implicit = name.name(),
+                explanation = name.explanation(),
+            )
+        }
+    }
 }
 
 /// 1-based line/column for a byte offset.
@@ -104,6 +165,11 @@ struct CaptureValidator<'s> {
     /// nested inside it are not extracted by the transform, so no stack is
     /// needed — the outermost eligible function wins.
     server_scope: Option<ScopeId>,
+    /// Whether `this` and `arguments` at the current position are bound by a
+    /// `function` or class inside the server function. False means they come
+    /// from outside it and would not survive extraction. Only meaningful
+    /// while `server_scope` is set.
+    binds_own_this: bool,
     error: Option<CaptureError>,
 }
 
@@ -114,7 +180,12 @@ impl CaptureValidator<'_> {
             .any(|directive| directive.expression.value == self.directive)
     }
 
-    fn enter_server_scope(&mut self, scope: Option<ScopeId>, walk: impl FnOnce(&mut Self)) {
+    fn enter_server_scope(
+        &mut self,
+        scope: Option<ScopeId>,
+        binds_own_this: bool,
+        walk: impl FnOnce(&mut Self),
+    ) {
         if self.server_scope.is_some() || scope.is_none() {
             // Already validating an enclosing server function (nested
             // directives are ignored by the transform), or semantic did not
@@ -123,8 +194,27 @@ impl CaptureValidator<'_> {
             return;
         }
         self.server_scope = scope;
+        self.binds_own_this = binds_own_this;
         walk(self);
         self.server_scope = None;
+        self.binds_own_this = false;
+    }
+
+    /// Walks a subtree that binds its own `this` and `arguments`, restoring
+    /// the previous state afterwards. Nested arrows within it keep inheriting
+    /// from it, which is exactly the flag staying true.
+    fn with_own_this(&mut self, walk: impl FnOnce(&mut Self)) {
+        let previous = std::mem::replace(&mut self.binds_own_this, true);
+        walk(self);
+        self.binds_own_this = previous;
+    }
+
+    /// Reports `this` or `arguments` read from outside the server function.
+    fn check_implicit(&mut self, name: Implicit, span: Span) {
+        if self.error.is_some() || self.server_scope.is_none() || self.binds_own_this {
+            return;
+        }
+        self.error = Some(CaptureError::Implicit { name, span });
     }
 
     fn check_reference(&mut self, identifier: &oxc_ast::ast::IdentifierReference<'_>) {
@@ -144,7 +234,12 @@ impl CaptureValidator<'_> {
             return;
         }
         let Some(symbol_id) = reference.symbol_id() else {
-            // Unresolved: a true global.
+            // Unresolved: a true global, or the implicit `arguments` of an
+            // enclosing function. A declared binding named `arguments` has a
+            // symbol and falls through to the scope walk below.
+            if identifier.name == "arguments" {
+                self.check_implicit(Implicit::Arguments, identifier.span);
+            }
             return;
         };
         let declaration_scope = self.scoping.symbol_scope_id(symbol_id);
@@ -166,7 +261,7 @@ impl CaptureValidator<'_> {
                 None => break,
             }
         }
-        self.error = Some(CaptureError {
+        self.error = Some(CaptureError::Binding {
             name: identifier.name.to_string(),
             reference_span: identifier.span,
             declaration_span: self.scoping.symbol_span(symbol_id),
@@ -197,12 +292,15 @@ impl<'a> Visit<'a> for CaptureValidator<'_> {
             _ => false,
         };
         if marked {
-            let scope = match expression {
-                Expression::ArrowFunctionExpression(arrow) => arrow.scope_id.get(),
-                Expression::FunctionExpression(function) => function.scope_id.get(),
+            // A marked `function` binds its own `this`/`arguments` and takes
+            // them with it; a marked arrow reads them from where it was
+            // written, which extraction leaves behind.
+            let (scope, binds_own_this) = match expression {
+                Expression::ArrowFunctionExpression(arrow) => (arrow.scope_id.get(), false),
+                Expression::FunctionExpression(function) => (function.scope_id.get(), true),
                 _ => unreachable!("shape checked above"),
             };
-            self.enter_server_scope(scope, |validator| {
+            self.enter_server_scope(scope, binds_own_this, |validator| {
                 walk::walk_expression(validator, expression);
             });
             return;
@@ -226,12 +324,28 @@ impl<'a> Visit<'a> for CaptureValidator<'_> {
                 .as_ref()
                 .is_some_and(|body| self.body_has_directive(body));
         if marked {
-            self.enter_server_scope(function.scope_id.get(), |validator| {
+            self.enter_server_scope(function.scope_id.get(), true, |validator| {
                 walk::walk_function(validator, function, flags);
             });
             return;
         }
-        walk::walk_function(self, function, flags);
+        // Any other `function` reached from inside a server function binds
+        // its own `this` and `arguments` for everything below it.
+        self.with_own_this(|validator| {
+            walk::walk_function(validator, function, flags);
+        });
+    }
+
+    /// A class body rebinds `this` for its methods, field initializers, and
+    /// static blocks, so nothing inside one is an escaping capture.
+    fn visit_class(&mut self, class: &oxc_ast::ast::Class<'a>) {
+        self.with_own_this(|validator| {
+            walk::walk_class(validator, class);
+        });
+    }
+
+    fn visit_this_expression(&mut self, this: &oxc_ast::ast::ThisExpression) {
+        self.check_implicit(Implicit::This, this.span);
     }
 
     /// Same carve-out as the transform: `{ foo() {} }` object methods (and
@@ -242,7 +356,13 @@ impl<'a> Visit<'a> for CaptureValidator<'_> {
             self.visit_property_key(&property.key);
             match &property.value {
                 Expression::FunctionExpression(function) => {
-                    walk::walk_function(self, function, oxc_syntax::scope::ScopeFlags::Function);
+                    self.with_own_this(|validator| {
+                        walk::walk_function(
+                            validator,
+                            function,
+                            oxc_syntax::scope::ScopeFlags::Function,
+                        );
+                    });
                 }
                 other => self.visit_expression(other),
             }


### PR DESCRIPTION

An arrow takes `this` and `arguments` from the function it was written in. A function-level `"use server"` arrow is extracted to module top level, where `this` is undefined and `arguments` does not exist, so both reads broke at runtime with no compile-time complaint. Every other capture from an intermediate scope was already rejected; these two slipped through because the validator only inspected identifier references with a declaration to point at.

- A marked arrow reading `this` or `arguments`, directly or from a nested arrow, is now an error naming the reference and what it would resolve to.
- A marked `function` binds its own, so it is unaffected.
- Any `function`, class, or object method nested inside a server function rebinds both, so code inside those is unaffected too.
- A declared binding named `arguments` still goes through the ordinary scope check.