### PR TITLE
docs: correct createContext guidance for server rendering

### DIFF
--- a/packages/solid/src/client/core.ts
+++ b/packages/solid/src/client/core.ts
@@ -61,9 +61,11 @@ export interface Context<T> extends ContextProviderComponent<T> {
  *   static fallback (theme, locale, frozen config). Outside any Provider,
  *   `useContext` returns `defaultValue`.
  *
- * If you want truly app-wide state, **don't use Context** — a module-scope
- * signal/store *is* a global. Context is for scoping state to a subtree;
- * that's why a Provider is required.
+ * Context is for state that belongs to a subtree, which includes app-wide
+ * state in an app that renders on the server: a value created inside a
+ * component is created once per request, and the Provider owns and disposes
+ * it. Module scope is shared by every request in the same process, so reserve
+ * it for constants.
  *
  * @param defaultValue optional default; only meaningful for primitive
  *   fallbacks. Omit for any context carrying reactive state.
@@ -87,6 +89,7 @@ export interface Context<T> extends ContextProviderComponent<T> {
  * function TodoList() {
  *   const [todos, { addTodo }] = useContext(TodosContext); // typed as TodosCtx
  *   // ...
+ *   return null;
  * }
  * ```
  *
@@ -142,6 +145,7 @@ export function createContext<T>(defaultValue?: T, options?: EffectOptions): Con
  * function TodoList() {
  *   const [todos, { addTodo }] = useContext(TodosContext); // throws if no Provider
  *   // ...
+ *   return null;
  * }
  * ```
  *

--- a/packages/web/server-functions/src/server.ts
+++ b/packages/web/server-functions/src/server.ts
@@ -3236,7 +3236,7 @@ function nativePromise(value) {
  *
  * @example
  * ```ts
- * import { handleServerFunctionRequest } from "@solidjs/web/server-functions";
+ * import { handleServerFunctionRequest } from "@solidjs/web/server-functions/server";
  * import "virtual:solid-server-function-manifest";
  *
  * // in the server's request handling:


### PR DESCRIPTION
Closes #3390 (except the `useContext` URL, see below).

### `createContext` guidance

The JSDoc recommended a module-scope signal or store for app-wide state. Under `ssr: true` a module is evaluated once per process, so that state is shared across requests, and the 2.0 docs advise the opposite. Since the reference page is generated from this JSDoc, the two contradicted each other. This uses the wording from the issue.

### Smaller items from the same issue

- `createContext` / `useContext` `@example`: the `TodoList` stub had no return value, so the examples fail `tsc` as written. Added `return null;`.
- `handleServerFunctionRequest` `@example`: imported from `@solidjs/web/server-functions`. In `packages/web/package.json` that subpath resolves to `server-functions/dist/client.js` under the `browser` condition, while `./server-functions/server` maps unconditionally to the server build, so the example now imports from `@solidjs/web/server-functions/server`.

### Not done

The fourth item, `useContext`'s `@description https://docs.solidjs.com/reference/component-apis/use-context` being a 1.x URL, is left alone: every `@description` in the 2.0 source points at `docs.solidjs.com/reference/...`, including `create-context` and `children` directly around it, and the repo has no other docs host, so I could not tell what the intended 2.0 target is. Happy to update this one, and its neighbours if they are stale too, once you name the URL.

Comment-only changes; no runtime code is touched.
