### PR TITLE
fix(compiler): reject exports a "use server" module cannot register

### DIFF
--- a/.changeset/reject-unsupported-server-module-exports.md
+++ b/.changeset/reject-unsupported-server-module-exports.md
@@ -1,0 +1,9 @@
+---
+"@solidjs/compiler": patch
+---
+
+A module-level `"use server"` module that exports something other than a server function is now a compile error instead of producing a client build with the export missing.
+
+- Covers re-exports, `export *`, class and enum exports, destructured exports, and exports declared without an initializer.
+- The message names the export, its position, and what to do instead.
+- Type-only and `declare` exports are erased and stay allowed.

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -155,6 +155,8 @@ A function-level `"use server"` function is extracted out of its lexical positio
 
 A function-level directive only works where the pass can extract the function: a function declaration, a function expression, or an arrow with a block body. Methods, getters, and setters are never extracted, so a directive on one is a compile error rather than a directive that silently does nothing. Assign a function to a property instead.
 
+A module-level `"use server"` module can only export server functions. Its client build is rebuilt from those exports alone, so anything else would be missing from the browser bundle. Re-exports, `export *`, class and enum exports, destructured exports, and exports declared without an initializer are compile errors naming the export and its position. Type-only and `declare` exports are erased and are fine.
+
 The runtime module defaults to `@solidjs/web/server-functions`. Function IDs use `xxhash32(root-relative path)-<count>` (name-suffixed with `env: "development"`). There are also experimental `transformLazy` and `transformRefresh` passes.
 
 ## Rust compiler core

