### PR TITLE
fix(compiler): reject a server directive on a method

### DIFF
--- a/.changeset/reject-server-directive-on-methods.md
+++ b/.changeset/reject-server-directive-on-methods.md
@@ -1,0 +1,9 @@
+---
+"@solidjs/compiler": patch
+---
+
+A `"use server"` directive on a method, getter, or setter is now a compile error instead of being silently ignored.
+
+- Those forms are never extracted, so the body kept running wherever it was called, browser included.
+- Covers object literal methods and accessors, and class methods, accessors, and constructors.
+- Assign a function to a property instead, which the pass does extract.

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -153,6 +153,8 @@ result.functions; // [{ id, name, exports }] for manifest building
 
 A function-level `"use server"` function is extracted out of its lexical position, so it may only reference its own parameters and locals, module top-level bindings, and globals. Capturing anything else is a compile error. That includes `this` and `arguments` in a marked arrow, which an arrow takes from the function it was written in. Use a `function` if the server function needs its own `this` or `arguments`.
 
+A function-level directive only works where the pass can extract the function: a function declaration, a function expression, or an arrow with a block body. Methods, getters, and setters are never extracted, so a directive on one is a compile error rather than a directive that silently does nothing. Assign a function to a property instead.
+
 The runtime module defaults to `@solidjs/web/server-functions`. Function IDs use `xxhash32(root-relative path)-<count>` (name-suffixed with `env: "development"`). There are also experimental `transformLazy` and `transformRefresh` passes.
 
 ## Rust compiler core

--- a/packages/compiler/__tests__/directives-validation.test.js
+++ b/packages/compiler/__tests__/directives-validation.test.js
@@ -204,6 +204,83 @@ describe('"use server" closure-capture validation', () => {
       ].join("\n");
       expect(() => compile(code, { mode: "client" })).toThrow(/cannot capture `this`/);
     });
+
+    it("rejects the directive on an object method", () => {
+      const code = [
+        "export function make() {",
+        "  return {",
+        "    async go() {",
+        '      "use server";',
+        "      return 1;",
+        "    }",
+        "  };",
+        "}"
+      ].join("\n");
+      expect(() => compile(code)).toThrow(
+        /a "use server" directive has no effect on a method: `go` is not extracted/
+      );
+    });
+
+    it("rejects the directive on an object accessor", () => {
+      const code = [
+        "export function make() {",
+        '  return { get x() { "use server"; return 1; } };',
+        "}"
+      ].join("\n");
+      expect(() => compile(code)).toThrow(/has no effect on a method: `x`/);
+    });
+
+    it("rejects the directive on a class method", () => {
+      const code = [
+        "export class Service {",
+        "  async go() {",
+        '    "use server";',
+        "    return 1;",
+        "  }",
+        "}"
+      ].join("\n");
+      expect(() => compile(code)).toThrow(/has no effect on a method: `go`/);
+    });
+
+    it("rejects the directive on a static class method", () => {
+      const code = [
+        "export class Service {",
+        '  static async go() { "use server"; return 1; }',
+        "}"
+      ].join("\n");
+      expect(() => compile(code)).toThrow(/has no effect on a method: `go`/);
+    });
+
+    it("names a computed method key generically", () => {
+      const code = [
+        'const key = "go";',
+        "export function make() {",
+        '  return { async [key]() { "use server"; return 1; } };',
+        "}"
+      ].join("\n");
+      expect(() => compile(code)).toThrow(
+        /has no effect on a method: this method is not extracted/
+      );
+    });
+
+    it("rejects method directives in client mode too", () => {
+      const code = ["export class Service {", '  async go() { "use server"; return 1; }', "}"].join(
+        "\n"
+      );
+      expect(() => compile(code, { mode: "client" })).toThrow(/has no effect on a method/);
+    });
+
+    it("reports the method's position", () => {
+      const code = [
+        "export class Service {",
+        "  async go() {",
+        '    "use server";',
+        "    return 1;",
+        "  }",
+        "}"
+      ].join("\n");
+      expect(() => compile(code)).toThrow(/\/project\/src\/module\.ts:2:3: /);
+    });
   });
 
   describe("allowed", () => {
@@ -339,21 +416,44 @@ describe('"use server" closure-capture validation', () => {
       expect(result.functions).toHaveLength(1);
     });
 
-    it("ignores object methods (never extracted by the transform)", () => {
+    it("allows a function assigned to a property or class field", () => {
+      // The extractable spelling of what a method cannot do.
+      const code = [
+        "export function make() {",
+        '  return { go: async () => { "use server"; return 1; } };',
+        "}",
+        "export class Service {",
+        '  refresh = async () => { "use server"; return 2; };',
+        "}"
+      ].join("\n");
+      expect(compile(code).functions).toHaveLength(2);
+    });
+
+    it("allows a method directive inside an already-extracted server function", () => {
+      // The whole body ships to the server, so the inner directive changes
+      // nothing and must not be reported.
+      const code = [
+        "export const outer = async () => {",
+        '  "use server";',
+        '  return { m() { "use server"; return 1; } };',
+        "};"
+      ].join("\n");
+      expect(compile(code).functions).toHaveLength(1);
+    });
+
+    it("allows object methods without the directive", () => {
+      // Methods are never extracted, so their ordinary closures are fine.
       const code = [
         "export function factory() {",
         "  const state = 1;",
-        "  return {",
-        "    read() {",
-        '      "use server";',
-        "      return state;",
-        "    }",
-        "  };",
-        "}"
+        "  return { read() { return state; } };",
+        "}",
+        "export const ping = async () => {",
+        '  "use server";',
+        "  return 1;",
+        "};"
       ].join("\n");
-      // Not extracted, so no capture error and nothing transformed.
-      const result = compile(code);
-      expect(result.valid).toBe(false);
+      expect(compile(code).valid).toBe(true);
     });
   });
 });

