### PR TITLE
fix(web): omit nullish style/class in ssrElement, no stray tag whitespace

### DIFF
--- a/.changeset/fix-ssr-element-nullish-style-class.md
+++ b/.changeset/fix-ssr-element-nullish-style-class.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/web": patch
+---
+
+`ssrElement` no longer emits `style=""` / `class=""` for nullish values; they are omitted like every other attribute, matching the client. Skipped props also leave no stray whitespace in the opening tag (#3382).

--- a/packages/web/src/server.ts
+++ b/packages/web/src/server.ts
@@ -3577,7 +3577,10 @@ export function ssrElement(tag, props, children, needsId) {
   if (props == null) props = {};
   const skipChildren = VOID_ELEMENTS.test(tag);
   const keys = Object.keys(props);
-  let result = `<${tag}${hk} `;
+  // Each emitted attribute carries its own leading space (the hydration key
+  // already does), so skipped props leave no stray whitespace behind:
+  // `<li _hk=0>` rather than `<li _hk=0 >` (#3382).
+  let result = `<${tag}${hk}`;
   for (let i = 0; i < keys.length; i++) {
     const prop = keys[i];
     // Every branch reads `props[prop]` itself, and only when it will use it.
@@ -3606,11 +3609,10 @@ export function ssrElement(tag, props, children, needsId) {
       continue;
     }
     const value = props[prop];
-    if (prop === "style") {
-      result += `style="${ssrStyle(value)}"`;
-    } else if (prop === "class") {
-      result += `class="${ssrClassName(value)}"`;
-    } else if (
+    // Nullish is "not set" for every attribute, `style`/`class` included —
+    // the client removes the attribute for `undefined`, and emitting
+    // `style=""` here made the server disagree with it (#3382).
+    if (
       value == undefined ||
       prop === "ref" ||
       prop.slice(0, 2) === "on" ||
@@ -3632,16 +3634,21 @@ export function ssrElement(tag, props, children, needsId) {
         );
       }
       continue;
+    } else if (prop === "style") {
+      result += ` style="${ssrStyle(value)}"`;
+    } else if (prop === "class") {
+      result += ` class="${ssrClassName(value)}"`;
     } else if (typeof value === "boolean") {
       if (!value) continue;
-      result += escape(prop);
+      result += ` ${escape(prop)}`;
     } else {
-      result += value === "" ? escape(prop) : `${escape(prop)}="${escape(value, true)}"`;
+      result += value === "" ? ` ${escape(prop)}` : ` ${escape(prop)}="${escape(value, true)}"`;
     }
-    if (i !== keys.length - 1) result += " ";
   }
 
-  if (skipChildren) return { t: result + "/>" };
+  // The hydration key is unquoted, so a void element needs the space before
+  // `/>` or the slash becomes part of the key's value.
+  if (skipChildren) return { t: result + " />" };
   if (typeof children === "function") children = children();
   return ssr([result + ">", `</${tag}>`], resolveSSRNode(children, undefined, true));
 }

--- a/packages/web/test/harness/__artifacts__/spread-children.json
+++ b/packages/web/test/harness/__artifacts__/spread-children.json
@@ -1,5 +1,5 @@
 {
   "name": "spread-children",
-  "shell": "<div _hk=1 class=\"sp\" ><em _hk=0>spread</em></div>",
+  "shell": "<div _hk=1 class=\"sp\"><em _hk=0>spread</em></div>",
   "rest": ""
 }

--- a/packages/web/test/server/ssr-element-nullish-attrs.spec.tsx
+++ b/packages/web/test/server/ssr-element-nullish-attrs.spec.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jsxImportSource @solidjs/web
+ */
+import { describe, expect, test } from "vitest";
+import { renderToString, ssrElement, Dynamic } from "@solidjs/web";
+
+// Regression (#3382): ssrElement checked `style` and `class` before the
+// nullish early-out, so a spread whose style/class resolved to undefined
+// serialized as `style="" class=""` while every other attribute was omitted
+// — and while the client removes the attribute for the same value.
+describe("ssrElement nullish style/class (#3382)", () => {
+  test("nullish style and class are omitted like any other attribute", () => {
+    const html = renderToString(() =>
+      ssrElement("button", { style: undefined, class: null, id: undefined }, undefined, false)
+    );
+    expect(html).toBe("<button></button>");
+  });
+
+  test("through a spread and through Dynamic", () => {
+    const props = { style: undefined, class: undefined, "data-x": "1" };
+    expect(renderToString(() => <button {...props} />)).toMatch(
+      /^<button( _hk=\w+)? data-x="1"><\/button>$/
+    );
+    expect(renderToString(() => <Dynamic component="button" {...props} />)).toMatch(
+      /^<button( _hk=\w+)? data-x="1"><\/button>$/
+    );
+  });
+
+  test("present values still serialize", () => {
+    const html = renderToString(() =>
+      ssrElement(
+        "div",
+        { style: { color: "red" }, class: { a: true, b: false }, title: "" },
+        undefined,
+        false
+      )
+    );
+    expect(html).toBe('<div style="color:red" class="a" title></div>');
+  });
+
+  test("skipped props leave no stray whitespace", () => {
+    expect(renderToString(() => ssrElement("li", {}, "x", true))).toMatch(/^<li _hk=\w+>x<\/li>$/);
+    expect(renderToString(() => ssrElement("li", { id: undefined }, "x", false))).toBe(
+      "<li>x</li>"
+    );
+    expect(renderToString(() => ssrElement("input", { value: "v" }, undefined, true))).toMatch(
+      /^<input _hk=\w+ value="v" \/>$/
+    );
+    // The unquoted hydration key must not swallow the void slash.
+    expect(renderToString(() => ssrElement("br", {}, undefined, true))).toMatch(
+      /^<br _hk=\w+ \/>$/
+    );
+  });
+});


### PR DESCRIPTION
Fixes #3382.

`ssrElement` tested `style` and `class` before the nullish early-out, so a spread whose style/class resolved to `undefined` serialized `style="" class=""` while every other attribute was omitted — and while the client removes the attribute for the same value:

```js
ssrElement("button", { style: undefined, class: undefined, id: undefined }, undefined, true)
// before: { t: '<button style="" class="" ></button>' }
// after:  { t: '<button></button>' }
```

Moves the two branches below the early-out. While there, emitted attributes carry their own leading space (as the hydration key already does) instead of a trailing one appended per key, so skipped props leave nothing behind: `<li _hk=0>` rather than `<li _hk=0 >`. Void elements keep the space before `/>` because the hydration key is unquoted (`_hk=0/>` would swallow the slash into the value).

Neither compiler emits these attributes; this is runtime-only. One parity-harness artifact (`spread-children`) changes by the trailing space.

Tests: `test/server/ssr-element-nullish-attrs.spec.tsx`. `@solidjs/web` dom / server / hydrate suites green.

Surfaced by the `@yak/solid` audit (DigitecGalaxus/next-yak#644); the base runtime shipped `style=""` on every `styled(Component)` element because of this.

---
Authored with Claude via Cursor.