--- a/packages/compiler/__tests__/directives-module-exports.test.js
+++ b/packages/compiler/__tests__/directives-module-exports.test.js
@@ -1,0 +1,156 @@
+// Export validation for module-level `"use server"` directives.
+//
+// The client build of such a module is rebuilt from its traced server-function
+// exports alone, so an export the pass cannot trace would be missing from the
+// browser bundle while the server build still has it. Those shapes are
+// compile errors naming the export and its position.
+
+const path = require("path");
+
+const compilerDir = path.resolve(__dirname, "..");
+const { transformDirectives } = require(compilerDir);
+
+const RUNTIME = "@solidjs/web/server-functions";
+const ROOT = "/project";
+const FILENAME = `${ROOT}/src/module.ts`;
+
+function compile(code, overrides = {}) {
+  return transformDirectives(code, {
+    filename: FILENAME,
+    root: ROOT,
+    mode: "client",
+    env: "production",
+    directive: "use server",
+    register: { kind: "named", name: "registerServerReference", source: RUNTIME },
+    create: { kind: "named", name: "createServerReference", source: RUNTIME },
+    ...overrides
+  });
+}
+
+const source = (...lines) => ['"use server";', ...lines].join("\n");
+
+describe('module-level "use server" export validation', () => {
+  describe("errors", () => {
+    it("rejects a named re-export", () => {
+      const code = source('export { helper } from "./helper";', "export const a = async () => 1;");
+      expect(() => compile(code)).toThrow(
+        /`helper` is re-exported from "\.\/helper"/
+      );
+    });
+
+    it("rejects a star re-export", () => {
+      const code = source('export * from "./other";');
+      expect(() => compile(code)).toThrow(/`\*` is re-exported from "\.\/other"/);
+    });
+
+    it("rejects a namespace re-export", () => {
+      const code = source('export * as ns from "./other";');
+      expect(() => compile(code)).toThrow(/`ns` is re-exported from "\.\/other"/);
+    });
+
+    it("rejects a class export", () => {
+      const code = source("export class Foo {}", "export const b = async () => 2;");
+      expect(() => compile(code)).toThrow(/`Foo` is a class declaration/);
+    });
+
+    it("rejects a default class export", () => {
+      const code = source("export default class Foo {}");
+      expect(() => compile(code)).toThrow(/`default` is a class declaration/);
+    });
+
+    it("rejects an export declared without an initializer", () => {
+      const code = source("export let later;", "later = async () => 1;");
+      expect(() => compile(code)).toThrow(/`later` is declared without an initializer/);
+    });
+
+    it("rejects a destructured export", () => {
+      const code = source("export const { a, b } = make();");
+      expect(() => compile(code)).toThrow(/is bound by a destructuring pattern/);
+    });
+
+    it("rejects re-exporting an imported binding", () => {
+      const code = source('import { x } from "./y";', "export { x };");
+      expect(() => compile(code)).toThrow(
+        /`x` does not resolve to a top-level binding with an initializer/
+      );
+    });
+
+    it("rejects an enum export", () => {
+      const code = source("export enum Color { Red }", "export const c = async () => 3;");
+      expect(() => compile(code)).toThrow(/`Color` is an enum declaration/);
+    });
+
+    it("errors in server mode too", () => {
+      // The server build would keep the export, so allowing it there would
+      // mean the two builds disagree about the module's shape.
+      const code = source('export * from "./other";');
+      expect(() => compile(code, { mode: "server" })).toThrow(/is re-exported/);
+    });
+
+    it("reports the filename and the export's position", () => {
+      const code = source("", 'export * from "./other";');
+      expect(() => compile(code)).toThrow(/\/project\/src\/module\.ts:3:1: /);
+    });
+
+    it("names the configured directive", () => {
+      const code = ['"use backend";', 'export * from "./other";'].join("\n");
+      expect(() => compile(code, { directive: "use backend" })).toThrow(
+        /a "use backend" module can only export server functions/
+      );
+    });
+  });
+
+  describe("allowed", () => {
+    it("allows the ordinary export forms", () => {
+      const code = source(
+        'import { db } from "./db";',
+        "export async function getUser(id) { return db.find(id); }",
+        "export const remove = async id => db.remove(id);",
+        "const impl = async () => db.raw();",
+        "export { impl as runQuery };",
+        "export default getUser;"
+      );
+      expect(compile(code).functions).toHaveLength(3);
+    });
+
+    it("allows wrapped exports and anonymous defaults", () => {
+      const code = source(
+        'import { withDelay } from "./wrappers";',
+        "export const save = withDelay(async () => 1, 400);",
+        'export default withDelay(async () => "mocked", 400);'
+      );
+      expect(compile(code).functions).toHaveLength(2);
+    });
+
+    it("allows type-only exports, which are erased", () => {
+      const code = source(
+        'export type { Session } from "./session";',
+        "export type Id = string;",
+        "export interface Shape { x: number }",
+        "export const a = async () => 1;"
+      );
+      expect(compile(code).functions).toHaveLength(1);
+    });
+
+    it("allows ambient declarations, which are erased", () => {
+      const code = source("export declare const ambient: number;", "export const a = async () => 1;");
+      expect(compile(code).functions).toHaveLength(1);
+    });
+
+    it("leaves function-level directives alone", () => {
+      // Only the module-level form rebuilds the client module, so a file with
+      // a function-level directive keeps its other exports as written.
+      const code = [
+        "export function outer() {",
+        "  return async () => {",
+        '    "use server";',
+        "    return 1;",
+        "  };",
+        "}",
+        "export class Keep {}",
+        'export * from "./other";'
+      ].join("\n");
+      expect(compile(code).valid).toBe(true);
+    });
+  });
+});

--- a/packages/compiler/src/directives/mod.rs
+++ b/packages/compiler/src/directives/mod.rs
@@ -21,7 +21,7 @@ use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_parser::{ParseOptions, Parser};
 
 use crate::config::source_type_for_filename;
-use transform::{DirectivesTransform, Env, ImportDef, ImportKind, Mode};
+use transform::{DirectivesTransform, Env, ImportDef, ImportKind, Mode, UnsupportedExport};
 
 const DEFAULT_RUNTIME: &str = "@solidjs/web/server-functions";
 
@@ -147,12 +147,19 @@ pub fn transform_directives(
         &allocator,
         mode,
         env,
-        directive,
+        directive.clone(),
         hash,
         import_def(options.register.as_ref(), "registerServerReference"),
         import_def(options.create.as_ref(), "createServerReference"),
     );
-    pass.run(&mut program);
+    if let Err(unsupported) = pass.run(&mut program) {
+        return Err(Error::from_reason(format_unsupported_export(
+            unsupported,
+            &code,
+            filename,
+            &directive,
+        )));
+    }
 
     let valid = pass.valid;
     let functions = pass
@@ -208,6 +215,28 @@ pub fn transform_directives(
         valid,
         functions,
     })