--- a/packages/compiler/src/directives/validate.rs
+++ b/packages/compiler/src/directives/validate.rs
@@ -25,12 +25,16 @@
 //! and so does any `function` or class nested inside the server function, so
 //! those are left alone.
 //!
+//! The pass also rejects the directive in a position the transform never
+//! extracts. A method, a getter, or a setter keeps its directive and keeps
+//! running wherever it is called, browser included, so a directive there is
+//! silently doing nothing. That is reported rather than ignored.
+//!
 //! Module-level directives are unaffected (the whole module runs on the
 //! server, so its closures are intact); the caller skips this pass for them.
-//! Eligibility mirrors the transform exactly: functions the transform would
-//! never extract (object/class methods, getters/setters) are not validated,
-//! and directives nested inside an already-extracted server function are
-//! ignored just like the transform ignores them.
+//! Eligibility otherwise mirrors the transform exactly, and directives
+//! nested inside an already-extracted server function are ignored just like
+//! the transform ignores them.
 
 use oxc_ast::ast::{Expression, Program, PropertyKind};
 use oxc_ast_visit::{Visit, walk};
@@ -65,7 +69,7 @@ pub(crate) fn validate_captures(
     validator.visit_program(program);
 
     match validator.error {
-        Some(error) => Err(format_error(error, code, filename)),
+        Some(error) => Err(format_error(error, code, filename, directive)),
         None => Ok(()),
     }
 }
@@ -81,6 +85,9 @@ enum CaptureError {
     /// `this` or `arguments`, taken from an enclosing function because the
     /// server function is an arrow. There is no declaration to point at.
     Implicit { name: Implicit, span: Span },
+    /// The directive sits on a method, getter, or setter, which the
+    /// transform never extracts.
+    Method { name: String, span: Span },
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -111,7 +118,7 @@ impl Implicit {
     }
 }
 
