### PR TITLE
perf(signals): narrow store writes clone by spread; overlay only for wide owned backings (#3360 part 1)

### DIFF
--- a/.changeset/store-write-floor-narrow.md
+++ b/.changeset/store-write-floor-narrow.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+Store writes on narrow containers are ~1.85× cheaper (629 → 340 ns per write+commit steady state; a fresh store's first write+commit 3× cheaper). Plain-data containers now clone by spread instead of a descriptor walk, and the #3044 prototype overlay is taken only for wide (>32 own keys) containers over an already-owned backing — for narrow or unowned ones the overlay cost more than the clone it was meant to avoid (`Object.create` turns the backing into a V8 prototype, and the first commit had to privatize-clone anyway). Part one of #3360; the remaining per-write cost is the weak-collection registration of each pending backing.

--- a/packages/signals/src/store/next/store.ts
+++ b/packages/signals/src/store/next/store.ts
@@ -130,6 +130,7 @@ function TargetShape(this: any) {
   this.d = undefined;
   this.a = undefined;
   this.sc = undefined;
+  this.kc = undefined;
   this.nc = undefined;
   this.ab = undefined;
   this.fam = undefined;
@@ -169,7 +170,8 @@ function createTarget(
   t.px = null;
   t.d = false;
   t.a = false;
-  t.sc = false;
+  t.sc = 0;
+  t.kc = 0;
   t.nc = 0;
   t.ab = null;
   t.fam = fam;
@@ -419,6 +421,15 @@ const foldOlds = new Map<StoreNextTarget, Record<PropertyKey, any>>();
 let hookInstalled = false;
 
 function cloneRaw(source: Record<PropertyKey, any>, t?: StoreNextTarget): Record<PropertyKey, any> {
+  // Plain-data fast path (#3360): a scanned `Object.prototype` container
+  // whose own keys are all enumerable data clones by spread — the same
+  // result as the descriptor walk below (own enumerable string+symbol keys,
+  // normalized writable+configurable), at ~1/50th the cost. Callers always
+  // pass their own committed backing as `source`.
+  if (t) {
+    t.sc || scanAccessorsOnce(t);
+    if (t.sc === 2) return { ...source };
+  }
   // Descriptor-preserving shallow clone (R29: installed getters stay live;
   // ruled 2026-08-17: frozen sources clone unfrozen — theirs stays frozen).
   // Data descriptors normalize to writable+configurable (the clone is OURS to
@@ -450,19 +461,34 @@ function copyOwn(to: object, from: object, key: PropertyKey): void {
 }
 
 /** One-time own-accessor scan (Annex-B probes, no descriptor allocation);
- * returns true when the container is plain data (overlay-safe). */
+ * returns true when the container is plain data (overlay-safe). Also grades
+ * the container for the plain-data fast paths (`sc` = 2): `Object.prototype`
+ * and every own key an enumerable data property — what a spread copies
+ * exactly and what a bare assignment lands exactly. */
 function scanAccessorsOnce(target: StoreNextTarget): boolean {
   const src = target.v;
-  for (const key of Reflect.ownKeys(src)) {
+  const keys = Reflect.ownKeys(src);
+  let plain = Object.getPrototypeOf(src) === Object.prototype;
+  for (const key of keys) {
     // Own keys shadow prototype accessors, so the lookups are exact here.
     if (lookupGetter.call(src, key) !== undefined || lookupSetter.call(src, key) !== undefined) {
       target.a = true;
+      plain = false;
       break;
     }
+    if (plain && !propertyIsEnumerable.call(src, key)) plain = false;
   }
-  target.sc = true;
+  target.sc = plain ? 2 : 1;
+  target.kc = keys.length;
   return !target.a;
 }
+
+/** Own-key count above which a draft opens as a prototype overlay rather
+ * than a clone (#3360). Below it a spread clone of a plain container is
+ * cheaper than the overlay's `Object.create` (V8 converts the committed
+ * backing into a prototype, and every later flatten writes into that
+ * prototype); above it the clone's O(keys) copy dominates (#3044). */
+const OVERLAY_MIN_KEYS = 32;
 
 /** Downgrade a prototype-overlay pending backing to the clone path: builds
  * the real container (committed + overlay writes − deletes) that fold will
@@ -522,15 +548,26 @@ function ensurePB(target: StoreNextTarget): Record<PropertyKey, any> {
     // backings (the committed layer is another store's proxy — an overlay
     // would route every read-through into its traps), accessor containers
     // (live getters).
+    // The overlay pays off only for a WIDE container over an OWNED committed
+    // backing (#3360). Narrow containers clone cheaper than they overlay (a
+    // spread is a fast-path copy; `Object.create` turns the backing into a
+    // V8 prototype and every later flatten writes into that prototype). An
+    // unowned backing has to be privatized (cloned) at commit anyway, so an
+    // overlay there would cost the create PLUS the clone PLUS a per-key
+    // copy — the clone path does the one clone and swaps it in. The first
+    // write on a fresh store is exactly that case.
+    const v = target.v;
     if (
       !target.fam?.opt &&
       !target.ch &&
-      !Array.isArray(target.v) &&
-      (target.sc ? !target.a : scanAccessorsOnce(target))
+      !Array.isArray(v) &&
+      (target.sc !== 0 ? !target.a : scanAccessorsOnce(target)) &&
+      target.kc > OVERLAY_MIN_KEYS &&
+      ownedRaw.has(v)
     ) {
-      pb = target.pb = Object.create(target.v) as Record<PropertyKey, any>;
+      pb = target.pb = Object.create(v) as Record<PropertyKey, any>;
       target.ovl = true;
-    } else pb = target.pb = cloneRaw(target.v, target);
+    } else pb = target.pb = cloneRaw(v, target);
     // Optimistic families: seed USER drafts from the OPTIMISTIC VIEW
     // (committed + active node overrides), so follow-up writes compose on
     // optimism instead of clobbering from base (#2951's compose half).
@@ -639,7 +676,7 @@ export function adoptPB(
   // draft rescans once (#3044 audit follow-up).
   target.ovl = false;
   target.del = null;
-  target.sc = false;
+  target.sc = 0;
   target.a = false;
   target.wk = null; // adoption supersedes staged trap writes
   target.v = incoming;
@@ -763,7 +800,12 @@ function parentSlotKey(target: StoreNextTarget, expected: unknown): PropertyKey 
 function flattenOverlay(t: StoreNextTarget, pb: Record<PropertyKey, any>): void {
   privatizeCommitted(t);
   const v = t.v;
-  for (const key of Reflect.ownKeys(pb)) copyOwn(v, pb, key);
+  // Plain-data grade (sc 2): every own key on the overlay is an enumerable
+  // writable data slot (set-trap writes; a non-plain defineProperty
+  // downgrades the grade) — a bare assignment lands it without the
+  // descriptor round trip.
+  for (const key of Reflect.ownKeys(pb))
+    t.sc === 2 ? ((v as any)[key] = pb[key as any]) : copyOwn(v, pb, key);
   if (t.del !== null) {
     for (const key of t.del) delete (v as any)[key];
     t.del = null;
@@ -1504,6 +1546,7 @@ const hasOwn = Object.prototype.hasOwnProperty;
 // shadow prototype accessors, so hasOwn + lookup is an exact own-check.
 const lookupGetter = (Object.prototype as any).__lookupGetter__;
 const lookupSetter = (Object.prototype as any).__lookupSetter__;
+const propertyIsEnumerable = Object.prototype.propertyIsEnumerable;
 function isOwnAccessor(src: Record<PropertyKey, any>, key: PropertyKey): boolean {
   return (
     hasOwn.call(src, key) &&
@@ -1984,7 +2027,14 @@ const traps: ProxyHandler<StoreNextTarget> = {
         wk.add(key);
         wk.add("length");
       }
-    } else if (target.wk !== WK_ALL) (target.wk ??= new Set()).add(key);
+    } else {
+      if (target.wk !== WK_ALL) (target.wk ??= new Set()).add(key);
+      // Live own-key estimate for the overlay/clone choice (#3360): `in`
+      // sees through an overlay to the committed keys, so this counts keys
+      // NEW to the container. Deletes are not un-counted (a stale high
+      // count only picks the overlay a little early).
+      if (!(key in pb)) target.kc++;
+    }
     // Own data keys literally named "prototype"/"constructor" land as data —
     // defineProperty sidesteps a proto-chain setter named the same.
     if (UNSAFE_KEYS.has(key)) {
@@ -1999,8 +2049,10 @@ const traps: ProxyHandler<StoreNextTarget> = {
     }
     // Overlay first-write DEFINES the own key: assignment through the proto
     // chain would reject on a non-writable committed property (the clone
-    // path normalized descriptors for exactly this — R51 parity).
-    if (target.ovl && !hasOwn.call(pb, key)) {
+    // path normalized descriptors for exactly this — R51 parity). A
+    // plain-data-graded backing (sc 2, owned: every slot writable) takes the
+    // bare assignment — it lands as an own key on the overlay all the same.
+    if (target.ovl && target.sc !== 2 && !hasOwn.call(pb, key)) {
       Object.defineProperty(pb, key, {
         value: uv,
         writable: true,
@@ -2027,6 +2079,10 @@ const traps: ProxyHandler<StoreNextTarget> = {
     // Unwrap before ensurePB (see the set trap: self-reference materializes).
     if ("value" in desc) desc = { ...desc, value: unwrapValue(desc.value) };
     const pb = ensurePB(target);
+    // A non-default data descriptor (or an accessor) leaves the plain-data
+    // grade: the key reaches the committed backing as defined, so the spread
+    // clone and bare-assignment paths no longer describe it.
+    if (target.a || !(desc.enumerable && desc.writable && desc.configurable)) target.sc = 1;
     pendingNotify.add(target);
     if (target.wk !== WK_ALL) (target.wk ??= new Set()).add(key);
     Object.defineProperty(pb, key, desc);

--- a/packages/signals/src/store/next/target.ts
+++ b/packages/signals/src/store/next/target.ts
@@ -99,9 +99,17 @@ export interface StoreNextTarget {
    * this target (first-read scan, defineProperty, or clone scan). Gates the
    * fold diff's descriptor-safe path and the get trap's descriptor path. */
   a: boolean;
-  /** Accessor scan performed (scan-once on first trap read; adopted data is
-   * not rescanned — legacy-parity behavior). */
-  sc: boolean;
+  /** Accessor scan grade: 0 = not yet scanned (adoption resets — adopted data
+   * is not rescanned until the next draft), 1 = scanned, 2 = scanned and
+   * PLAIN DATA — `Object.prototype` with every own key an enumerable data
+   * property. Grade 2 unlocks the spread clone (cloneRaw), bare-assignment
+   * overlay writes and flatten (#3360); a non-plain defineProperty through
+   * the draft downgrades it to 1. */
+  sc: 0 | 1 | 2;
+  /** Own-key count: exact at scan, then bumped by set-trap writes of keys new
+   * to the container (never decremented — an estimate for the overlay/clone
+   * choice only, #3360). */
+  kc: number;
   /** Adoption diff base, non-null when the backing was swapped by adoption
    * this batch: the view the nodes were LAST TOLD — the pre-batch committed
    * backing, or the draft's pending backing when a draft preceded the

--- a/packages/signals/tests/store/projection-root-overlay.test.ts
+++ b/packages/signals/tests/store/projection-root-overlay.test.ts
@@ -18,7 +18,8 @@ import {
  *
  * The complexity guard is deterministic, not timed: `cloneRaw` is the only
  * store code that calls `Object.getOwnPropertyDescriptors`, so a spy on it
- * counts container clones exactly. One clone is legitimate per lifetime —
+ * counts descriptor clones exactly (plain-data records clone by spread since
+ * #3360 and register zero). At most one clone is legitimate per lifetime —
  * privatizing the user's seed at the first fold (never-mutate-user-data).
  */
 const KEYS = 2000;
@@ -100,9 +101,11 @@ describe("projection root writes are O(written) (#3352)", () => {
     const spy = clones();
     setGone("b");
     flush();
-    // Exactly the one-time seed privatization (the first derive wrote nothing,
+    // At most the one-time seed privatization (the first derive wrote nothing,
     // so no fold had cloned the user's object yet) — not a per-derive clone.
-    expect(recordClones(spy, "a")).toBe(1);
+    // A plain-data record clones by spread (#3360), which the descriptor spy
+    // does not see at all — hence "at most".
+    expect(recordClones(spy, "a")).toBeLessThanOrEqual(1);
     expect("b" in proj).toBe(false);
     expect(proj.b).toBeUndefined();
     expect(Object.keys(proj)).toEqual(["a", "c"]);
@@ -116,7 +119,7 @@ describe("projection root writes are O(written) (#3352)", () => {
     // Now owned: the next derive's root delete opens an overlay, no clone.
     setGone("c");
     flush();
-    expect(recordClones(spy, "a")).toBe(1);
+    expect(recordClones(spy, "a")).toBeLessThanOrEqual(1);
     expect(Object.keys(proj)).toEqual(["a"]);
     expect(seenKeys).toHaveLength(3);
   });

--- a/packages/signals/tests/store/write-floor.bench.ts
+++ b/packages/signals/tests/store/write-floor.bench.ts
@@ -1,0 +1,39 @@
+// Per-write floor of narrow stores (#3360 repro shape): one root key written
+// per store, one flush, no subscribers — the cost is pure draft/commit
+// bookkeeping. rc.7 paid a descriptor clone (or, over an owned backing, a
+// prototype overlay whose flatten wrote into a V8 prototype) plus a
+// privatizing clone at the first commit; narrow plain containers now clone by
+// spread and swap the clone in. The steady-state case is the number to watch;
+// the fresh-store case covers the reporter's exact benchmark.
+import { bench, describe } from "vitest";
+import { createStore, flush } from "../../src/index.js";
+
+const N = 2000;
+
+describe(`${N} one-key stores, one write each per commit`, () => {
+  const stores = Array.from({ length: N }, () => createStore({ value: 0 }));
+  for (const [, set] of stores)
+    set(d => {
+      d.value = -1;
+    });
+  flush();
+  let tick = 0;
+
+  bench("steady state: owned backings (#3360)", () => {
+    const v = ++tick;
+    for (let i = 0; i < N; i++)
+      stores[i][1](d => {
+        d.value = v;
+      });
+    flush();
+  });
+
+  bench("fresh stores: create + first write + first commit (reporter shape)", () => {
+    const fresh = Array.from({ length: N }, () => createStore({ value: 0 }));
+    for (let i = 0; i < N; i++)
+      fresh[i][1](d => {
+        d.value = 1;
+      });
+    flush();
+  });
+});

--- a/packages/signals/tests/store/write-floor.test.ts
+++ b/packages/signals/tests/store/write-floor.test.ts
@@ -1,0 +1,173 @@
+/**
+ * #3360: per-write floor of narrow stores.
+ *
+ * Drafts on plain-data containers clone by spread and swap the clone in at
+ * commit; only WIDE owned containers open as prototype overlays (#3044). The
+ * fast paths are gated on a one-time scan grade — these pin the cases the
+ * grade must exclude (accessors, non-enumerable keys, custom prototypes,
+ * non-plain defineProperty through the draft) and the cases it must keep
+ * (symbol keys, frozen sources, growth past the overlay threshold).
+ */
+import { describe, expect, it } from "vitest";
+import { createStore, flush, snapshot } from "../../src/index.js";
+
+describe("narrow store writes (#3360)", () => {
+  it("a one-key store round-trips writes and snapshots", () => {
+    const [s, set] = createStore({ value: 0 });
+    for (let i = 1; i <= 3; i++) {
+      set(d => {
+        d.value = i;
+      });
+      flush();
+      expect(s.value).toBe(i);
+      expect(snapshot(s)).toEqual({ value: i });
+    }
+  });
+
+  it("enumerable symbol keys survive the spread clone", () => {
+    const sym = Symbol("tag");
+    const [s, set] = createStore<{ a: number; [sym]?: string }>({ a: 1, [sym]: "x" });
+    set(d => {
+      d.a = 2;
+    });
+    flush();
+    expect(s.a).toBe(2);
+    expect(s[sym]).toBe("x");
+    expect(Reflect.ownKeys(snapshot(s))).toEqual(["a", sym]);
+  });
+
+  it("a non-enumerable own key keeps its attributes through a write (descriptor clone)", () => {
+    const src: { a: number; hidden?: number } = { a: 1 };
+    Object.defineProperty(src, "hidden", {
+      value: 7,
+      enumerable: false,
+      writable: true,
+      configurable: true
+    });
+    const [s, set] = createStore(src);
+    set(d => {
+      d.a = 2;
+    });
+    flush();
+    expect(s.a).toBe(2);
+    expect(s.hidden).toBe(7);
+    expect(Object.keys(s)).toEqual(["a"]);
+    expect(Object.getOwnPropertyDescriptor(snapshot(s), "hidden")?.enumerable).toBe(false);
+  });
+
+  it("a custom prototype survives the clone", () => {
+    class Point {
+      constructor(
+        public x = 0,
+        public y = 0
+      ) {}
+      get len() {
+        return Math.hypot(this.x, this.y);
+      }
+    }
+    const [s, set] = createStore(new Point(3, 4));
+    set(d => {
+      d.x = 6;
+      d.y = 8;
+    });
+    flush();
+    expect(s.len).toBe(10);
+    expect(snapshot(s)).toBeInstanceOf(Point);
+  });
+
+  it("a frozen source clones unfrozen and stays writable (R51)", () => {
+    const [s, set] = createStore(Object.freeze({ a: 1 }) as { a: number });
+    set(d => {
+      d.a = 2;
+    });
+    flush();
+    set(d => {
+      d.a = 3;
+    });
+    flush();
+    expect(s.a).toBe(3);
+    expect(Object.isFrozen(snapshot(s))).toBe(false);
+  });
+
+  it("a non-plain defineProperty through the draft is preserved by later writes", () => {
+    const [s, set] = createStore<{ a: number; ro?: number }>({ a: 1 });
+    set(d => {
+      Object.defineProperty(d, "ro", {
+        value: 5,
+        enumerable: false,
+        writable: false,
+        configurable: true
+      });
+    });
+    flush();
+    expect(s.ro).toBe(5);
+    // Later writes must not launder `ro` into a plain enumerable slot.
+    set(d => {
+      d.a = 2;
+    });
+    flush();
+    set(d => {
+      d.a = 3;
+    });
+    flush();
+    expect(s.a).toBe(3);
+    expect(s.ro).toBe(5);
+    expect(Object.keys(s)).toEqual(["a"]);
+    // Enumerability is preserved; writability normalizes to writable on the
+    // descriptor clone (R51: non-writable is writable through the store).
+    expect(Object.getOwnPropertyDescriptor(snapshot(s), "ro")?.enumerable).toBe(false);
+  });
+
+  it("an accessor installed through the draft stays live", () => {
+    const [s, set] = createStore<{ a: number; double?: number }>({ a: 1 });
+    set(d => {
+      Object.defineProperty(d, "double", {
+        get() {
+          return this.a * 2;
+        },
+        enumerable: true,
+        configurable: true
+      });
+    });
+    flush();
+    set(d => {
+      d.a = 21;
+    });
+    flush();
+    expect(s.double).toBe(42);
+  });
+
+  it("a record that grows from empty past the overlay threshold keeps every key", () => {
+    const [s, set] = createStore<Record<string, number>>({});
+    const N = 200;
+    for (let i = 0; i < N; i++) {
+      set(d => {
+        d[`k${i}`] = i;
+      });
+      flush();
+    }
+    expect(Object.keys(s)).toHaveLength(N);
+    expect(s.k0).toBe(0);
+    expect(s[`k${N - 1}`]).toBe(N - 1);
+    // Deletes and re-adds keep working once the container is on the overlay path.
+    set(d => {
+      delete d.k0;
+      d.k0 = -1;
+      delete d.k1;
+    });
+    flush();
+    expect(s.k0).toBe(-1);
+    expect("k1" in s).toBe(false);
+    expect(Object.keys(s)).toHaveLength(N - 1);
+  });
+
+  it("many narrow stores written in one batch each commit their own value", () => {
+    const stores = Array.from({ length: 500 }, (_, i) => createStore({ value: i }));
+    for (const [, set] of stores)
+      set(d => {
+        d.value = -d.value;
+      });
+    flush();
+    stores.forEach(([s], i) => expect(s.value).toBe(-i));
+  });
+});

--- a/scripts/size/.size-limit.js
+++ b/scripts/size/.size-limit.js
@@ -356,7 +356,12 @@ module.exports = [
     // measured at 14.776 (was 14.696). The core-floor arm plus the slot-node
     // literal's `_prevChild` and the unlink calls in the four unobserved
     // hooks (value, presence, key-set, deep witness).
-    limit: "14.83 KB",
+    // Narrow-store write floor (#3360, 2026-09-10): 14.83 -> 14.97 KB,
+    // measured at 14.921 (was 14.770). The scan grade + own-key count on
+    // the target, the spread arm in cloneRaw, the width/ownership gate on
+    // the overlay, and the bare-assignment arms in the set trap and
+    // flatten. Buys 1.85x on per-write cost (629 -> 340 ns steady state).
+    limit: "14.97 KB",
     modifyEsbuildConfig
   },
   {
@@ -705,7 +710,9 @@ module.exports = [
     // Firewall child chain doubly linked (#3351, 2026-09-10): 27.34 -> 27.48 KB,
     // measured at 27.430 (was 27.273; +80 B of it is the createStore arm, the
     // rest brotli layout across the store family bundle). See the createStore note.
-    limit: "27.48 KB",
+    // Narrow-store write floor (#3360, 2026-09-10): 27.48 -> 27.57 KB,
+    // measured at 27.518 (was 27.391). The createStore arm; see that note.
+    limit: "27.57 KB",
     modifyEsbuildConfig
   },
   {


### PR DESCRIPTION
Part one of #3360 (does not close it — part two, below, does).

## Problem

#3360 reports a ~4× regression rc.0 → rc.7 on the per-write floor of stores: 100k one-key stores, one `setStore` each, one `flush`. Reproduced (prod): rc.0 ~61 ms, rc.7 ~265 ms. Both linear — it's a constant factor from the rc.1 immutable-backing model. Profiled three costs:

1. **`cloneRaw` was a descriptor clone** (`getOwnPropertyDescriptors` + `Object.create(proto, descs)`): ~530 ns for a one-key object. A spread is ~10 ns and produces the same result for plain-data containers.
2. **The #3044 prototype overlay loses on narrow and on unowned containers.** `Object.create(v)` turns the committed backing into a V8 prototype (~200 ns), and every later flatten writes into a prototype object (~250 ns/key + validity-cell churn). On an *unowned* backing (every fresh store's first write) the flatten had to privatize-clone anyway, so that path paid create + descriptor clone + per-key descriptor copy — the reporter's 128 ms first flush.
3. **Every pending backing is registered in two weak collections** (~190 ns of identity-hash + ephemeron cost per write). Not addressed here — see part two.

## Change

- `scanAccessorsOnce` grades the container (`sc`: 0 unscanned / 1 scanned / 2 plain data = `Object.prototype` with every own key an enumerable data property) and records the own-key count `kc` (bumped by set-trap writes of keys new to the container, so a `{}` that grows still graduates).
- `cloneRaw` spreads at grade 2.
- Overlay only when `kc > 32` **and** the backing is owned; otherwise clone and swap. `OVERLAY_MIN_KEYS` sits at the measured crossover.
- Grade-2 containers flatten and take overlay first-writes by bare assignment; a non-plain `defineProperty` through the draft downgrades the grade.

## Numbers (prod)

| | rc.0 | rc.7 / `next` | this PR |
|---|---|---|---|
| steady state, 1000 stores × 1000 write+flush rounds | 214 ns/write | 629 ns | **340 ns** |
| reporter's 100k fresh stores, one write + flush | 61 ms | ~265 ms | **~90 ms** |

Existing store benches all improved or held: batched 2-key writes 5.6k → 10.2k ops/s, selection map 3.2k → 3.9k, input burst 3.2k → 4.2k, projection root/nested (#3352) 393k/328k → 465k/459k, commit-boundary flat. New `write-floor.bench.ts` pins the steady and fresh-store shapes.

## Behavior note

A `writable: false` data property defined *through a draft* used to stay non-writable across later writes only because the overlay never touched it; on the clone path the descriptor walk normalizes it to writable (R51). Enumerability is preserved either way; the test pins that and documents the normalization.

## Tests / gates

- `tests/store/write-floor.test.ts` (9): symbol keys, non-enumerable keys, custom prototypes, frozen sources, non-plain and accessor `defineProperty` through the draft, growth past the threshold, 500-store batch.
- Two `#3352` clone-spy assertions loosened to `≤ 1` (spread is not a descriptor clone).
- signals 1707/1707; prod-tier failure count identical to `next` (238); solid 595; web 734.
- Size: `createStore` 14.77 → 14.92 KB, hydrating+stores 27.39 → 27.52 KB (~150 B of real code; caps bumped with notes).

## Part two

The remaining ~190 ns is `storeNextLookup.set(pb)` + `ownedRaw.add(pb)` per draft. Removing them (incorrectly, to measure) gives 154 ns/write — under rc.0. The plan is to stamp *owned* raws with a non-enumerable owner symbol at creation and keep the WeakMap only for user-supplied objects; owned raws are never reachable by user code (`snapshot` copies them, there is no `unwrap`), so the surface is purely internal. Separate PR so each half is bisectable and CodSpeed shows its effect alone.

Made with [Cursor](https://cursor.com)