### PR TITLE
fix(signals): treat a plain merge() result as an ordinary source (#3384)

### DIFF
--- a/.changeset/fix-merge-plain-result-not-flattened.md
+++ b/.changeset/fix-merge-plain-result-not-flattened.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/signals": patch
+---
+
+`merge()` no longer flattens through a plain-object merge result. That form is a real object callers may copy (`Reflect.ownKeys` descriptor copies, `{...props}`) or mutate afterwards (`@solidjs/html` assigns props and a `children` getter after spreading), and a later `merge` tunnelled back to the original sources through the `$SOURCES` symbol — resurrecting removed keys and dropping added or overwritten ones (#3384). The plain result now records no sources and is read like any other object; only merge *proxies*, whose writes are no-ops, are still flattened. A side effect: `merge(defaults, props)` where `props` is itself a plain merge result that covers every default now returns `props` directly instead of always allocating.

--- a/packages/signals/src/store/utils.ts
+++ b/packages/signals/src/store/utils.ts
@@ -81,11 +81,12 @@ function resolveSource(s: any) {
 
 const $SOURCES = Symbol(__DEV__ ? "MERGE_SOURCE" : 0);
 /** @internal The flattened sources behind a `merge()` PROXY, or undefined.
- * Only the proxy form: its writes are no-ops, so the sources are the whole
- * truth. merge()'s plain-object form also records `$SOURCES` (so nested
- * merges flatten), but it is a real object callers may mutate afterwards
- * (html's tagged templates assign props after spreading) — those own writes
- * live on the object, not in the sources, so it must be read directly. */
+ * Only the proxy form carries sources: its writes are no-ops, so they are
+ * the whole truth. The plain-object form is a real object callers may copy
+ * (descriptor copies, `{...props}`) or mutate afterwards (html's tagged
+ * templates assign props and a children getter after spreading) — what is
+ * on the object is the truth there, so it records nothing and every consumer,
+ * a nested merge included, reads it directly (#3384). */
 export function mergeSources(o: any): any[] | undefined {
   return o != null && o[$PROXY] === o ? o[$SOURCES] : undefined;
 }
@@ -115,14 +116,25 @@ export function merge<T extends unknown[]>(...sources: T): Merge<T> {
   const flattened: T[] = [];
   for (let i = 0; i < sources.length; i++) {
     const s = sources[i];
-    proxy = proxy || (!!s && $PROXY in (s as object));
-    const childSources = !!s && (s as object)[$SOURCES];
-    if (childSources) {
-      for (let i = 0; i < childSources.length; i++) flattened.push(childSources[i]);
-    } else
-      flattened.push(
-        typeof s === "function" ? ((proxy = true), createMemo(s as () => any)) : (s as any)
-      );
+    if (typeof s === "function") {
+      proxy = true;
+      flattened.push(createMemo(s as () => any) as any);
+      continue;
+    }
+    if (s && $PROXY in (s as object)) {
+      proxy = true;
+      // Only a merge() PROXY is flattened through: its writes are no-ops, so
+      // its sources are exactly what it reads. A plain-object merge result
+      // is an ordinary source — it may have been copied or mutated since,
+      // and what is on the object is the truth (#3384). omit() proxies
+      // answer $SOURCES with undefined on purpose (#3014).
+      const childSources = (s as object)[$SOURCES];
+      if (childSources) {
+        for (let j = 0; j < childSources.length; j++) flattened.push(childSources[j]);
+        continue;
+      }
+    }
+    flattened.push(s as any);
   }
   if (SUPPORTS_PROXY && proxy) {
     return new Proxy(
@@ -188,7 +200,6 @@ export function merge<T extends unknown[]>(...sources: T): Merge<T> {
     if (desc.get) Object.defineProperty(target, key, desc);
     else target[key] = desc.value;
   }
-  (target as any)[$SOURCES] = flattened;
   return target as any;
 }
 

--- a/packages/signals/tests/store/utilities.test.ts
+++ b/packages/signals/tests/store/utilities.test.ts
@@ -7,6 +7,7 @@ import {
   flush,
   getOwner,
   merge,
+  mergeSources,
   omit,
   reconcile,
   snapshot,
@@ -176,6 +177,69 @@ describe("merge", () => {
     const props = merge({ a: 1 }, { b });
     b.value = 2;
     expect(props.b.value).toBe(2);
+  });
+  // #3384: the plain-object result is a real object callers may copy or
+  // mutate. A later merge must read what is on the object, not tunnel back
+  // to the sources it was built from.
+  it("re-merging a descriptor copy of a merged object reads the copy (#3384)", () => {
+    const props = merge({ href: "/x", title: "t" }, { $active: true, children: "hi" });
+    const out: Record<PropertyKey, unknown> = {};
+    for (const key of Reflect.ownKeys(props)) {
+      if (key === "$active") continue;
+      Object.defineProperty(out, key, Reflect.getOwnPropertyDescriptor(props, key)!);
+    }
+    Object.defineProperty(out, "class", {
+      get: () => "yak-abc",
+      enumerable: true,
+      configurable: true
+    });
+    const final = merge(out, { rel: "noopener" }) as Record<string, unknown>;
+    expect(final.class).toBe("yak-abc");
+    expect(final.$active).toBeUndefined();
+    expect(final.href).toBe("/x");
+    expect(final.children).toBe("hi");
+    expect(Object.keys(final).sort()).toEqual(["children", "class", "href", "rel", "title"]);
+  });
+  it("re-merging a spread copy of a merged object reads the copy (#3384)", () => {
+    const props = merge({ a: 1, b: 2 }, { c: 3 });
+    const copy = { ...props, b: 20, d: 4 } as Record<string, unknown>;
+    delete copy.a;
+    const final = merge(copy, { e: 5 }) as Record<string, unknown>;
+    expect(final.a).toBeUndefined();
+    expect(final.b).toBe(20);
+    expect(final.d).toBe(4);
+    expect(Object.getOwnPropertySymbols(final)).toEqual([]);
+  });
+  it("re-merging a merged object mutated afterwards reads the mutations (#3384)", () => {
+    // @solidjs/html assigns props and a children getter onto merge()'s result
+    // after spreading; a component's own merge(defaults, props) must see them.
+    const props = merge({ type: "button", label: "a" }, { disabled: false }) as Record<
+      string,
+      unknown
+    >;
+    props.label = "b";
+    props.extra = 1;
+    Object.defineProperty(props, "children", { get: () => "kids", configurable: true });
+    const final = merge({ type: "submit", size: "m" }, props) as Record<string, unknown>;
+    expect(final.type).toBe("button");
+    expect(final.label).toBe("b");
+    expect(final.extra).toBe(1);
+    expect(final.children).toBe("kids");
+    expect(final.size).toBe("m");
+  });
+  it("still flattens merge proxies (writes are no-ops, so the sources are the truth)", () => {
+    const [store] = createStore({ a: 1 });
+    const b = { b: 2 };
+    const c = { c: 3 };
+    const inner = merge(b, store);
+    const outer = merge(inner, c);
+    expect(mergeSources(outer)).toEqual([b, store, c]);
+    expect(outer.a).toBe(1);
+    expect(outer.b).toBe(2);
+    expect(outer.c).toBe(3);
+    expect(Object.keys(outer).sort()).toEqual(["a", "b", "c"]);
+    // and a plain-object result is not a source list
+    expect(mergeSources(merge(b, c))).toBeUndefined();
   });
   it("handles undefined values", () => {
     const props = merge({ a: 1 }, { a: undefined });


### PR DESCRIPTION
Fixes #3384.

## Problem

`merge()`'s plain-object form recorded its flattened sources on the result under the `$SOURCES` symbol, and a later `merge()` flattened *through* them instead of reading the object. But that result is a real object callers copy or mutate afterwards:

- descriptor copies via `Reflect.ownKeys` carry the symbol along (this is what `@yak/solid` PR #644's `copyProps` does, so `$`-prefixed props leaked onto DOM elements and the computed `class` was lost whenever the target spread `{...props}`);
- `{...props}` copies carry it too (enumerable symbol);
- `@solidjs/html` (`tagged-jsx.ts`) calls `mergeProps(props, spread)` and then assigns later props and a `children` getter onto the result before `createComponent` — a component's own `merge(defaults, props)` then dropped them.

No cheap check validates the recorded sources (a same-key value overwrite is invisible to key counts or owner identity), so the plain form can't be trusted at all.

## Fix

The plain-object result records nothing and is treated as an ordinary source by a nested `merge`. Only merge **proxies**, whose writes are no-ops, are still flattened through — that is also all `mergeSources()` (used by `spread()`) ever returned, so no consumer changes. `omit()` proxies keep answering `$SOURCES` with `undefined` (#3014).

Side effect worth knowing: `merge(defaults, props)` where `props` is a plain merge result covering every default now returns `props` directly — flattening used to defeat the "all keys covered → return the source" shortcut, so that common component pattern always allocated before.

## Tests

Four new tests in `utilities.test.ts`; three fail on `next`:
- descriptor copy of a merged object (the issue repro) — copy is read, `$active` gone, `class` present;
- `{...props}` copy with a deleted and an overridden key;
- html-style post-merge mutation (assign, add, `defineProperty children`);
- guard: merge proxies still flatten (`mergeSources(outer)` is the flat list), plain results yield `undefined`.

Suites: signals 1769, solid 595, html 200, web dom 735 / server 790 / hydrate 169 — all green.

## Performance

Interleaved A/B, old vs new `dist/prod` in one process, 41 alternating rounds, ratio new/old:

| path | ratio |
|---|---|
| `merge(defaults, props5)` construct | 0.97 |
| `merge(props12, {children})` construct | 0.96 |
| nested `merge(inner, {c})`, not covered | 1.05–1.10 |
| nested `merge(defaults, inner)`, covered | **0.52** |
| getter reads through 1 / 2 / 3 levels | 0.84 / 1.01 / 1.06 |
| proxy construct / read, `omit` | 0.96–1.03 (unchanged path) |

The one regression is the non-covered nested plain merge: it walks the intermediate result (bound getters, re-bound once more) instead of the original sources. The covered case, which is the `merge(defaults, props)` shape, no longer allocates at all.