-fn format_error(error: CaptureError, code: &str, filename: &str) -> String {
+fn format_error(error: CaptureError, code: &str, filename: &str, directive: &str) -> String {
     match error {
         CaptureError::Binding {
             name,
@@ -141,6 +148,14 @@ fn format_error(error: CaptureError, code: &str, filename: &str) -> String {
                  {explanation}.",
                 implicit = name.name(),
                 explanation = name.explanation(),
+            )
+        }
+        CaptureError::Method { name, span } => {
+            let (line, column) = line_column(code, span.start);
+            format!(
+                "{filename}:{line}:{column}: a \"{directive}\" directive has no effect on a method: \
+                 {name} is not extracted, so its body would still run wherever it is called, \
+                 including in the browser. Assign a function to a property instead.",
             )
         }
     }
@@ -215,6 +230,28 @@ impl CaptureValidator<'_> {
             return;
         }
         self.error = Some(CaptureError::Implicit { name, span });
+    }
+
+    /// Reports a directive sitting on a method, getter, or setter. Skipped
+    /// inside an already-extracted server function: that whole body ships to
+    /// the server, so a directive within it changes nothing.
+    fn check_method_directive(
+        &mut self,
+        body: Option<&oxc_ast::ast::FunctionBody<'_>>,
+        key: &oxc_ast::ast::PropertyKey<'_>,
+        span: Span,
+    ) {
+        if self.error.is_some() || self.server_scope.is_some() {
+            return;
+        }
+        if !body.is_some_and(|body| self.body_has_directive(body)) {
+            return;
+        }
+        let name = key
+            .static_name()
+            .map(|name| format!("`{name}`"))
+            .unwrap_or_else(|| "this method".to_string());
+        self.error = Some(CaptureError::Method { name, span });
     }
 
     fn check_reference(&mut self, identifier: &oxc_ast::ast::IdentifierReference<'_>) {
@@ -348,11 +385,21 @@ impl<'a> Visit<'a> for CaptureValidator<'_> {
         self.check_implicit(Implicit::This, this.span);
     }
 
-    /// Same carve-out as the transform: `{ foo() {} }` object methods (and
-    /// getters/setters) are never extracted, so their directives are not
-    /// validated — but nested eligible functions inside them still are.
+    /// `{ foo() {} }` object methods and `{ get x() {} }` accessors are
+    /// never extracted by the transform, so a directive on one is reported.
+    /// Nested eligible functions inside them are still validated.
     fn visit_object_property(&mut self, property: &oxc_ast::ast::ObjectProperty<'a>) {
         if property.method || property.kind != PropertyKind::Init {
+            if let Expression::FunctionExpression(function) = &property.value {
+                self.check_method_directive(
+                    function.body.as_deref(),
+                    &property.key,
+                    property.span,
+                );
+            }
+            if self.error.is_some() {
+                return;
+            }
             self.visit_property_key(&property.key);
             match &property.value {
                 Expression::FunctionExpression(function) => {
@@ -369,5 +416,15 @@ impl<'a> Visit<'a> for CaptureValidator<'_> {
             return;
         }
         walk::walk_object_property(self, property);
+    }
+
+    /// Class methods, constructors, getters and setters are never extracted
+    /// either.
+    fn visit_method_definition(&mut self, method: &oxc_ast::ast::MethodDefinition<'a>) {
+        self.check_method_directive(method.value.body.as_deref(), &method.key, method.span);
+        if self.error.is_some() {
+            return;
+        }
+        walk::walk_method_definition(self, method);
     }
 }


### PR DESCRIPTION
A method, getter, or setter is never extracted by the directive pass, so a `"use server"` directive on one did nothing at all. The directive string shipped verbatim in the client bundle and the body kept running wherever it was called, browser included. The pass reported `valid: false` and said nothing.

It is now a compile error naming the method and its position, with the extractable spelling as the fix.

- Covers object literal methods and accessors, and class methods, accessors, and constructors.
- Runs in both server and client mode.
- A directive on a method nested inside an already-extracted server function is still ignored, since that whole body ships to the server.
- A function assigned to a property or a class field is extracted as before and is unaffected.