+}
+
+/// The message for an export a module-level directive cannot register. The
+/// client build of such a module is rebuilt from its server-function exports
+/// alone, so an export the pass cannot trace would be missing from the
+/// browser bundle while the server build still has it. That used to compile
+/// and fail later as a missing-export error with nothing pointing back here.
+fn format_unsupported_export(
+    unsupported: UnsupportedExport,
+    code: &str,
+    filename: &str,
+    directive: &str,
+) -> String {
+    let (line, column) = validate::line_column(code, unsupported.span.start);
+    format!(
+        "{filename}:{line}:{column}: a \"{directive}\" module can only export server \
+         functions: `{name}` {clause}. The client build of this module is rebuilt from \
+         its server-function exports alone, so this export would be missing from it. {hint}",
+        name = unsupported.name,
+        clause = unsupported.reason.clause(),
+        hint = unsupported.reason.hint(),
+    )
 }
 
 fn import_def(option: Option<&DirectiveImportOption>, default_name: &str) -> ImportDef {

--- a/packages/compiler/src/directives/transform.rs
+++ b/packages/compiler/src/directives/transform.rs
@@ -21,7 +21,7 @@ use oxc_ast::ast::{
     ImportOrExportKind, Program, Statement, VariableDeclarationKind,
 };
 use oxc_ast_visit::{VisitMut, walk_mut};
-use oxc_span::Span;
+use oxc_span::{GetSpan, Span};
 
 use crate::shared::ast::{expression_to_argument, variable_statement};
 use crate::shared::ast_builder::AstBuilder;
@@ -138,7 +138,7 @@ impl<'a> DirectivesTransform<'a> {
         self.valid && self.count > 0 && !self.module_level_applied
     }
 
-    pub(crate) fn run(&mut self, program: &mut Program<'a>) {
+    pub(crate) fn run(&mut self, program: &mut Program<'a>) -> Result<(), UnsupportedExport> {
         self.scan_taken_names(program);
         let is_module_level = program
             .directives
@@ -149,7 +149,7 @@ impl<'a> DirectivesTransform<'a> {
             program
                 .directives
                 .retain(|directive| directive.expression.value != self.directive);
-            self.transform_module_level(program);
+            self.transform_module_level(program)?;
             self.valid = true;
         } else {
             self.transform_function_level(program);
@@ -162,6 +162,7 @@ impl<'a> DirectivesTransform<'a> {
         for import in self.prepended_imports.drain(..).rev() {
             program.body.insert(0, import);
         }
+        Ok(())
     }
 
     // --- Naming -------------------------------------------------------------
@@ -373,11 +374,15 @@ impl<'a> DirectivesTransform<'a> {
 
     // --- Module-level directive ------------------------------------------------
 
-    fn transform_module_level(&mut self, program: &mut Program<'a>) {
+    fn transform_module_level(&mut self, program: &mut Program<'a>) -> Result<(), UnsupportedExport> {
         self.bubble_top_level_functions(program);
 
         let bindings = collect_top_level_bindings(program);
         let exports = collect_exported_bindings(program, &bindings);
+        // The client build is rebuilt from the traced exports alone, so an
+        // export the tracer did not reach would simply be missing from it
+        // while the server build still has it. Reject it here instead.
+        check_supported_exports(program, &exports)?;
 
         // Module-level contract: each export's *evaluated value* is the
         // server function. The server build registers the binding's terminal
@@ -392,6 +397,7 @@ impl<'a> DirectivesTransform<'a> {
             Mode::Server => self.module_level_server(program, &exports),
             Mode::Client => self.module_level_client(program, &exports),
         }
+        Ok(())
     }
 
     /// Rewrites top-level function declarations into `const` function
@@ -1077,6 +1083,242 @@ fn binding_descriptive_name(program: &Program<'_>, key: BindingKey) -> Option<St
         return Some(id.name.to_string());
     }
     Some("anonymous".to_string())
+}
+
+/// An export a module-level directive cannot turn into a server function.
+pub(crate) struct UnsupportedExport {
+    pub(crate) span: Span,
+    pub(crate) name: String,
+    pub(crate) reason: UnsupportedReason,
+}
+
+pub(crate) enum UnsupportedReason {
+    ReExport { source: String },
+    /// A declaration form with a runtime value that is not a binding the
+    /// pass can register. `kind` carries its article, so the clause reads
+    /// "is a class declaration" or "is an enum declaration".
+    Declaration { kind: &'static str },
+    NoInitializer,
+    DestructuringPattern,
+    NotABinding,
+}
+
+impl UnsupportedReason {
+    /// Completes "`name` ...".
+    pub(crate) fn clause(&self) -> String {
+        match self {
+            UnsupportedReason::ReExport { source } => {
+                format!("is re-exported from \"{source}\"")
+            }
+            UnsupportedReason::Declaration { kind } => format!("is {kind} declaration"),
+            UnsupportedReason::NoInitializer => "is declared without an initializer".to_string(),
+            UnsupportedReason::DestructuringPattern => {
+                "is bound by a destructuring pattern".to_string()
+            }
+            UnsupportedReason::NotABinding => {
+                "does not resolve to a top-level binding with an initializer".to_string()
+            }
+        }
+    }
+
+    pub(crate) fn hint(&self) -> &'static str {
+        match self {
+            UnsupportedReason::ReExport { .. } => {
+                "Re-export it from a module without the directive."
+            }
+            UnsupportedReason::NoInitializer => {
+                "Give it an initializer, or move it to a module without the directive."
+            }
+            UnsupportedReason::DestructuringPattern => {
+                "Export a single initialized binding instead."
+            }
+            UnsupportedReason::Declaration { .. } | UnsupportedReason::NotABinding => {
+                "Move it to a module without the directive."
+            }
+        }
+    }
+}
+
+/// Reports the first export the module-level path cannot register. Runs on
+/// the post-bubble program, so `export function name() {}` has already
+/// become a traceable `const` plus an `export { name }` specifier and never
+/// reaches this check.
+fn check_supported_exports(
+    program: &Program<'_>,
+    exports: &ExportedBindings,
+) -> Result<(), UnsupportedExport> {
+    let is_traced = |name: &str| exports.exported.iter().any(|(exported, _)| exported == name);
+
+    for statement in &program.body {
+        match statement {
+            // `export * from "./x"` and `export * as ns from "./x"`.
+            Statement::ExportAllDeclaration(export) => {
+                if export.export_kind == ImportOrExportKind::Type {
+                    continue;
+                }
+                let name = export
+                    .exported
+                    .as_ref()
+                    .and_then(|exported| exported.identifier_name())
+                    .map(|name| name.to_string())
+                    .unwrap_or_else(|| "*".to_string());
+                return Err(UnsupportedExport {
+                    span: export.span,
+                    name,
+                    reason: UnsupportedReason::ReExport {
+                        source: export.source.value.to_string(),
+                    },
+                });
+            }
+            // `export { a, b as c } from "./x"`.
+            Statement::ExportFromDeclaration(export) => {
+                if export.export_kind == ImportOrExportKind::Type {
+                    continue;
+                }
+                for specifier in &export.specifiers {
+                    if specifier.export_kind == ImportOrExportKind::Type {
+                        continue;
+                    }
+                    return Err(UnsupportedExport {
+                        span: specifier.span,
+                        name: export_specifier_name(specifier),
+                        reason: UnsupportedReason::ReExport {
+                            source: export.source.value.to_string(),
+                        },
+                    });
+                }
+            }
+            // `export { a, b as c }` over local bindings.
+            Statement::ExportNamedDeclaration(export) => {
+                if export.export_kind == ImportOrExportKind::Type {
+                    continue;
+                }
+                for specifier in &export.specifiers {
+                    if specifier.export_kind == ImportOrExportKind::Type {
+                        continue;
+                    }
+                    let name = export_specifier_name(specifier);
+                    if !is_traced(&name) {
+                        return Err(UnsupportedExport {
+                            span: specifier.span,
+                            name,
+                            reason: UnsupportedReason::NotABinding,
+                        });
+                    }
+                }
+            }
+            Statement::ExportDeclaration(export) => {
+                if let Some(unsupported) = check_exported_declaration(&export.declaration, &is_traced)
+                {
+                    return Err(unsupported);
+                }
+            }
+            Statement::ExportDefaultDeclaration(export) => {
+                if is_traced("default") {
+                    continue;
+                }
+                let reason = match &export.declaration {
+                    ExportDefaultDeclarationKind::ClassDeclaration(_) => {
+                        UnsupportedReason::Declaration { kind: "a class" }
+                    }
+                    // Bubbling gives every other default form a synthesized
+                    // binding, so anything still untraced here is a TS
+                    // declaration form with no runtime value.
+                    _ => UnsupportedReason::NotABinding,
+                };
+                return Err(UnsupportedExport {
+                    span: export.span,
+                    name: "default".to_string(),
+                    reason,
+                });
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn check_exported_declaration(
+    declaration: &Declaration<'_>,
+    is_traced: &impl Fn(&str) -> bool,
+) -> Option<UnsupportedExport> {
+    match declaration {
+        Declaration::VariableDeclaration(variable) => {
+            // `export declare const x: number` is ambient and erased.
+            if variable.declare {
+                return None;
+            }
+            for declarator in &variable.declarations {
+                let BindingPattern::BindingIdentifier(id) = &declarator.id else {
+                    return Some(UnsupportedExport {
+                        span: declarator.span,
+                        name: "this export".to_string(),
+                        reason: UnsupportedReason::DestructuringPattern,
+                    });
+                };
+                if declarator.init.is_none() {
+                    return Some(UnsupportedExport {
+                        span: declarator.span,
+                        name: id.name.to_string(),
+                        reason: UnsupportedReason::NoInitializer,
+                    });
+                }
+                if !is_traced(&id.name) {
+                    return Some(UnsupportedExport {
+                        span: declarator.span,
+                        name: id.name.to_string(),
+                        reason: UnsupportedReason::NotABinding,
+                    });
+                }
+            }
+            None
+        }
+        Declaration::ClassDeclaration(class) => {
+            if class.declare {
+                return None;
+            }
+            Some(UnsupportedExport {
+                span: class.span,
+                name: class
+                    .id
+                    .as_ref()
+                    .map(|id| id.name.to_string())
+                    .unwrap_or_else(|| "this class".to_string()),
+                reason: UnsupportedReason::Declaration { kind: "a class" },
+            })
+        }
+        // `export enum`, `export namespace`, and `export import`: runtime
+        // values that bubbling did not turn into a traceable binding.
+        Declaration::TSEnumDeclaration(declared) => Some(UnsupportedExport {
+            span: declared.span,
+            name: declared.id.name.to_string(),
+            reason: UnsupportedReason::Declaration { kind: "an enum" },
+        }),
+        Declaration::TSNamespaceDeclaration(declared) => Some(UnsupportedExport {
+            span: declared.span,
+            name: declared.id.name.to_string(),
+            reason: UnsupportedReason::Declaration { kind: "a namespace" },
+        }),
+        Declaration::TSExternalModuleDeclaration(_)
+        | Declaration::TSImportEqualsDeclaration(_) => Some(UnsupportedExport {
+            span: declaration.span(),
+            name: "this export".to_string(),
+            reason: UnsupportedReason::NotABinding,
+        }),
+        // Function declarations are bubbled away before this runs, and the
+        // remaining forms (`type`, `interface`) are erased.
+        _ => None,
+    }
+}
+
+fn export_specifier_name(specifier: &oxc_ast::ast::ExportSpecifier<'_>) -> String {
+    match &specifier.exported {
+        oxc_ast::ast::ModuleExportName::StringLiteral(literal) => literal.value.to_string(),
+        other => other
+            .identifier_name()
+            .map(|name| name.to_string())
+            .unwrap_or_default(),
+    }
 }
 
 /// Mutable access to the function expression stored in a traced binding's

--- a/packages/compiler/src/directives/validate.rs
+++ b/packages/compiler/src/directives/validate.rs
@@ -162,7 +162,7 @@ fn format_error(error: CaptureError, code: &str, filename: &str, directive: &str
 }
 
 /// 1-based line/column for a byte offset.
-fn line_column(code: &str, offset: u32) -> (usize, usize) {
+pub(crate) fn line_column(code: &str, offset: u32) -> (usize, usize) {
     let offset = (offset as usize).min(code.len());
     let before = &code[..offset];
     let line = before.matches('\n').count() + 1;


### PR DESCRIPTION
The client build of a module-level `"use server"` module is rebuilt from its traced server-function exports alone. An export the tracer could not reach was simply dropped from that build while the server build kept it, so the module compiled and then failed in the bundler as a missing export with nothing pointing back at the directive.

The pass now reports the first such export with its position and what to do instead. The check runs on the post-bubble program and reuses the same tracer the transform uses, so the two cannot disagree about which shapes are supported.

- Covers re-exports, `export *`, `export * as ns`, class and enum and namespace exports, destructured exports, exports declared without an initializer, and named exports of imported bindings.
- Runs in both server and client mode, so the builds never disagree about a module's shape.
- Type-only and `declare` exports are erased and stay allowed.
